### PR TITLE
Hash#values should not return a set

### DIFF
--- a/lib/hamster/hash.rb
+++ b/lib/hamster/hash.rb
@@ -140,7 +140,7 @@ module Hamster
     end
 
     def values
-      reduce(Hamster.set) { |values, key, value| values.add(value) }
+      reduce(Hamster.list) { |values, key, value| values.cons(value) }
     end
 
     def clear

--- a/spec/hamster/hash/values_spec.rb
+++ b/spec/hamster/hash/values_spec.rb
@@ -12,10 +12,23 @@ describe Hamster::Hash do
       @result = hash.values
     end
 
-    it "returns the keys as a set" do
-      @result.should == Hamster.set("aye", "bee", "see")
+    it "returns the keys as a list" do
+      @result.should be_a Hamster::List
+      @result.to_a.sort.should == %w(aye bee see)
     end
 
+  end
+
+  describe "#values with duplicates" do
+    before do
+      hash = Hamster.hash(:A => 15, :B => 19, :C => 15)
+      @result = hash.values
+    end
+
+    it "returns the keys as a list" do
+      @result.should be_a Hamster::List
+      @result.to_a.sort.should == [15,15,19]
+    end
   end
 
 end


### PR DESCRIPTION
Returning a set means that duplicates are ignored, which is different from ruby's Hash#values and caused us to have a disturbing five minutes when we saw that `h.length != h.values.length`.
