### PR TITLE
Hamster::Hash#fetch to match Ruby's ::Hash#fetch

### DIFF
--- a/lib/hamster/hash.rb
+++ b/lib/hamster/hash.rb
@@ -57,6 +57,19 @@ module Hamster
     end
     def_delegator :self, :get, :[]
 
+    def fetch(key, default = Undefined)
+      entry = @trie.get(key)
+      if entry
+        entry.value
+      elsif default != Undefined
+        default
+      elsif block_given?
+        yield
+      else
+        raise KeyError.new("key not found: #{key.inspect}")
+      end
+    end
+
     def put(key, value = Undefined)
       return put(key, yield(get(key))) if value.equal?(Undefined)
       transform { @trie = @trie.put(key, value) }

--- a/spec/hamster/hash/fetch_spec.rb
+++ b/spec/hamster/hash/fetch_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+require 'hamster/hash'
+
+describe Hamster::Hash do
+
+  describe "#fetch" do
+
+    describe "with no default provided" do
+
+      describe "when the key exists" do
+
+        before do
+          @hash = Hamster.hash("A" => "aye")
+        end
+
+        it "returns the value associated with the key" do
+          @hash.fetch("A").should == "aye"
+        end
+
+      end
+
+      describe "when the key does not exist" do
+
+        before do
+          @hash = Hamster.hash("A" => "aye")
+        end
+
+        it "raises a KeyError" do
+          lambda { @hash.fetch("B") }.should raise_error(KeyError)
+        end
+
+      end
+
+    end
+
+    describe "with a default value" do
+
+      describe "when the key exists" do
+
+        before do
+          @hash = Hamster.hash("A" => "aye")
+        end
+
+        it "returns the value associated with the key" do
+          @hash.fetch("A", "default").should == "aye"
+        end
+
+      end
+
+      describe "when the key does not exist" do
+
+        before do
+          @hash = Hamster.hash("A" => "aye")
+        end
+
+        it "returns the default value" do
+          @hash.fetch("B", "default").should == "default"
+        end
+
+      end
+
+    end
+
+    describe "with a default block" do
+
+      describe "when the key exists" do
+
+        before do
+          @hash = Hamster.hash("A" => "aye")
+        end
+
+        it "returns the value associated with the key" do
+          @hash.fetch("A") { "default".upcase }.should == "aye"
+        end
+
+      end
+
+      describe "when the key does not exist" do
+
+        before do
+          @hash = Hamster.hash("A" => "aye")
+        end
+
+        it "returns the default value" do
+          @hash.fetch("B") { "default".upcase }.should == "DEFAULT"
+        end
+
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
I find [fetch](http://ruby-doc.org/core-1.9.3/Hash.html#method-i-fetch) really useful when I want my code to complain loudly when the key doesn't exist
