### PR TITLE
Prevent entry order changing Hash#hash value

### DIFF
--- a/lib/hamster/hash.rb
+++ b/lib/hamster/hash.rb
@@ -176,7 +176,9 @@ module Hamster
     def_delegator :self, :eql?, :==
 
     def hash
-      reduce(0) { |hash, key, value| (hash << 32) - hash + key.hash + value.hash }
+      keys.sort.reduce(0) do |hash, key|
+        (hash << 32) - hash + key.hash + get(key).hash
+      end
     end
 
     def_delegator :self, :dup, :uniq

--- a/spec/hamster/hash/hash_spec.rb
+++ b/spec/hamster/hash/hash_spec.rb
@@ -22,6 +22,15 @@ describe Hamster::Hash do
       Hamster.hash("ka" => "va").hash.should_not == Hamster.hash("kb" => "va").hash
     end
 
+    it "generates the same hash value for the a hash regardless of the order things were added to it" do
+      # The keys :issued_at and :expires_at happen to end up in the same
+      # bucket in the trie, so depending on which one gets added first, one
+      # of them will end up in a child trie. The hash value should be the
+      # same regardless of which is added first
+      Hamster.hash.put(:issued_at, nil).put(:expires_at, nil).hash.should == 
+        Hamster.hash.put(:expires_at, nil).put(:issued_at, nil).hash
+    end
+
     describe "on an empty hash" do
 
       before do


### PR DESCRIPTION
The previous implementation of the Hash#hash method was affected by the
order that the key/value pairs were returned from the internal trie's
each method. This meant that two Hashes that appeared identical could
fail an equality check because their hash values could be different.

Sorting the keys before building up the hash value is a simple (and
obvious) way to correct this. There is likely a more efficient or clever
solution to this problem, but in the meantime this patch at least fixes 
the bug I have been running into.
