### PR TITLE
Adding `add` and `pop` to Hamster::List

### DIFF
--- a/lib/hamster/list.rb
+++ b/lib/hamster/list.rb
@@ -73,6 +73,11 @@ module Hamster
     end
     def_delegator :self, :cons, :>>
 
+    def add(item)
+      self.append(Hamster.list(item))
+    end
+    def_delegator :self, :add, :<<
+
     def each
       return self unless block_given?
       list = self
@@ -124,6 +129,15 @@ module Hamster
       Stream.new do
         next self if empty?
         next Sequence.new(head, tail.take(number - 1)) if number > 0
+        EmptyList
+      end
+    end
+
+    def pop
+      Stream.new do
+        next self if empty?
+        new_size = size - 1
+        next Sequence.new(head, tail.take(new_size - 1)) if new_size >= 1
         EmptyList
       end
     end

--- a/spec/hamster/list/add_spec.rb
+++ b/spec/hamster/list/add_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+require 'hamster/list'
+
+describe Hamster::List do
+
+  describe "#add" do
+
+    it "should add an item onto the end of a list" do
+      list = Hamster.list("a", "b")
+      list.add("c").should == Hamster.list("a", "b", "c")
+    end
+
+  end
+
+end

--- a/spec/hamster/list/pop_spec.rb
+++ b/spec/hamster/list/pop_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+require 'hamster/list'
+
+describe Hamster::List do
+
+  describe "#pop" do
+
+    context "with an empty list" do
+
+      before(:each) do
+        @list = Hamster.list
+      end
+
+      it "returns an empty list" do
+        @list.pop.should == Hamster.list
+      end
+
+    end
+
+    context "with a list with a few items" do
+
+      before(:each) do
+        @list = Hamster.list("a", "b", "c")
+      end
+
+      it "should remove the last item" do
+        @list.pop.should == Hamster.list("a", "b")
+        @list.pop.pop.should == Hamster.list("a")
+        @list.pop.pop.pop.should == Hamster.list
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
I was surprised to find that `Hamster::List` doesn't have methods to add and pop elements off the end of a list.  This seems like good functionality to have to maintain parity with Ruby's core `Array` data structure, so here's a pull request :)
