### PR TITLE
We want to use HTTPS for contacting rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
-source :rubygems
+#!/usr/bin/env ruby
+source "https://rubygems.org/"
 
+# Specify your gem's dependencies in hamster.gemspec
 gemspec


### PR DESCRIPTION
For security reasons we should only communicate
with rubygems via https scheme. In addition
this commit contains some minor documentation
pulled from the standard bundler generated
Gemfile.
