### PR TITLE
Modernizing the gemspec

### DIFF
--- a/hamster.gemspec
+++ b/hamster.gemspec
@@ -20,6 +20,13 @@ Gem::Specification.new do |spec|
   spec.executables   = Dir["bin/**/*"].map! { |f| f.gsub(/bin\//, '') }
   spec.test_files    = Dir["test/**/*", "spec/**/*"]
   spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "mocha", "~> 0.14"
+  spec.add_development_dependency "rake", "~> 10.1"
+  spec.add_development_dependency "yard", "~> 0.8"
+  spec.add_development_dependency "kramdown", "~> 1.2"
+  spec.add_development_dependency "pry", "~> 0.9"
   spec.add_development_dependency "coveralls", "~> 0.7"
 end


### PR DESCRIPTION
- Adding a few development gems I find handy in modern gem development
- Matching the latest gemspec layout/usage
- Removing some old deprecated api usage
- Specifying utf-8 encoding
