### PR TITLE
Add rake tasks for running the benchmarks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,11 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "yard"
+require "pathname"
+
+HAMSTER_ROOT = Pathname.new(__FILE__).join('../..')
+BENCH_ROOT   = HAMSTER_ROOT.join('bench')
+
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -12,3 +17,38 @@ end
 
 desc "Default: run tests and generate docs"
 task default: [ :spec, :yard ]
+
+
+def bench_task_name(file_name)
+  file_name.relative_path_from(HAMSTER_ROOT).sub(/\_bench.rb$/, '').to_s.tr('/', ':')
+end
+
+bench_suites = Dir[HAMSTER_ROOT.join('bench/*')].map(&method(:Pathname)).select(&:directory?)
+
+bench_suites.each do |bench_suite|
+  bench_files = Dir[File.join(bench_suite, '/**/*.rb')].map(&method(:Pathname))
+
+  bench_files.each do |bench_file|
+    name = bench_task_name(bench_file)
+
+    desc "Benchmark #{name}"
+    task name do
+      begin
+        $LOAD_PATH.unshift HAMSTER_ROOT.join('lib')
+        load bench_file
+      rescue LoadError => e
+        if e.path == 'benchmark/ips'
+          STDERR.puts "Please install the benchmark-ips gem"
+        else
+          STDERR.puts e
+        end
+      end
+    end
+  end
+
+  desc "Benchmark #{bench_task_name(bench_suite)}"
+  task bench_task_name(bench_suite) => bench_files.map(&method(:bench_task_name))
+end
+
+desc "Run all benchmarks"
+task bench: bench_suites.map(&method(:bench_task_name))


### PR DESCRIPTION
Hi,

I wrote this yesterday while I was toying around with the benchmarks. But I see now the tasks directory has gone.

Is this something you would want to have in, and if so, where best to put it?

```
rake bench            # Run all benchmarks
rake bench:hash       # Benchmark bench:hash
rake bench:hash:each  # Benchmark bench:hash:each
rake bench:hash:get   # Benchmark bench:hash:get
rake bench:hash:put   # Benchmark bench:hash:put
rake bench:list       # Benchmark bench:list
rake bench:list:at    # Benchmark bench:list:at
rake bench:list:cons  # Benchmark bench:list:cons
```
