### PR TITLE
Add Hamster.enumerate to turn an enumerator into a list

### DIFF
--- a/lib/hamster/list.rb
+++ b/lib/hamster/list.rb
@@ -98,6 +98,29 @@ module Hamster
       Stream.new { Sequence.new(item, iterate(yield(item), &block)) }
     end
 
+    # Turn an enumerator into a Hamster list
+    #
+    # The result is a lazy collection where the values are memoized as they are
+    # generated.
+    #
+    # @example
+    #   def rg ; loop { yield rand(100) } ; end
+    #   Hamster.enumerate(to_enum(:rg)).take(10)
+    #
+    # @param enum [Enumerator] The object to iterate over
+    # @return [Stream]
+    #
+    # @api public
+    def enumerate(enum)
+      Stream.new do
+        begin
+          Sequence.new(enum.next, enumerate(enum))
+        rescue StopIteration
+          EmptyList
+        end
+      end
+    end
+
     private
 
     def interval_exclusive(from, to)

--- a/spec/hamster/list/construction_spec.rb
+++ b/spec/hamster/list/construction_spec.rb
@@ -137,4 +137,27 @@ describe Hamster do
 
   end
 
+  describe ".enumerate" do
+    let(:counter) { i = 0 ; -> { i+=1 } }
+
+    let(:enum) do
+      Enumerator.new do |yielder|
+        yielder << 1
+        yielder << 2
+        yielder << 3
+        raise "list fully realized"
+      end
+    end
+
+    let(:list) { Hamster.enumerate(enum) }
+
+    it 'should return a list based on the values yielded from the enumerator' do
+      expect(list.take(2)).to eq Hamster.list(1,2)
+    end
+
+    it 'should realize values as they are needed' do
+      expect { list.take(3).to_a }.to raise_exception
+    end
+  end
+
 end


### PR DESCRIPTION
This seemed like a handy utility, for those cases where you already have an Enumerator but want to treat it as a list.

The fact that the enumerator is only called lazily, and the results memoized is very interesting.

Not sure if this is within scope of the project, happy to take feedback.
