### PR TITLE
Implement list#flat_map

### DIFF
--- a/lib/hamster/list.rb
+++ b/lib/hamster/list.rb
@@ -166,6 +166,16 @@ module Hamster
     end
     def_delegator :self, :map, :collect
 
+    def flat_map(&block)
+      return self unless block_given?
+      Stream.new do
+        next self if empty?
+        head_list = Hamster.list(*yield(head))
+        next tail.flat_map(&block) if head_list.empty?
+        Sequence.new(head_list.first, head_list.drop(1).append(tail.flat_map(&block)))
+      end
+    end
+
     def filter(&block)
       return self unless block_given?
       Stream.new do

--- a/spec/hamster/list/flat_map_spec.rb
+++ b/spec/hamster/list/flat_map_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+require 'hamster/list'
+
+describe Hamster::List, '#flat_map' do
+  subject { list.flat_map(&block) }
+  let(:block) { ->(i) { [i, i+1, i*i]} }
+
+  context 'with an empty list' do
+    let(:list) { Hamster.list }
+    it { should eq Hamster.list }
+  end
+
+  context 'with a block that returns an empty list' do
+    let(:list) { Hamster.list(1,2,3) }
+    let(:block) { ->(i){ [] } }
+    it { should eq Hamster.list }
+  end
+
+  context 'with a list of one item' do
+    let(:list) { Hamster.list(7) }
+    it { should eq Hamster.list(7,8,49) }
+  end
+
+  context 'with a list of multiple items' do
+    let(:list) { Hamster.list(1,2,3) }
+    it { should eq Hamster.list(1,2,1, 2,3,4, 3,4,9) }
+  end
+end


### PR DESCRIPTION
While using Hamster I tried to use flat_map and found out it's not implemented. (flat_map is a standard method for Ruby Enumerables).

I've added it, although the implementation is a bit ugly. Opening this PR mostly to get some feedback on this.
