### PR TITLE
We want to report coverage to coveralls.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --colour
+--format documentation

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@ require "rspec/core/rake_task"
 require "yard"
 require "pathname"
 
+ENV["COVERALLS_NOISY"] = "true"
+
 HAMSTER_ROOT = Pathname.new(__FILE__).dirname
 
 RSpec::Core::RakeTask.new(:spec)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,10 @@
-# Common spec-related code goes here
-
-require 'simplecov'
-SimpleCov.start
-SimpleCov.at_exit do
-  SimpleCov.result.format!
-  open("#{SimpleCov.coverage_dir}/covered_percent", "w") do |f|
-    f.puts SimpleCov.result.covered_percent.to_s
-  end
+require "coveralls"
+Coveralls.wear! do
+  add_filter "/spec/"
 end
+
+require "pry"
+require "rspec"
 
 STACK_OVERFLOW_DEPTH = if RUBY_ENGINE == "ruby"
   def calculate_stack_overflow_depth(n)


### PR DESCRIPTION
- In order to keep up with covearge we're opting in to use a coverage reporting tool
- Coveralls triggers both locally (showing a simple %-per-file) and in travis.ci (reporting to coveralls API)
- It'll comment on the pull request we make with coverage details.

This is a stopgap until we get Code Climate Coverage.
