### PR TITLE
Only load coveralls when running inside Travis CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
-require "coveralls"
-Coveralls.wear! do
-  add_filter "/spec/"
+if ENV['TRAVIS']
+  require "coveralls"
+  Coveralls.wear! do
+    add_filter "/spec/"
+  end
 end
 
 require "pry"


### PR DESCRIPTION
Coveralls is a no-op outside of Travis anyway, and it messes with setting custom Simplecov formatters.
