### PR TITLE
Fix Marshal loading/dumping for Hamster::Set

### DIFF
--- a/lib/hamster/set.rb
+++ b/lib/hamster/set.rb
@@ -167,6 +167,20 @@ module Hamster
     def inspect
       "{#{to_a.inspect[1..-2]}}"
     end
+
+    def marshal_dump
+      output = {}
+      each do |key|
+        output[key] = nil
+      end
+      output
+    end
+
+    def marshal_load(dictionary)
+      @trie = dictionary.reduce(EmptyTrie) do |trie, key_value|
+        trie.put(key_value.first, nil)
+      end
+    end
   end
 
   EmptySet = Hamster::Set.new


### PR DESCRIPTION
After pushing my last PR, I noticed the specs were failing, not just on my branch but on master as well. With this patch, they are all passing again.
