### PR TITLE
Differentiate between Hamster::Hash#== and Hamster::Hash#eql?

### DIFF
--- a/lib/hamster/hash.rb
+++ b/lib/hamster/hash.rb
@@ -167,10 +167,15 @@ module Hamster
       self.class.empty
     end
 
+    # Value-and-type equality
     def eql?(other)
       instance_of?(other.class) && @trie.eql?(other.instance_variable_get(:@trie))
     end
-    def_delegator :self, :eql?, :==
+
+    # Value equality, will do type coercion
+    def ==(other)
+      self.eql?(other) || (other.respond_to?(:to_hash) && to_hash.eql?(other.to_hash))
+    end
 
     def hash
       keys.sort.reduce(0) do |hash, key|
@@ -186,12 +191,16 @@ module Hamster
       "{#{reduce([]) { |memo, key, value| memo << "#{key.inspect} => #{value.inspect}" }.join(", ")}}"
     end
 
-    def marshal_dump
+    def to_hash
       output = {}
       each do |key, value|
         output[key] = value
       end
       output
+    end
+
+    def marshal_dump
+      to_hash
     end
 
     def marshal_load(dictionary)

--- a/spec/hamster/hash/eql_spec.rb
+++ b/spec/hamster/hash/eql_spec.rb
@@ -4,25 +4,53 @@ require "hamster/hash"
 
 describe Hamster::Hash do
 
+  describe "#eql?" do
+
+    describe "returns false when comparing with" do
+
+      before do
+        @hash = Hamster.hash("A" => "aye", "B" => "bee", "C" => "see")
+      end
+
+      it "a standard hash" do
+        @hash.eql?("A" => "aye", "B" => "bee", "C" => "see").should == false
+      end
+
+      it "an arbitrary object" do
+        @hash.eql?(Object.new).should == false
+      end
+
+    end
+
+  end
+
+  describe "#==" do
+
+    describe "returns true when comparing with" do
+
+      before do
+        @hash = Hamster.hash("A" => "aye", "B" => "bee", "C" => "see")
+      end
+
+      it "a standard hash" do
+        (@hash == {"A" => "aye", "B" => "bee", "C" => "see"}).should == true
+      end
+
+    end
+
+    describe "returns false when comparing with" do
+
+      it "an arbitrary object" do
+        (@hash == Object.new).should == false
+      end
+
+    end
+
+  end
+
   [:eql?, :==].each do |method|
 
     describe "##{method}" do
-
-      describe "returns false when comparing with" do
-
-        before do
-          @hash = Hamster.hash("A" => "aye", "B" => "bee", "C" => "see")
-        end
-
-        it "a standard hash" do
-          @hash.send(method, "A" => "aye", "B" => "bee", "C" => "see").should == false
-        end
-
-        it "an aribtrary object" do
-          @hash.send(method, Object.new).should == false
-        end
-
-      end
 
       [
         [{}, {}, true],


### PR DESCRIPTION
This is just the same as what was done in PR #86, but applied to Hamster::Hash.

Fixes #85.
