### PR TITLE
Hash#merge works when passed a Ruby Hash

### DIFF
--- a/lib/hamster/hash.rb
+++ b/lib/hamster/hash.rb
@@ -143,7 +143,9 @@ module Hamster
     def_delegator :self, :find, :detect
 
     def merge(other)
-      transform { @trie = other.reduce(@trie, &:put) }
+      transform do
+        other.each { |key, value| @trie = @trie.put(key, value) }
+      end
     end
     def_delegator :self, :merge, :+
 

--- a/spec/hamster/hash/merge_spec.rb
+++ b/spec/hamster/hash/merge_spec.rb
@@ -21,10 +21,13 @@ describe Hamster::Hash do
             @result = Hamster.hash(*a).send(method, Hamster.hash(*b))
           end
 
-          it "returns #{expected.inspect}"  do
+          it "returns #{expected.inspect} when passed a Hamster::Hash"  do
             @result.should == Hamster.hash(*expected)
           end
 
+          it "returns #{expected.inspect} when passed a Ruby Hash" do
+            Hamster.hash(*a).send(method, Hash[*b]).should == Hamster.hash(*expected)
+          end
         end
 
       end


### PR DESCRIPTION
In issue #84, it was requested to make `Hamster::Hash#merge` work when passed a Ruby Hash. This patch does the trick.

Why it works may not be obvious at first glance -- it's because of the way that Ruby passes parameters to blocks. (When a single `Array` argument is passed to a block which expects multiple params, it is _automatically_ splatted. That is what makes the call to `#each` in the below code work both for Ruby Hashes, which yield key-value pair Arrays, and for Hamster::Hashes, which pass keys and values as separate parameters.)

Fixes #84.
