### PR TITLE
More concise (and faster) implementation of Hamster::Tuple

### DIFF
--- a/lib/hamster/tuple.rb
+++ b/lib/hamster/tuple.rb
@@ -16,5 +16,7 @@ module Hamster
     def inspect
       "(#{super[1..-2]})"
     end
+
+    undef :<<, :[]=, :collect!, :compact!, :delete, :delete_at, :delete_if, :flatten!, :map!, :reject!, :reverse!, :rotate!, :select!, :shuffle!, :slice!, :sort!, :sort_by!, :uniq!
   end
 end


### PR DESCRIPTION
The title says it all.

I suspect that a lot of experienced Ruby programmers don't know this trick. When you subclass a core Ruby class like Array/Hash/String, the Ruby runtime will use the exact same (efficient) data representation "under the hood" for your subclass as it does for the built-in class. Additionally, built-in methods which have a special-cased "fast path" when passed an Array, etc. will generally use the fast path for your subclass as well.
