### PR TITLE
Removed unneeded warning about stack overflow from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ morphed into something I actually use. My primary concern has
 been to round out the functionality with good test coverage
 and clean, readable code.
 
-Performance is pretty good -- especially with lazy lists --
-but there are some things which may blow the stack due to a
-lack of Tail-Call-Optimisation in Ruby.
-
 Documentation is sparse but I've tried as best I can to write
 specs that read as documentation. I've also tried to alias
 methods as their `Enumerable` equivalents where


### PR DESCRIPTION
In our test suite, we have a number of tests which ensure that various `List` methods don't cause a stack overflow even when called on large `List`s. Are there any methods remaining which _do_ blow the stack? If so, that is a bug and should be fixed. If not, there is no reason to keep this warning.
