### PR TITLE
Optimize Set#union for better performance when receiver is small Set and arg is large Set

### DIFF
--- a/bench/set/union_bench.rb
+++ b/bench/set/union_bench.rb
@@ -1,0 +1,15 @@
+require "benchmark/ips"
+require "hamster/set"
+
+Benchmark.ips do |b|
+  small_set = Hamster::Set.new((1..10).to_a)
+  large_set = Hamster::Set.new((1..1000).to_a)
+
+  b.report "small.union(large)" do
+    small_set.union(large_set)
+  end
+
+  b.report "large.union(small)" do
+    large_set.union(small_set)
+  end
+end

--- a/lib/hamster/set.rb
+++ b/lib/hamster/set.rb
@@ -242,7 +242,14 @@ module Hamster
     # @param other [Enumerable] The collection to merge with
     # @return [Set]
     def union(other)
-      trie = other.reduce(@trie) do |a, element|
+      if other.is_a?(Hamster::Set) && other.size > size
+        small_set = self
+        large_set_trie = other.instance_variable_get(:@trie)
+      else
+        small_set = other
+        large_set_trie = @trie
+      end
+      trie = small_set.reduce(large_set_trie) do |a, element|
         next a if a.key?(element)
         a.put(element, nil)
       end

--- a/spec/lib/hamster/set/union_spec.rb
+++ b/spec/lib/hamster/set/union_spec.rb
@@ -38,6 +38,15 @@ describe Hamster::Set do
         context "when passed a Ruby Array" do
           it "returns the expected Set" do
             Hamster.set(*a).send(method, b.freeze).should eql(Hamster.set(*expected))
+            Hamster.set(*b).send(method, a.freeze).should eql(Hamster.set(*expected))
+          end
+        end
+
+        context "from a subclass" do
+          it "returns an instance of the subclass" do
+            subclass = Class.new(Hamster::Set)
+            subclass.new(a).union(Hamster::Set.new(b)).class.should be(subclass)
+            subclass.new(b).union(Hamster::Set.new(a)).class.should be(subclass)
           end
         end
       end


### PR DESCRIPTION
mentioned as a suggested optimization in issue #136 .

Also added test case to verify that `Set#union` returns indeed an object of the same class as the receiver.
## Benchmarks

Before the fix:

```
  small.union(large)      136.5 (±2.2%) i/s -        689 in   5.050567s
  large.union(small)    70035.8 (±3.9%) i/s -     353404 in   5.053927s
```

After the fix:

```
  small.union(large)    84855.7 (±0.8%) i/s -     426690 in   5.028729s
  large.union(small)    90258.2 (±1.1%) i/s -     459368 in   5.090155s
```
