### PR TITLE
We're not interested in minor versions right now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
+  - 2.0
+  - 2.1
   - ruby-head


### PR DESCRIPTION
We're only interested in major backwards compatability
for the moment. It's too much of an issue to keep up
with minor version bugs in MRI.
