### PR TITLE
Trie#put, Trie#bulk_put: return self if value is not changed

### DIFF
--- a/lib/hamster/hash.rb
+++ b/lib/hamster/hash.rb
@@ -223,7 +223,12 @@ module Hamster
     # @yieldreturn [Object] The new value to store
     # @return [Hash]
     def put(key, value = yield(get(key)))
-      self.class.alloc(@trie.put(key, value), @default)
+      new_trie = @trie.put(key, value)
+      if new_trie.equal?(@trie)
+        self
+      else
+        self.class.alloc(new_trie, @default)
+      end
     end
 
     # Return a new `Hash` with the existing key/value associations, plus an association
@@ -238,7 +243,7 @@ module Hamster
     # @param value [Object] The value to associate it with
     # @return [Hash]
     def store(key, value)
-      self.class.alloc(@trie.put(key, value), @default)
+      put(key, value)
     end
 
     # Return a new `Hash` with the association for `key` removed. If `key` is not

--- a/spec/lib/hamster/hash/merge_spec.rb
+++ b/spec/lib/hamster/hash/merge_spec.rb
@@ -39,6 +39,14 @@ describe Hamster::Hash do
         end
       end
 
+      context "when merging with subset Hash" do
+        it "returns self" do
+          big_hash = Hamster.hash((1..300).zip(1..300))
+          small_hash = Hamster.hash((1..200).zip(1..200))
+          big_hash.send(method, small_hash).should be(big_hash)
+        end
+      end
+
       context "when called on a subclass" do
         it "returns an instance of the subclass" do
           subclass = Class.new(Hamster::Hash)

--- a/spec/lib/hamster/hash/put_spec.rb
+++ b/spec/lib/hamster/hash/put_spec.rb
@@ -58,6 +58,28 @@ describe Hamster::Hash do
       end
     end
 
+    context "with duplicate key and identical value" do
+      let(:hash) { Hamster::Hash["X" => 1, "Y" => 2] }
+      let(:result) { hash.put("X", 1) }
+
+      it "returns the original hash unmodified" do
+        result.should be(hash)
+      end
+
+      context "with big hash (force nested tries)" do
+        let(:keys) { (0..99).map(&:to_s) }
+        let(:values) { (100..199).to_a }
+        let(:hash) { Hamster::Hash[keys.zip(values)] }
+
+        it "returns the original hash unmodified for all changes" do
+          keys.each_with_index do |key, index|
+            result = hash.put(key, values[index])
+            result.should be(hash)
+          end
+        end
+      end
+    end
+
     context "with unequal keys which hash to the same value" do
       let(:hash) { Hamster.hash(DeterministicHash.new('a', 1) => 'aye') }
 

--- a/spec/lib/hamster/hash/store_spec.rb
+++ b/spec/lib/hamster/hash/store_spec.rb
@@ -31,6 +31,28 @@ describe Hamster::Hash do
       end
     end
 
+    context "with duplicate key and identical value" do
+      let(:hash) { Hamster::Hash["X" => 1, "Y" => 2] }
+      let(:result) { hash.store("X", 1) }
+
+      it "returns the original hash unmodified" do
+        result.should be(hash)
+      end
+
+      context "with big hash (force nested tries)" do
+        let(:keys) { (0..99).map(&:to_s) }
+        let(:values) { (100..199).to_a }
+        let(:hash) { Hamster::Hash[keys.zip(values)] }
+
+        it "returns the original hash unmodified for all changes" do
+          keys.each_with_index do |key, index|
+            result = hash.store(key, values[index])
+            result.should be(hash)
+          end
+        end
+      end
+    end
+
     context "with unequal keys which hash to the same value" do
       let(:hash) { Hamster.hash(DeterministicHash.new('a', 1) => 'aye') }
 

--- a/spec/lib/hamster/set/union_spec.rb
+++ b/spec/lib/hamster/set/union_spec.rb
@@ -50,6 +50,15 @@ describe Hamster::Set do
           end
         end
       end
+
+      context "when receiving a subset" do
+        let(:set_a) { Hamster.set(*(1..300).to_a) }
+        let(:set_b) { Hamster.set(*(1..200).to_a) }
+
+        it "returns self" do
+          set_a.send(method, set_b).should be(set_a)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Modify `Trie#put` and `Trie#bulk_put` so they don't create a new `Trie` instance if the value being stored is identical (same Ruby object_id) to the value that already appears in the receiver.

This allows the nice behaviour in which `Hash#merge` and `Set#union` simply return self when merging with a subset Hash/Set (and of course same for `Hash#put` and `Hash#store`).

One thing that requires extra care: I changed `Hash#store` to simply call `Hash#put` (to avoid code duplication). However, maybe we _do_ want to have the duplication to allow people to subclass `Hamster::Hash` and modify `put`'s behaviour without affecting `store`'s behaviour??

BTW - if this is accepted I'm considering similar change for `Vector`.
