### PR TITLE
Deque#pop, Deque#shift: when empty, return empty object of same class

### DIFF
--- a/lib/hamster/deque.rb
+++ b/lib/hamster/deque.rb
@@ -127,7 +127,7 @@ module Hamster
       front, rear = @front, @rear
 
       if rear.empty?
-        return EmptyDeque if front.empty?
+        return self.class.empty if front.empty?
         front, rear = EmptyList, front.reverse
       end
 
@@ -147,7 +147,7 @@ module Hamster
       front, rear = @front, @rear
 
       if front.empty?
-        return EmptyDeque if rear.empty?
+        return self.class.empty if rear.empty?
         front, rear = rear.reverse, EmptyList
       end
 

--- a/spec/lib/hamster/deque/dequeue_spec.rb
+++ b/spec/lib/hamster/deque/dequeue_spec.rb
@@ -23,5 +23,13 @@ describe Hamster::Deque do
         end
       end
     end
+
+    context "on empty subclass" do
+      let(:subclass) { Class.new(Hamster::Deque) }
+      let(:empty_instance) { subclass.new }
+      it "returns emtpy object of same class" do
+        empty_instance.send(method).class.should be subclass
+      end
+    end
   end
 end

--- a/spec/lib/hamster/deque/pop_spec.rb
+++ b/spec/lib/hamster/deque/pop_spec.rb
@@ -21,5 +21,13 @@ describe Hamster::Deque do
         end
       end
     end
+
+    context "on empty subclass" do
+      let(:subclass) { Class.new(Hamster::Deque) }
+      let(:empty_instance) { subclass.new }
+      it "returns emtpy object of same class" do
+        empty_instance.pop.class.should be subclass
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently when calling `#pop` or `#shift` on an empty subclass of `Deque` we return an empty `Hamster::Deque` instead of the subclass.

``` ruby
class MyDeque < Hamster::Deque
end

my_deque = MyDeque.new
my_deque.class
# => MyDeque
my_deque.pop.class
# => Hamster::Deque
```

This PR fixes it (uses `self.class.empty`).
