### PR TITLE
SortedSet#drop, SortedSet#take: return self if collection hasn't changed

### DIFF
--- a/lib/hamster/sorted_set.rb
+++ b/lib/hamster/sorted_set.rb
@@ -377,6 +377,7 @@ module Hamster
     # @param n [Integer] The number of elements to remove
     # @return [SortedSet]
     def drop(n)
+      return self if n == 0
       self.class.new(super)
     end
 
@@ -384,6 +385,7 @@ module Hamster
     # @param n [Integer] The number of elements to retain
     # @return [SortedSet]
     def take(n)
+      return self if n >= size
       self.class.new(super)
     end
 

--- a/spec/lib/hamster/sorted_set/drop_spec.rb
+++ b/spec/lib/hamster/sorted_set/drop_spec.rb
@@ -25,5 +25,12 @@ describe Hamster::SortedSet do
         end
       end
     end
+
+    context "when argument is zero" do
+      let(:sorted_set) { Hamster.sorted_set(6, 7, 8, 9) }
+      it "returns self" do
+        sorted_set.drop(0).should be(sorted_set)
+      end
+    end
   end
 end

--- a/spec/lib/hamster/sorted_set/take_spec.rb
+++ b/spec/lib/hamster/sorted_set/take_spec.rb
@@ -22,5 +22,13 @@ describe Hamster::SortedSet do
         end
       end
     end
+
+    context "when argument is at least size of receiver" do
+      let(:sorted_set) { Hamster.sorted_set(6, 7, 8, 9) }
+      it "returns self" do
+        sorted_set.take(sorted_set.size).should be(sorted_set)
+        sorted_set.take(sorted_set.size + 1).should be(sorted_set)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the trivial case for `SortedSet#drop` and `SortedSet#take`.

Supposedly we can take this a step further: even for complex operations like `take_while` and `filter` and so on, we can check whether any change was made at all to the collection, and if not - return `self`. But the cost is a complication of the code. I guess we don't want to do this except in the trivial cases like in this PR.
