### PR TITLE
Vector#flatten: correct behaviour when no argument is passed - to support Rubinius and JRuby

### DIFF
--- a/lib/hamster/vector.rb
+++ b/lib/hamster/vector.rb
@@ -420,7 +420,7 @@ module Hamster
     #
     # @param level [Integer] The depth to which flattening should be applied
     # @return [Vector]
-    def flatten(level = nil)
+    def flatten(level = -1)
       return self if level == 0
       self.class.new(((array = to_a).frozen? ? array.flatten(level) : array.flatten!(level)).freeze)
     end


### PR DESCRIPTION
In case no argument is passed to `Vector#flatten`, we call
`Array#flatten(nil)`; but the correct argument to pass is -1 to indicate
endless recursive flatenning.

While MRI accepts both -1 and `nil`, Rubinius and JRuby don't accept an
explicit `nil` argument to `Array#flatten`.

With this patch applied the Hamster specs pass on Rubinius 2.3.0 .

See relevant discussion in the Rubinius ticket: https://github.com/rubinius/rubinius/pull/3175
