### PR TITLE
SortedSet#find_index: fix wrong returned indexes when using the non-block variant

### DIFF
--- a/lib/hamster/sorted_set.rb
+++ b/lib/hamster/sorted_set.rb
@@ -360,10 +360,10 @@ module Hamster
           direction = node.direction(obj, @comparator)
           if direction > 0
             node = node.right
-            index += node.left.size
+            index += (node.left.size + 1)
           elsif direction < 0
             node = node.left
-            index -= node.right.size
+            index -= (node.right.size + 1)
           else
             return index
           end

--- a/spec/lib/hamster/sorted_set/find_index_spec.rb
+++ b/spec/lib/hamster/sorted_set/find_index_spec.rb
@@ -22,7 +22,13 @@ describe Hamster::SortedSet do
         [[2.0], 2.0, 0],
         [[2.0], 2, 0],
       ].each do |values, item, expected|
-        context "looking for #{item.inspect} in #{values.inspect}" do
+        context "looking for #{item.inspect} in #{values.inspect} without block" do
+          it "returns #{expected.inspect}" do
+            Hamster.sorted_set(*values).send(method, item).should == expected
+          end
+        end
+
+        context "looking for #{item.inspect} in #{values.inspect} with block" do
           it "returns #{expected.inspect}" do
             Hamster.sorted_set(*values).send(method) { |x| x == item }.should == expected
           end


### PR DESCRIPTION
`SortedSet#find_index(obj)` returns wrong indexes. This variant of the method was not covered at all by the spec.

Before the fix:

```
[1] pry(main)> s = Hamster::SortedSet[*(0..10)]
=> Hamster::SortedSet[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
[2] pry(main)> s.each { |e| p [e, s.find_index(e)] }
[0, 2]
[1, 2]
[2, 3]
[3, 3]
[4, 3]
[5, 5]
[6, 6]
[7, 6]
[8, 7]
[9, 7]
[10, 7]
```

After the fix:

```
[1] pry(main)> s = Hamster::SortedSet[*(0..10)]
=> Hamster::SortedSet[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
[2] pry(main)> s.each { |e| p [e, s.find_index(e)] }
[0, 0]
[1, 1]
[2, 2]
[3, 3]
[4, 4]
[5, 5]
[6, 6]
[7, 7]
[8, 8]
[9, 9]
[10, 10]
```
