### PR TITLE
Removing shortcut methods [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Structures][PDS]: [`Hash`][HASH-DOC], [`Vector`][VECTOR-DOC], [`Set`][SET-DOC], 
 Hamster collections are **immutable**. Whenever you modify a Hamster
 collection, the original is preserved and a modified copy is returned. This
 makes them inherently thread-safe and shareable. At the same time, they remain
-CPU and memory-efficient by sharing between copies. 
+CPU and memory-efficient by sharing between copies.
 
 While Hamster collections are immutable, you can still mutate objects stored
-in them. We recommend that  you don't do this, unless you are sure you know 
-what you are doing. Hamster collections are thread-safe and can be freely 
-shared between threads, but you are responsible for making sure that the 
+in them. We recommend that  you don't do this, unless you are sure you know
+what you are doing. Hamster collections are thread-safe and can be freely
+shared between threads, but you are responsible for making sure that the
 objects stored in them are used in a thread-safe manner.
 
 Hamster collections are almost always closed under a given operation. That is,
@@ -146,11 +146,11 @@ Other `Array`-like methods like `#select`, `#map`, `#shuffle`, `#uniq`, `#revers
 A `Set` is an unordered collection of values with no duplicates. It is much like the Ruby standard library's `Set`, but immutable. Examples:
 
 ``` ruby
-set = Hamster.set(:red, :blue, :yellow) # => Hamster::Set[:red, :blue, :yellow]
+set = Hamster::Set.new(:red, :blue, :yellow) # => Hamster::Set[:red, :blue, :yellow]
 set.include? :red                       # => true
 set.add :green                          # => Hamster::Set[:red, :blue, :yellow, :green]
 set.delete :blue                        # => Hamster::Set[:red, :yellow]
-set.superset? Hamster.set(:red, :blue)  # => true
+set.superset? Hamster::Set.new(:red, :blue)  # => true
 set.union([:red, :blue, :pink])         # => Hamster::Set[:red, :blue, :yellow, :pink]
 set.intersection([:red, :blue, :pink])  # => Hamster::Set[:red, :blue]
 ```
@@ -167,7 +167,7 @@ do with a `Set`. Additionally, you can get the `#first` and `#last` item, or ret
 an item using an integral index:
 
 ``` ruby
-set = Hamster.sorted_set('toast', 'jam', 'bacon') # => Hamster::SortedSet["bacon", "jam", "toast"]
+set = Hamster::SortedSet.new('toast', 'jam', 'bacon') # => Hamster::SortedSet["bacon", "jam", "toast"]
 set.first                                         # => "bacon"
 set.last                                          # => "toast"
 set[1]                                            # => "jam"
@@ -176,8 +176,8 @@ set[1]                                            # => "jam"
 You can also specify the sort order using a block:
 
 ``` ruby
-Hamster.sorted_set('toast', 'jam', 'bacon') { |a,b| b <=> a }
-Hamster.sorted_set('toast', 'jam', 'bacon') { |str| str.chars.last }
+Hamster::SortedSet.new('toast', 'jam', 'bacon') { |a,b| b <=> a }
+Hamster::SortedSet.new('toast', 'jam', 'bacon') { |str| str.chars.last }
 ```
 
 See the [API documentation][SORTED-SET-DOC] for details on all `SortedSet` methods.
@@ -189,7 +189,7 @@ Hamster `List`s have a "head" (the value at the front of the list),
 and a "tail" (a list of the remaining items):
 
 ``` ruby
-list = Hamster.list(1, 2, 3)
+list = Hamster::List(1, 2, 3)
 list.head                    # => 1
 list.tail                    # => Hamster.list(2, 3)
 ```
@@ -197,7 +197,7 @@ list.tail                    # => Hamster.list(2, 3)
 To add to a list, you use `List#cons`:
 
 ``` ruby
-original = Hamster.list(1, 2, 3)
+original = Hamster::List(1, 2, 3)
 copy = original.cons(0)      # => Hamster.list(0, 1, 2, 3)
 ```
 

--- a/YARD-README.md
+++ b/YARD-README.md
@@ -128,11 +128,11 @@ Other `Array`-like methods like `#select`, `#map`, `#shuffle`, `#uniq`, `#revers
 A `Set` is an unordered collection of values with no duplicates. It is much like the Ruby standard library's `Set`, but immutable. Examples:
 
 ``` ruby
-set = Hamster.set(:red, :blue, :yellow) # => Hamster::Set[:red, :blue, :yellow]
+set = Hamster::Set.new(:red, :blue, :yellow) # => Hamster::Set[:red, :blue, :yellow]
 set.include? :red                       # => true
 set.add :green                          # => Hamster::Set[:red, :blue, :yellow, :green]
 set.delete :blue                        # => Hamster::Set[:red, :yellow]
-set.superset? Hamster.set(:red, :blue)  # => true
+set.superset? Hamster::Set.new(:red, :blue)  # => true
 set.union([:red, :blue, :pink])         # => Hamster::Set[:red, :blue, :yellow, :pink]
 set.intersection([:red, :blue, :pink])  # => Hamster::Set[:red, :blue]
 ```

--- a/lib/hamster/deque.rb
+++ b/lib/hamster/deque.rb
@@ -2,12 +2,6 @@ require "hamster/immutable"
 require "hamster/list"
 
 module Hamster
-  # Create a new `Deque` populated with the given items.
-  # @return [Deque]
-  def self.deque(*items)
-    items.empty? ? EmptyDeque : Deque.new(items)
-  end
-
   # A `Deque` (or double-ended queue) is an ordered, sequential collection of objects,
   # which allows elements to be efficiently added and removed at the front and end of
   # the sequence. Retrieving the elements at the front and end is also efficient. This

--- a/lib/hamster/experimental/mutable_queue.rb
+++ b/lib/hamster/experimental/mutable_queue.rb
@@ -2,10 +2,6 @@ require "hamster/deque"
 require "hamster/read_copy_update"
 
 module Hamster
-  def self.mutable_queue(*items)
-    MutableQueue.new(deque(*items))
-  end
-
   class MutableQueue
     include ReadCopyUpdate
 

--- a/lib/hamster/experimental/mutable_set.rb
+++ b/lib/hamster/experimental/mutable_set.rb
@@ -2,10 +2,6 @@ require "hamster/set"
 require "hamster/read_copy_update"
 
 module Hamster
-  def self.mutable_set(*items)
-    MutableSet.new(set(*items))
-  end
-
   class MutableSet
     include ReadCopyUpdate
 

--- a/lib/hamster/hash.rb
+++ b/lib/hamster/hash.rb
@@ -6,10 +6,6 @@ require "hamster/set"
 require "hamster/vector"
 
 module Hamster
-  def self.hash(pairs = nil, &block)
-    (pairs.nil? && block.nil?) ? EmptyHash : Hash.new(pairs, &block)
-  end
-
   # A `Hamster::Hash` maps from a set of unique keys to corresponding values,
   # much like a dictionary maps from words to definitions. Given a key, it can
   # efficiently store and retrieve values. Looking up a key given its value is also

--- a/lib/hamster/list.rb
+++ b/lib/hamster/list.rb
@@ -10,18 +10,6 @@ require "hamster/set"
 
 module Hamster
   class << self
-
-    # Create a list containing the given items.
-    #
-    # @example
-    #   list = Hamster.list(:a, :b, :c)
-    #   # => Hamster::List[:a, :b, :c]
-    #
-    # @return [List]
-    def list(*items)
-      items.to_list
-    end
-
     # Create a lazy, infinite list.
     #
     # The given block is called as necessary to return successive elements of the list.

--- a/lib/hamster/mutable_hash.rb
+++ b/lib/hamster/mutable_hash.rb
@@ -2,10 +2,6 @@ require "hamster/hash"
 require "hamster/read_copy_update"
 
 module Hamster
-  def self.mutable_hash(pairs = {}, &block)
-    MutableHash.new(hash(pairs, &block))
-  end
-
   class MutableHash
     include ReadCopyUpdate
 

--- a/lib/hamster/set.rb
+++ b/lib/hamster/set.rb
@@ -7,10 +7,6 @@ require "hamster/sorted_set"
 require "set"
 
 module Hamster
-  def self.set(*items)
-    items.empty? ? EmptySet : Set.new(items)
-  end
-
   # `Hamster::Set` is a collection of unordered values with no duplicates. Testing whether
   # an object is present in the `Set` is fast. `Set` is also `Enumerable`, so you can
   # iterate over the members of the set with {#each}, transform them with {#map}, filter

--- a/lib/hamster/vector.rb
+++ b/lib/hamster/vector.rb
@@ -3,12 +3,6 @@ require "hamster/enumerable"
 require "hamster/hash"
 
 module Hamster
-  # Create a new `Vector` populated with the given items.
-  # [Vector]
-  def self.vector(*items)
-    items.empty? ? EmptyVector : Vector.new(items.freeze)
-  end
-
   # A `Vector` is an ordered, integer-indexed collection of objects. Like `Array`,
   # `Vector` indexing starts at 0. Also like `Array`, negative indexes count back
   # from the end of the `Vector`.


### PR DESCRIPTION
We really don't need these, since the regular way of creating these objects is pretty simple already.