### PR TITLE
Fix List#index spec for JRuby

### DIFF
--- a/spec/lib/hamster/list/index_spec.rb
+++ b/spec/lib/hamster/list/index_spec.rb
@@ -20,13 +20,36 @@ describe Hamster::List do
       [["A", "B", nil], nil, 2],
       [["A", "B", nil], "C", nil],
       [[2], 2, 0],
-      [[2], 2.0, 0],
+      # [[2], 2.0, 0], # Doesn't work in JRuby, look at https://github.com/jruby/jruby/issues/2902.
+                       # Consider using block for comparison with type cast.
       [[2.0], 2.0, 0],
       [[2.0], 2, 0],
     ].each do |values, item, expected|
       context "looking for #{item.inspect} in #{values.inspect}" do
         it "returns #{expected.inspect}" do
           Hamster.list(*values).index(item).should == expected
+        end
+      end
+    end
+
+    [
+      [[], "A", nil],
+      [[], nil, nil],
+      [["A"], "A", 0],
+      [["A"], "B", nil],
+      [["A"], nil, nil],
+      [["A", "B", nil], "A", 0],
+      [["A", "B", nil], "B", 1],
+      [["A", "B", nil], nil, 2],
+      [["A", "B", nil], "C", nil],
+      [[2], 2, 0],
+      [[2], 2.0, 0],
+      [[2.0], 2.0, 0],
+      [[2.0], 2, 0],
+    ].each do |values, item, expected|
+      context "looking for #{item.inspect} in #{values.inspect} by block" do
+        it "returns #{expected.inspect}" do
+          Hamster.list(*values).index { |x| x == item }.should == expected
         end
       end
     end


### PR DESCRIPTION
JRuby have a bug for Enumerable#find_index with type cast. Look at https://github.com/jruby/jruby/issues/2902. 
I commented related spec and added version with comparison by block, where type cast works right for all rubies. 