### PR TITLE
Fix List#permutation spec for JRuby

### DIFF
--- a/spec/lib/hamster/list/permutation_spec.rb
+++ b/spec/lib/hamster/list/permutation_spec.rb
@@ -3,36 +3,36 @@ require "hamster/list"
 
 describe Hamster::List do
   describe "#permutation" do
-    let(:list) { Hamster.list(1,2,3,4,5) }
+    let(:list) { Hamster.list(1,2,3,4) }
 
     context "with no block" do
       it "returns an Enumerator" do
         list.permutation.class.should be(Enumerator)
-        list.permutation.to_a.sort.should == [1,2,3,4,5].permutation.to_a.sort
+        list.permutation.to_a.sort.should == [1,2,3,4].permutation.to_a.sort
       end
     end
 
     context "with no argument" do
       it "yields all permutations of the list" do
         perms = list.permutation.to_a
-        perms.size.should be(120)
-        perms.sort.should == [1,2,3,4,5].permutation.to_a.sort
+        perms.size.should be(24)
+        perms.sort.should == [1,2,3,4].permutation.to_a.sort
         perms.each { |item| item.should be_kind_of(Hamster::List) }
       end
     end
 
     context "with a length argument" do
       it "yields all N-size permutations of the list" do
-        perms = list.permutation(3).to_a
-        perms.size.should be(60)
-        perms.sort.should == [1,2,3,4,5].permutation(3).to_a.sort
+        perms = list.permutation(2).to_a
+        perms.size.should be(12)
+        perms.sort.should == [1,2,3,4].permutation(2).to_a.sort
         perms.each { |item| item.should be_kind_of(Hamster::List) }
       end
     end
 
     context "with a length argument greater than length of list" do
       it "yields nothing" do
-        list.permutation(6).to_a.should be_empty
+        list.permutation(5).to_a.should be_empty
       end
     end
 


### PR DESCRIPTION
Original spec generate error
```ruby
     Failure/Error: Unable to find matching line from backtrace
     Java::JavaLang::OutOfMemoryError:
       unable to create new native thread
```

Code where memory finished Hamster::Enumerable#<=>
```ruby
    def <=>(other)
      return 0 if self.equal?(other)
      enum1, enum2 = self.to_enum, other.to_enum
      loop do
        item1 = enum1.next
        item2 = enum2.next
        comp  = (item1 <=> item2)
        return comp if comp != 0
      end
      size1, size2 = self.size, other.size
      return 0 if size1 == size2
      size1 > size2 ? 1 : -1
    end
```

Reason for that - JRuby creates new Thread on every Enumerable#next (and doesn't for Array#next). Look to related issue for JRuby https://github.com/jruby/jruby/issues/2577. 

I don't see any way to avoid usage of Enumerable#next, so that related operations will be weighty in JRuby.

So i reduced count of elements in List#permutation spec, it keeps original logic and fits standard JRuby memory limits.