### PR TITLE
Fix Partitioned#realize and Left#realize for JRuby

### DIFF
--- a/lib/hamster/list.rb
+++ b/lib/hamster/list.rb
@@ -1311,7 +1311,8 @@ module Hamster
             @tail = Partitioned.new(@partitioner, @buffer, @mutex)
             # don't hold onto references
             # tail will keep references alive until end of list is reached
-            @partitioner, @buffer, @mutex = nil, nil, nil
+            @partitioner, @buffer = nil, nil
+            @mutex = nil unless RUBY_ENGINE == 'jruby' # look at https://github.com/jruby/jruby/issues/2925
             return
           elsif @partitioner.done?
             @head, @size, @tail = nil, 0, self
@@ -1367,7 +1368,8 @@ module Hamster
             if !@buffer.empty?
               @head = @buffer.shift
               @tail = Left.new(@splitter, @buffer, @mutex)
-              @splitter, @buffer, @mutex = nil, nil, nil
+              @splitter, @buffer = nil, nil
+              @mutex = nil unless RUBY_ENGINE == 'jruby' # look at https://github.com/jruby/jruby/issues/2925
               return
             elsif @splitter.done?
               @head, @size, @tail = nil, 0, self


### PR DESCRIPTION
This is fix for List#partition spec
```ruby
    it "calls the passed block only once for each item, even with multiple threads" do
      mutex = Mutex.new
      yielded = [] # record all the numbers yielded to the block, to make sure each is yielded only once
      list = Hamster.iterate(0) do |n|
        sleep(rand / 500) # give another thread a chance to get in
        mutex.synchronize { yielded << n }
        sleep(rand / 500)
        n + 1
      end
      left, right = list.partition(&:odd?)

      10.times.collect do |i|
        Thread.new do
          # half of the threads will consume the "left" lazy list, while half consume
          # the "right" lazy list
          # make sure that only one thread will run the above "iterate" block at a
          # time, regardless
          if i % 2 == 0
            left.take(100).sum.should == 10000
          else
            right.take(100).sum.should == 9900
          end
        end
      end.each(&:join)

      # if no threads "stepped on" each other, the following should be true
      # make some allowance for "lazy" lists which actually realize a little bit ahead:
      (200..203).include?(yielded.size).should == true
      yielded.should == (0..(yielded.size-1)).to_a
    end
```

Generated error
```ruby
     Failure/Error: left.take(100).sum.should == 10000
     NoMethodError:
       undefined method `synchronize' for nil:NilClass
     # ./lib/hamster/list.rb:1306:in `realize'
     # ./lib/hamster/list.rb:1255:in `empty?'
     # ./lib/hamster/list.rb:303:in `block in take'
     # ./lib/hamster/list.rb:1205:in `realize'
     # ./lib/hamster/list.rb:1182:in `empty?'
     # ./lib/hamster/list.rb:197:in `each'
     # ./lib/hamster/enumerable.rb:49:in `sum'
     # ./spec/lib/hamster/list/partition_spec.rb:57:in `block in (root)'
```

Code where error happens, Partitioned#realize
```ruby
    def realize
      @mutex.synchronize do
        return if @head != Undefined # another thread got ahead of us
        while true
          if !@buffer.empty?
            @head = @buffer.shift
            @tail = Partitioned.new(@partitioner, @buffer, @mutex)
            # don't hold onto references
            # tail will keep references alive until end of list is reached
            @partitioner, @buffer, @mutex = nil, nil, nil
            return
          elsif @partitioner.done?
            @head, @size, @tail = nil, 0, self
            @partitioner, @buffer, @mutex = nil, nil, nil # allow them to be GC'd
            return
          else
            @partitioner.next_item
          end
        end
      end
```

Here in 10 threads list is iterated by tail recursion. Sometimes mutex passed by recursion becomes nil. Looks like it's JRuby garbage collector bug. Related JRuby issue https://github.com/jruby/jruby/issues/2925.

I see only way to fix it - don't set @mutex to nil in parent object.

This is last bug fix for JRuby.