### PR TITLE
Add JRuby and Rubinius to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,12 @@ rvm:
   - 1.9.3
   - 2.0
   - 2.1
+  - 2.2
   - ruby-head
+  - jruby
+  - jruby-head
+  - rbx
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head


### PR DESCRIPTION
Add JRuby and Rubinius to Travis.

Also add MRI 2.2 and set MRI-head and JRuby-head as allow to failure.

Now 2 red specs in Travis:
1. MRI 2.2 and head crashes on
```ruby
rspec ./spec/lib/hamster/nested/construction_spec.rb:60
```
Similar to https://redmine.ruby-lang.org/issues/11071

2. JRuby have one red spec. It will be green as soon as JRuby 1.7.20 will be default in RVM.