### PR TITLE
Fix 2.2.2+ segfault in Hamster.from for certain inputs.

### DIFF
--- a/lib/hamster/trie.rb
+++ b/lib/hamster/trie.rb
@@ -29,7 +29,15 @@ module Hamster
 
     # Calls <tt>block</tt> once for each entry in the trie, passing the key-value pair as parameters.
     def each(&block)
-      @entries.each { |entry| yield(entry) if entry }
+      # TODO: Using block.call here is slower than using yield by 5-10%, but
+      # the latter segfaults on ruby 2.2 and above. Once that is fixed and
+      # broken versions are sufficiently old, we should revert back to yield
+      # with a warning that the broken versions are unsupported.
+      #
+      # For more context:
+      # * https://bugs.ruby-lang.org/issues/11451
+      # * https://github.com/hamstergem/hamster/issues/189
+      @entries.each { |entry| block.call(entry) if entry }
       @children.each do |child|
         child.each(&block) if child
       end


### PR DESCRIPTION
The fault appears to be an issue with mixing &block and yield, but I couldn't
figure out a more minimal repro.

Fixes #189 