### PR TITLE
Allow Immutable methods to be hidden by subclasses.

### DIFF
--- a/lib/hamster/immutable.rb
+++ b/lib/hamster/immutable.rb
@@ -11,7 +11,7 @@ module Hamster
     # @private
     module ClassMethods
       def new(*args)
-        super.immutable!
+        super.__send__(:immutable!)
       end
 
       def memoize(*names)

--- a/spec/lib/hamster/immutable/new_spec.rb
+++ b/spec/lib/hamster/immutable/new_spec.rb
@@ -11,4 +11,18 @@ describe Hamster::Immutable do
   it "freezes the instance" do
     expect(immutable).to be_frozen
   end
+
+  context "subclass hides all public methods" do
+    it "freezes the instance" do
+      my_class = Class.new do
+        include Hamster::Immutable
+
+        (public_instance_methods - Object.public_instance_methods).each do |m|
+          protected m
+        end
+      end
+      immutable = my_class.new
+      expect(immutable).to be_frozen
+    end
+  end
 end


### PR DESCRIPTION
Sorry for the barrage of issues today! Don't feel like you need to respond to them at once :)

My motivation for this change is I don't want to leak hamster methods in the
API of one of my libraries. The easiest way to do this is to subclass
Vector and mark as protected any methods that aren't provided by Array.
(I also need to deal with methods that have different return types, but
that's a separate issue.)

Admittedly this use-case is kind of weird - I'm experimenting with a few
different library ideas. This change seemed pretty innocuous though.