### PR TITLE
Remove circular dependency on core_ext

### DIFF
--- a/lib/hamster/core_ext/enumerable.rb
+++ b/lib/hamster/core_ext/enumerable.rb
@@ -6,16 +6,6 @@ module Enumerable
   # Return a new {Hamster::List} populated with the items in this `Enumerable` object.
   # @return [List]
   def to_list
-    # use destructive operations to build up a new list, like Common Lisp's NCONC
-    # this is a very fast way to build up a linked list
-    list = tail = Hamster::Cons.allocate
-    each do |item|
-      new_node = Hamster::Cons.allocate
-      new_node.instance_variable_set(:@head, item)
-      tail.instance_variable_set(:@tail, new_node)
-      tail = new_node
-    end
-    tail.instance_variable_set(:@tail, Hamster::EmptyList)
-    list.tail
+    Hamster::List.from_enum(self)
   end
 end

--- a/lib/hamster/deque.rb
+++ b/lib/hamster/deque.rb
@@ -74,7 +74,7 @@ module Hamster
     end
 
     def initialize(items=[])
-      @front = items.to_list
+      @front = Hamster::List.from_enum(items)
       @rear  = EmptyList
     end
 

--- a/spec/lib/hamster/list/each_spec.rb
+++ b/spec/lib/hamster/list/each_spec.rb
@@ -32,7 +32,7 @@ describe Hamster::List do
         context "without a block" do
           it "returns an Enumerator" do
             list.each.class.should be(Enumerator)
-            list.each.to_list.should eql(list)
+            Hamster::List[*list.each].should eql(list)
           end
         end
       end


### PR DESCRIPTION
Ref #196 

Leaving `from_enum` private for now, there's a larger discussion to have about providing "fast" non-splatted constructors for all types.