### PR TITLE
added Hamster.from support (and specs) for Ruby core Structs (one-way only)

### DIFF
--- a/lib/hamster/nested.rb
+++ b/lib/hamster/nested.rb
@@ -27,6 +27,8 @@ module Hamster
         Hamster::Hash.new(res)
       when Hamster::Hash
         obj.map { |key, value| [from(key), from(value)] }
+      when ::Struct
+        from(obj.to_h)
       when ::Array
         res = obj.map { |element| from(element) }
         Hamster::Vector.new(res)

--- a/spec/lib/hamster/nested/construction_spec.rb
+++ b/spec/lib/hamster/nested/construction_spec.rb
@@ -4,6 +4,9 @@ require "hamster/deque"
 require "set"
 
 describe Hamster do
+
+  Struct.new("Customer", :name, :address)
+
   expectations = [
     # [Ruby, Hamster]
     [ { "a" => 1,
@@ -28,7 +31,11 @@ describe Hamster do
     [ ::SortedSet.new, Hamster::SortedSet[] ],
     [ ::SortedSet.new([1, 2, 3]), Hamster::SortedSet[1, 2, 3] ],
     [ 42, 42 ],
-    [ STDOUT, STDOUT ]
+    [ STDOUT, STDOUT ],
+
+    # Struct conversion is one-way (from Ruby core Struct to Hamster::Hash), not back again!
+    [ Struct::Customer.new, Hamster::Hash[ name: nil, address: nil], true ],
+    [ Struct::Customer.new('Dave', '123 Main'), Hamster::Hash[ name: 'Dave', address: '123 Main'], true ]
   ]
 
   describe ".from" do
@@ -58,10 +65,12 @@ describe Hamster do
   end
 
   describe ".to_ruby" do
-    expectations.each do |expected_result, input|
-      context "with #{input.inspect} as input" do
-        it "should return #{expected_result.inspect}" do
-          Hamster.to_ruby(input).should eql(expected_result)
+    expectations.each do |expected_result, input, one_way|
+      unless one_way
+        context "with #{input.inspect} as input" do
+          it "should return #{expected_result.inspect}" do
+            Hamster.to_ruby(input).should eql(expected_result)
+          end
         end
       end
     end


### PR DESCRIPTION
I'm using Hamster with the AWS SDK for Ruby. That thing produces Structs not Hashes. (nested Struct/Array conglomerations).

This PR adds support for converting .from Structs. There is no conversion back: the conversion back produces Hash since there is no way to now we came from a Struct. Most libs I've seen will accept Hashes in place of their Structs so I think this lack of perfect symmetry will be fine.

Added two expectation pairs to the nested test suite and added an optional third `one_way` element to an expectation. If present, and truthy, then it elides the `.to_ruby` specs for that entry. This lets us add more one-way conversions if needed.