### PR TITLE
Backport Struct#to_h to MRI 1.9.3 and earlier

### DIFF
--- a/lib/hamster/core_ext/struct.rb
+++ b/lib/hamster/core_ext/struct.rb
@@ -1,0 +1,9 @@
+class Struct
+  # Implement Struct#to_h for Ruby interpreters which don't have it
+  # (such as MRI 1.9.3 and lower)
+  unless method_defined?(:to_h)
+    def to_h
+      Hash[members.zip(values)]
+    end
+  end
+end

--- a/lib/hamster/nested.rb
+++ b/lib/hamster/nested.rb
@@ -5,6 +5,7 @@ require "hamster/vector"
 require "hamster/sorted_set"
 require "hamster/list"
 require "hamster/deque"
+require "hamster/core_ext/struct"
 
 module Hamster
   class << self


### PR DESCRIPTION
e7a8f12 added support for Ruby core `Struct`s to `Hamster.from`. Unfortunately,
MRI <= 1.9.3 doesn't provide `Struct#to_h`, which is used. Therefore, backport it.

We could use `Struct#members` and `Struct#values` directly in Hamster.from instead,
but that would penalize performance on new Ruby interpreters.

Contributors, your feedback please! Is this the best way to resolve this issue?