### PR TITLE
update concurrent ruby to 1.0.0

### DIFF
--- a/hamster.gemspec
+++ b/hamster.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*", "spec/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency     "concurrent-ruby", "~> 0.8"
+  spec.add_runtime_dependency     "concurrent-ruby", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake", "~> 10.1"

--- a/lib/hamster/list.rb
+++ b/lib/hamster/list.rb
@@ -1311,7 +1311,7 @@ module Hamster
     def initialize(&block)
       @head   = block # doubles as storage for block while yet unrealized
       @tail   = nil
-      @atomic = Concurrent::Atomic.new(0) # haven't yet run block
+      @atomic = Concurrent::AtomicReference.new(0) # haven't yet run block
       @size   = nil
     end
 

--- a/spec/lib/hamster/list/multithreading_spec.rb
+++ b/spec/lib/hamster/list/multithreading_spec.rb
@@ -4,7 +4,7 @@ require "concurrent/atomics"
 
 describe Hamster::List do
   it "ensures each node of a lazy list will only be realized on ONE thread, even when accessed by multiple threads" do
-    counter = Concurrent::Atomic.new(0)
+    counter = Concurrent::AtomicReference.new(0)
     list = (1..10000).to_list.map { |x| counter.update { |count| count + 1 }; x * 2 }
 
     threads = 10.times.collect do


### PR DESCRIPTION
Concurrent ruby now uses AtomicReference, which is a bit different under the hood, while having the same interface. It should be a touch faster, but I didn't benchmark it.