### PR TITLE
Fix minor error in benchmark messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+before_install:
+  - gem update --system
+  - gem --version
+  - gem update bundler
+  - bundle --version
 rvm:
   - 1.9.3
   - 2.0

--- a/bench/hash/get_bench.rb
+++ b/bench/hash/get_bench.rb
@@ -45,7 +45,7 @@ Benchmark.ips do |b|
     end
   end
 
-  b.report "get existing medium" do |n|
+  b.report "get missing medium" do |n|
     a = 0
     x = nil
     while a < n
@@ -54,7 +54,7 @@ Benchmark.ips do |b|
     end
   end
 
-  b.report "get existing large" do |n|
+  b.report "get missing large" do |n|
     a = 0
     x = nil
     while a < n


### PR DESCRIPTION
Corrects mistaken benchmark descriptions in `bench/hash/get_bench.rb`.