### PR TITLE
Add CI build for Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3
   - ruby-head
   - jruby-9.0.0.0
   - jruby-head


### PR DESCRIPTION
Should CI run a Ruby 2.3 build?

This probably needs to be rebased on #226 to pass CI.