### PR TITLE
Simplify Vector#uniq

### DIFF
--- a/lib/hamster/vector.rb
+++ b/lib/hamster/vector.rb
@@ -526,21 +526,9 @@ module Hamster
     # @return [Vector]
     def uniq(&block)
       array = self.to_a
-      if block_given?
-        if array.frozen?
-          self.class.new(array.uniq(&block).freeze)
-        elsif array.uniq!(&block) # returns nil if no changes were made
-          self.class.new(array.freeze)
-        else
-          self
-        end
-      elsif array.frozen?
-        self.class.new(array.uniq.freeze)
-      elsif array.uniq! # returns nil if no changes were made
-        self.class.new(array.freeze)
-      else
-        self
-      end
+      return self.class.new(array.uniq(&block).freeze) if array.frozen?
+      return self.class.new(array.freeze) if array.uniq!(&block)
+      self
     end
 
     # Return a new `Vector` with the same elements as this one, but in reverse order.


### PR DESCRIPTION
> There's no need to switch on `block_given?` (`&nil` can pass through to `Array#uniq{,!}`).

Signed-off-by: Stephen Celis <stephen@stephencelis.com>

This is an alternate PR for #224. It is identical to that (and contains the same commit), except that it is rebased on the latest `core` to persuade Travis to pass all required builds.