### PR TITLE
Adds an Array setter `#[]=` that raises an error

### DIFF
--- a/lib/hamster/hash.rb
+++ b/lib/hamster/hash.rb
@@ -266,6 +266,12 @@ module Hamster
       end
     end
 
+    # @private
+    # @raise NoMethodError
+    def []=(*)
+      raise NoMethodError, "Hamster::Hash doesn't support `[]='; use `put' instead"
+    end
+
     # Return a new `Hash` with a deeply nested value modified to the result of
     # the given code block.  When traversing the nested `Hash`es and `Vector`s,
     # non-existing keys are created with empty `Hash` values.

--- a/spec/lib/hamster/hash/put_spec.rb
+++ b/spec/lib/hamster/hash/put_spec.rb
@@ -2,6 +2,13 @@ require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do
+  describe "#[]=" do
+    it 'raises error pointing to #put' do
+      expect { subject[:A] = 'aye' }
+        .to raise_error(NoMethodError, /Hamster::Hash.*`put'/)
+    end
+  end
+
   describe "#put" do
     let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 


### PR DESCRIPTION
The error points to `#put`; this closes #219. The relevant spec is included in the `#put` specs.

I don't feel strongly about this being merged; I saw it was an easy issue to close, and had good support from the project contributors, so I threw a PR together. Feel free to close if this is just API pollution.