### PR TITLE
Use Prime.prime? in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,25 +207,15 @@ That's because Hamster `List`s are immutable.
 ### Laziness
 
 `List` is lazy where possible. It tries to defer processing items until
-absolutely necessary. For example, given a crude function to detect prime
-numbers:
+absolutely necessary. For example, the following code will only call
+`Prime.prime?` as many times as necessary to generate the first 3
+prime numbers between 10,000 and 1,000,000:
 
 ``` ruby
-def prime?(number)
-  2.upto(Math.sqrt(number).round) do |integer|
-    return false if (number % integer).zero?
-  end
-  true
-end
-```
+require 'prime'
 
-The following code will only call `#prime?` as many times as
-necessary to generate the first 3 prime numbers between 10,000
-and 1,000,000:
-
-``` ruby
 Hamster.interval(10_000, 1_000_000).select do |number|
-  prime?(number)
+  Prime.prime?(number)
 end.take(3)
   # => 0.0009s
 ```
@@ -236,7 +226,7 @@ first three:
 
 ``` ruby
 (10000..1000000).select do |number|
-  prime?(number)
+  Prime.prime?(number)
 end.take(3)
   # => 10s
 ```


### PR DESCRIPTION
Ruby comes with [`Prime.prime?` in its standard library](https://ruby-doc.org/stdlib-2.4.0/libdoc/prime/rdoc/Prime.html), so the _Laziness_ section does not need to define its own `#prime?` function.