### PR TITLE
Update "Installing" section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Installing
 
 Add this line to your application's Gemfile:
 
-    gem "hamster", "2.0.0"
+    gem "hamster"
 
 And then execute:
 


### PR DESCRIPTION
Remove version number from `gem "hamster"` in README. This avoids the need to update the README each time there is a version change.