### PR TITLE
Add initial counters value in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Since it is immutable, Hamster's `Hash` doesn't provide an assignment
 transforms the value associated with a given key:
 
 ``` ruby
-counters.put(:odds) { |value| value + 1 } # => Hamster::Hash[:odds => 1, :evens => 0]
+counters = Hamster::Hash[evens: 0, odds: 0]  # => Hamster::Hash[:evens => 0, :odds => 0]
+counters.put(:odds) { |value| value + 1 }    # => Hamster::Hash[:odds => 1, :evens => 0]
 ```
 
 Or more succinctly:


### PR DESCRIPTION
This explicitly shows the initial value of the counters hash
so that the following section on how to update it is more clearly
understood

The example on updating the `odds` key was not clear the first time
since the initial value of the hash was not explicitly shown