### PR TITLE
Update Ruby supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ before_install:
   - gem update bundler
   - bundle --version
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
   - jruby-9.0.0.0
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - gem update bundler
   - bundle --version
 rvm:
-  - 1.9.3
   - 2.0
   - 2.1
   - 2.2


### PR DESCRIPTION
- Remove support for deprecated Ruby versions
- Use latest versions of supported Rubies

[Current supported versions](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/)