### PR TITLE
Modernize rspec syntax

### DIFF
--- a/spec/lib/hamster/associable/associable_spec.rb
+++ b/spec/lib/hamster/associable/associable_spec.rb
@@ -23,116 +23,116 @@ describe Hamster::Associable do
     }
     context "with one level on existing key" do
       it "Hash passes the value to the block" do
-        hash.update_in("A") { |value| value.should == "aye" }
+        hash.update_in("A") { |value| expect(value).to eq("aye") }
       end
 
       it "Vector passes the value to the block" do
-        vector.update_in(1) { |value| value.should == 101 }
+        vector.update_in(1) { |value| expect(value).to eq(101) }
       end
 
       it "Hash replaces the value with the result of the block" do
         result = hash.update_in("A") { |value| "FLIBBLE" }
-        result.get("A").should == "FLIBBLE"
+        expect(result.get("A")).to eq("FLIBBLE")
       end
 
       it "Vector replaces the value with the result of the block" do
         result = vector.update_in(1) { |value| "FLIBBLE" }
-        result.get(1).should == "FLIBBLE"
+        expect(result.get(1)).to eq("FLIBBLE")
       end
 
       it "Hash should preserve the original" do
         result = hash.update_in("A") { |value| "FLIBBLE" }
-        hash.get("A").should == "aye"
+        expect(hash.get("A")).to eq("aye")
       end
 
       it "Vector should preserve the original" do
         result = vector.update_in(1) { |value| "FLIBBLE" }
-        vector.get(1).should == 101
+        expect(vector.get(1)).to eq(101)
       end
     end
 
     context "with multi-level on existing keys" do
       it "Hash passes the value to the block" do
-        hash.update_in("B", "D", "E") { |value| value.should == "eee" }
+        hash.update_in("B", "D", "E") { |value| expect(value).to eq("eee") }
       end
 
       it "Vector passes the value to the block" do
-        vector.update_in(3, 2, 0) { |value| value.should == 300 }
+        vector.update_in(3, 2, 0) { |value| expect(value).to eq(300) }
       end
 
       it "Hash replaces the value with the result of the block" do
         result = hash.update_in("B", "D", "E") { |value| "FLIBBLE" }
-        result["B"]["D"]["E"].should == "FLIBBLE"
+        expect(result["B"]["D"]["E"]).to eq("FLIBBLE")
       end
 
       it "Vector replaces the value with the result of the block" do
         result = vector.update_in(3, 2, 0) { |value| "FLIBBLE" }
-        result[3][2][0].should == "FLIBBLE"
+        expect(result[3][2][0]).to eq("FLIBBLE")
       end
 
       it "Hash should preserve the original" do
         result = hash.update_in("B", "D", "E") { |value| "FLIBBLE" }
-        hash["B"]["D"]["E"].should == "eee"
+        expect(hash["B"]["D"]["E"]).to eq("eee")
       end
 
       it "Vector should preserve the original" do
         result = vector.update_in(3, 2, 0) { |value| "FLIBBLE" }
-        vector[3][2][0].should == 300
+        expect(vector[3][2][0]).to eq(300)
       end
 
     end
 
     context "with multi-level creating sub-hashes when keys don't exist" do
       it "Hash passes nil to the block" do
-        hash.update_in("B", "X", "Y") { |value| value.should be_nil }
+        hash.update_in("B", "X", "Y") { |value| expect(value).to be_nil }
       end
 
       it "Vector passes nil to the block" do
-        vector.update_in(3, 3, "X", "Y") { |value| value.should be_nil }
+        vector.update_in(3, 3, "X", "Y") { |value| expect(value).to be_nil }
       end
 
       it "Hash creates subhashes on the way to set the value" do
         result = hash.update_in("B", "X", "Y") { |value| "NEWVALUE" }
-        result["B"]["X"]["Y"].should == "NEWVALUE"
-        result["B"]["D"]["E"].should == "eee"
+        expect(result["B"]["X"]["Y"]).to eq("NEWVALUE")
+        expect(result["B"]["D"]["E"]).to eq("eee")
       end
 
       it "Vector creates subhashes on the way to set the value" do
         result = vector.update_in(3, 3, "X", "Y") { |value| "NEWVALUE" }
-        result[3][3]["X"]["Y"].should == "NEWVALUE"
-        result[3][2][0].should == 300
+        expect(result[3][3]["X"]["Y"]).to eq("NEWVALUE")
+        expect(result[3][2][0]).to eq(300)
       end
     end
 
     context "Hash with multi-level including Vector with existing keys" do
       it "passes the value to the block" do
-        hash.update_in("F", 1, "H") { |value| value.should == "eitch" }
+        hash.update_in("F", 1, "H") { |value| expect(value).to eq("eitch") }
       end
 
       it "replaces the value with the result of the block" do
         result = hash.update_in("F", 1, "H") { |value| "FLIBBLE" }
-        result["F"][1]["H"].should == "FLIBBLE"
+        expect(result["F"][1]["H"]).to eq("FLIBBLE")
       end
 
       it "should preserve the original" do
         result = hash.update_in("F", 1, "H") { |value| "FLIBBLE" }
-        hash["F"][1]["H"].should == "eitch"
+        expect(hash["F"][1]["H"]).to eq("eitch")
       end
     end
 
     context "Vector with multi-level including Hash with existing keys" do
       it "passes the value to the block" do
-        vector.update_in(4, "B") { |value| value.should == "bravo" }
+        vector.update_in(4, "B") { |value| expect(value).to eq("bravo") }
       end
 
       it "replaces the value with the result of the block" do
         result = vector.update_in(4, "B") { |value| "FLIBBLE" }
-        result[4]["B"].should == "FLIBBLE"
+        expect(result[4]["B"]).to eq("FLIBBLE")
       end
 
       it "should preserve the original" do
         result = vector.update_in(4, "B") { |value| "FLIBBLE" }
-        vector[4]["B"].should == "bravo"
+        expect(vector[4]["B"]).to eq("bravo")
       end
     end
 

--- a/spec/lib/hamster/deque/clear_spec.rb
+++ b/spec/lib/hamster/deque/clear_spec.rb
@@ -13,11 +13,11 @@ describe Hamster::Deque do
 
         it "preserves the original" do
           deque.clear
-          deque.should eql(D[*values])
+          expect(deque).to eql(D[*values])
         end
 
         it "returns an empty deque" do
-          deque.clear.should equal(D.empty)
+          expect(deque.clear).to equal(D.empty)
         end
       end
     end
@@ -27,8 +27,8 @@ describe Hamster::Deque do
     it "returns an instance of the subclass" do
       subclass = Class.new(Hamster::Deque)
       instance = subclass.new([1,2])
-      instance.clear.should be_empty
-      instance.clear.class.should be(subclass)
+      expect(instance.clear).to be_empty
+      expect(instance.clear.class).to be(subclass)
     end
   end
 end

--- a/spec/lib/hamster/deque/construction_spec.rb
+++ b/spec/lib/hamster/deque/construction_spec.rb
@@ -5,13 +5,13 @@ describe Hamster::Deque do
   describe ".[]" do
     context "with no arguments" do
       it "always returns the same instance" do
-        D[].class.should be(Hamster::Deque)
-        D[].should equal(D[])
+        expect(D[].class).to be(Hamster::Deque)
+        expect(D[]).to equal(D[])
       end
 
       it "returns an empty, frozen deque" do
-        D[].should be_empty
-        D[].should be_frozen
+        expect(D[]).to be_empty
+        expect(D[]).to be_frozen
       end
     end
 
@@ -19,11 +19,11 @@ describe Hamster::Deque do
       let(:deque) { D["A", "B", "C"] }
 
       it "always returns a different instance" do
-        deque.should_not equal(D["A", "B", "C"])
+        expect(deque).not_to equal(D["A", "B", "C"])
       end
 
       it "is the same as repeatedly using #endeque" do
-        deque.should eql(D.empty.enqueue("A").enqueue("B").enqueue("C"))
+        expect(deque).to eql(D.empty.enqueue("A").enqueue("B").enqueue("C"))
       end
     end
   end

--- a/spec/lib/hamster/deque/copying_spec.rb
+++ b/spec/lib/hamster/deque/copying_spec.rb
@@ -12,7 +12,7 @@ describe Hamster::Deque do
         let(:deque) { D[*values] }
 
         it "returns self" do
-          deque.send(method).should equal(deque)
+          expect(deque.send(method)).to equal(deque)
         end
       end
     end

--- a/spec/lib/hamster/deque/dequeue_spec.rb
+++ b/spec/lib/hamster/deque/dequeue_spec.rb
@@ -14,11 +14,11 @@ describe Hamster::Deque do
 
           it "preserves the original" do
             deque.send(method)
-            deque.should eql(D[*values])
+            expect(deque).to eql(D[*values])
           end
 
           it "returns #{expected.inspect}" do
-            deque.send(method).should eql(D[*expected])
+            expect(deque.send(method)).to eql(D[*expected])
           end
         end
       end
@@ -28,7 +28,7 @@ describe Hamster::Deque do
       let(:subclass) { Class.new(Hamster::Deque) }
       let(:empty_instance) { subclass.new }
       it "returns emtpy object of same class" do
-        empty_instance.send(method).class.should be subclass
+        expect(empty_instance.send(method).class).to be subclass
       end
     end
   end

--- a/spec/lib/hamster/deque/empty_spec.rb
+++ b/spec/lib/hamster/deque/empty_spec.rb
@@ -10,30 +10,30 @@ describe Hamster::Deque do
     ].each do |values, expected|
       context "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          D[*values].empty?.should == expected
+          expect(D[*values].empty?).to eq(expected)
         end
       end
     end
 
     context "after dedequeing an item from #{%w[A B C].inspect}" do
       it "returns false" do
-        D["A", "B", "C"].dequeue.should_not be_empty
+        expect(D["A", "B", "C"].dequeue).not_to be_empty
       end
     end
   end
 
   describe ".empty" do
     it "returns the canonical empty deque" do
-      D.empty.size.should be(0)
-      D.empty.class.should be(Hamster::Deque)
-      D.empty.object_id.should be(Hamster::EmptyDeque.object_id)
+      expect(D.empty.size).to be(0)
+      expect(D.empty.class).to be(Hamster::Deque)
+      expect(D.empty.object_id).to be(Hamster::EmptyDeque.object_id)
     end
 
     context "from a subclass" do
       it "returns an empty instance of the subclass" do
         subclass = Class.new(Hamster::Deque)
-        subclass.empty.class.should be(subclass)
-        subclass.empty.should be_empty
+        expect(subclass.empty.class).to be(subclass)
+        expect(subclass.empty).to be_empty
       end
     end
   end

--- a/spec/lib/hamster/deque/enqueue_spec.rb
+++ b/spec/lib/hamster/deque/enqueue_spec.rb
@@ -15,11 +15,11 @@ describe Hamster::Deque do
 
           it "preserves the original" do
             deque.send(method, new_value)
-            deque.should eql(D[*values])
+            expect(deque).to eql(D[*values])
           end
 
           it "returns #{expected.inspect}" do
-            deque.send(method, new_value).should eql(D[*expected])
+            expect(deque.send(method, new_value)).to eql(D[*expected])
           end
         end
       end

--- a/spec/lib/hamster/deque/first_spec.rb
+++ b/spec/lib/hamster/deque/first_spec.rb
@@ -10,7 +10,7 @@ describe Hamster::Deque do
     ].each do |values, expected|
       context "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          D[*values].first.should == expected
+          expect(D[*values].first).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/deque/inspect_spec.rb
+++ b/spec/lib/hamster/deque/inspect_spec.rb
@@ -12,11 +12,11 @@ describe Hamster::Deque do
         let(:deque) { D[*values] }
 
         it "returns #{expected.inspect}" do
-          deque.inspect.should == expected
+          expect(deque.inspect).to eq(expected)
         end
 
         it "returns a string which can be eval'd to get an equivalent object" do
-          eval(deque.inspect).should eql(deque)
+          expect(eval(deque.inspect)).to eql(deque)
         end
       end
     end

--- a/spec/lib/hamster/deque/last_spec.rb
+++ b/spec/lib/hamster/deque/last_spec.rb
@@ -10,7 +10,7 @@ describe Hamster::Deque do
     ].each do |values, expected|
       context "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          D[*values].last.should eql(expected)
+          expect(D[*values].last).to eql(expected)
         end
       end
     end

--- a/spec/lib/hamster/deque/new_spec.rb
+++ b/spec/lib/hamster/deque/new_spec.rb
@@ -5,10 +5,10 @@ describe Hamster::Deque do
   describe ".new" do
     it "accepts a single enumerable argument and creates a new deque" do
       deque = Hamster::Deque.new([1,2,3])
-      deque.size.should be(3)
-      deque.first.should be(1)
-      deque.dequeue.first.should be(2)
-      deque.dequeue.dequeue.first.should be(3)
+      expect(deque.size).to be(3)
+      expect(deque.first).to be(1)
+      expect(deque.dequeue.first).to be(2)
+      expect(deque.dequeue.dequeue.first).to be(3)
     end
 
     it "is amenable to overriding of #initialize" do
@@ -19,16 +19,16 @@ describe Hamster::Deque do
       end
 
       deque = SnazzyDeque.new
-      deque.size.should be(1)
-      deque.to_a.should == ['SNAZZY!!!']
+      expect(deque.size).to be(1)
+      expect(deque.to_a).to eq(['SNAZZY!!!'])
     end
 
     context "from a subclass" do
       it "returns a frozen instance of the subclass" do
         subclass = Class.new(Hamster::Deque)
         instance = subclass.new(["some", "values"])
-        instance.class.should be subclass
-        instance.frozen?.should be true
+        expect(instance.class).to be subclass
+        expect(instance.frozen?).to be true
       end
     end
   end
@@ -36,9 +36,9 @@ describe Hamster::Deque do
   describe ".[]" do
     it "accepts a variable number of items and creates a new deque" do
       deque = Hamster::Deque['a', 'b']
-      deque.size.should be(2)
-      deque.first.should == 'a'
-      deque.dequeue.first.should == 'b'
+      expect(deque.size).to be(2)
+      expect(deque.first).to eq('a')
+      expect(deque.dequeue.first).to eq('b')
     end
   end
 end

--- a/spec/lib/hamster/deque/pop_spec.rb
+++ b/spec/lib/hamster/deque/pop_spec.rb
@@ -13,15 +13,15 @@ describe Hamster::Deque do
 
         it "preserves the original" do
           deque.pop
-          deque.should eql(D[*values])
+          expect(deque).to eql(D[*values])
         end
 
         it "returns #{expected.inspect}" do
-          deque.pop.should eql(D[*expected])
+          expect(deque.pop).to eql(D[*expected])
         end
 
         it "returns a frozen instance" do
-          deque.pop.should be_frozen
+          expect(deque.pop).to be_frozen
         end
       end
     end
@@ -30,7 +30,7 @@ describe Hamster::Deque do
       let(:subclass) { Class.new(Hamster::Deque) }
       let(:empty_instance) { subclass.new }
       it "returns emtpy object of same class" do
-        empty_instance.pop.class.should be subclass
+        expect(empty_instance.pop.class).to be subclass
       end
     end
   end

--- a/spec/lib/hamster/deque/pretty_print_spec.rb
+++ b/spec/lib/hamster/deque/pretty_print_spec.rb
@@ -10,15 +10,15 @@ describe Hamster::Deque do
 
     it "prints the whole Deque on one line if it fits" do
       PP.pp(deque, stringio, 80)
-      stringio.string.chomp.should == 'Hamster::Deque["AAAA", "BBBB", "CCCC"]'
+      expect(stringio.string.chomp).to eq('Hamster::Deque["AAAA", "BBBB", "CCCC"]')
     end
 
     it "prints each item on its own line, if not" do
       PP.pp(deque, stringio, 10)
-      stringio.string.chomp.should == 'Hamster::Deque[
+      expect(stringio.string.chomp).to eq('Hamster::Deque[
  "AAAA",
  "BBBB",
- "CCCC"]'
+ "CCCC"]')
     end
   end
 end

--- a/spec/lib/hamster/deque/push_spec.rb
+++ b/spec/lib/hamster/deque/push_spec.rb
@@ -13,15 +13,15 @@ describe Hamster::Deque do
 
         it "preserves the original" do
           deque.push(item)
-          deque.should eql(D.new(original))
+          expect(deque).to eql(D.new(original))
         end
 
         it "returns #{expected.inspect}" do
-          deque.push(item).should eql(D.new(expected))
+          expect(deque.push(item)).to eql(D.new(expected))
         end
 
         it "returns a frozen instance" do
-          deque.push(item).should be_frozen
+          expect(deque.push(item)).to be_frozen
         end
       end
     end
@@ -30,7 +30,7 @@ describe Hamster::Deque do
       let(:subclass) { Class.new(Hamster::Deque) }
       let(:empty_instance) { subclass.new }
       it "returns an object of same class" do
-        empty_instance.push(1).class.should be subclass
+        expect(empty_instance.push(1).class).to be subclass
       end
     end
   end

--- a/spec/lib/hamster/deque/random_modification_spec.rb
+++ b/spec/lib/hamster/deque/random_modification_spec.rb
@@ -24,10 +24,10 @@ describe Hamster::Deque do
           deque = deque.unshift(value)
         end
 
-        deque.to_a.should eql(array)
-        deque.size.should == array.size
-        deque.first.should == array.first
-        deque.last.should == array.last
+        expect(deque.to_a).to eql(array)
+        expect(deque.size).to eq(array.size)
+        expect(deque.first).to eq(array.first)
+        expect(deque.last).to eq(array.last)
       end
     end
   end

--- a/spec/lib/hamster/deque/shift_spec.rb
+++ b/spec/lib/hamster/deque/shift_spec.rb
@@ -13,16 +13,16 @@ describe Hamster::Deque do
 
         it "preserves the original" do
           deque.shift
-          deque.should eql(D.new(values))
+          expect(deque).to eql(D.new(values))
         end
 
         it "returns #{expected.inspect}" do
-          deque.shift.should eql(D.new(expected))
+          expect(deque.shift).to eql(D.new(expected))
         end
 
 
         it "returns a frozen instance" do
-          deque.shift.should be_frozen
+          expect(deque.shift).to be_frozen
         end
       end
     end

--- a/spec/lib/hamster/deque/size_spec.rb
+++ b/spec/lib/hamster/deque/size_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::Deque do
       ].each do |values, expected|
         context "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            D[*values].send(method).should == expected
+            expect(D[*values].send(method)).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/deque/to_a_spec.rb
+++ b/spec/lib/hamster/deque/to_a_spec.rb
@@ -11,14 +11,14 @@ describe Hamster::Deque do
       ].each do |values|
         context "on #{values.inspect}" do
           it "returns #{values.inspect}" do
-            D[*values].send(method).should == values
+            expect(D[*values].send(method)).to eq(values)
           end
 
           it "returns a mutable array" do
             result = D[*values].send(method)
             expect(result.last).to_not eq("The End")
             result << "The End"
-            result.last.should == "The End"
+            expect(result.last).to eq("The End")
           end
         end
       end

--- a/spec/lib/hamster/deque/to_list_spec.rb
+++ b/spec/lib/hamster/deque/to_list_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::Deque do
     ].each do |values|
       context "on #{values.inspect}" do
         it "returns a list containing #{values.inspect}" do
-          D[*values].to_list.should eql(L[*values])
+          expect(D[*values].to_list).to eql(L[*values])
         end
       end
     end
@@ -19,7 +19,7 @@ describe Hamster::Deque do
     context "after dedequeing an item from #{%w[A B C].inspect}" do
       it "returns a list containing #{%w[B C].inspect}" do
         list = D["A", "B", "C"].dequeue.to_list
-        list.should eql(L["B", "C"])
+        expect(list).to eql(L["B", "C"])
       end
     end
   end

--- a/spec/lib/hamster/deque/unshift_spec.rb
+++ b/spec/lib/hamster/deque/unshift_spec.rb
@@ -14,16 +14,16 @@ describe Hamster::Deque do
 
         it "preserves the original" do
           deque.unshift(new_value)
-          deque.should eql(D[*values])
+          expect(deque).to eql(D[*values])
         end
 
         it "returns #{expected.inspect}" do
-          deque.unshift(new_value).should eql(D[*expected])
+          expect(deque.unshift(new_value)).to eql(D[*expected])
         end
 
 
         it "returns a frozen instance" do
-          deque.unshift(new_value).should be_frozen
+          expect(deque.unshift(new_value)).to be_frozen
         end
       end
     end

--- a/spec/lib/hamster/hash/all_spec.rb
+++ b/spec/lib/hamster/hash/all_spec.rb
@@ -10,13 +10,13 @@ describe Hamster::Hash do
 
       context "without a block" do
         it "returns true" do
-          hash.all?.should == true
+          expect(hash.all?).to eq(true)
         end
       end
 
       context "with a block" do
         it "returns true" do
-          hash.all? { false }.should == true
+          expect(hash.all? { false }).to eq(true)
         end
       end
     end
@@ -26,27 +26,27 @@ describe Hamster::Hash do
 
       context "without a block" do
         it "returns true" do
-          hash.all?.should == true
+          expect(hash.all?).to eq(true)
         end
       end
 
       context "with a block" do
         it "returns true if the block always returns true" do
-          hash.all? { true }.should == true
+          expect(hash.all? { true }).to eq(true)
         end
 
         it "returns false if the block ever returns false" do
-          hash.all? { |k,v| k != 'C' }.should == false
+          expect(hash.all? { |k,v| k != 'C' }).to eq(false)
         end
 
         it "propagates an exception from the block" do
-          -> { hash.all? { |k,v| raise "help" } }.should raise_error(RuntimeError)
+          expect { hash.all? { |k,v| raise "help" } }.to raise_error(RuntimeError)
         end
 
         it "stops iterating as soon as the block returns false" do
           yielded = []
           hash.all? { |k,v| yielded << k; false }
-          yielded.size.should == 1
+          expect(yielded.size).to eq(1)
         end
       end
     end

--- a/spec/lib/hamster/hash/any_spec.rb
+++ b/spec/lib/hamster/hash/any_spec.rb
@@ -5,11 +5,11 @@ describe Hamster::Hash do
   describe "#any?" do
     context "when empty" do
       it "with a block returns false" do
-        H.empty.any? {}.should == false
+        expect(H.empty.any? {}).to eq(false)
       end
 
       it "with no block returns false" do
-        H.empty.any?.should == false
+        expect(H.empty.any?).to eq(false)
       end
     end
 
@@ -25,28 +25,28 @@ describe Hamster::Hash do
         ].each do |pair|
 
           it "returns true if the block ever returns true (#{pair.inspect})" do
-            hash.any? { |key, value| key == pair.first && value == pair.last }.should == true
+            expect(hash.any? { |key, value| key == pair.first && value == pair.last }).to eq(true)
           end
 
           it "returns false if the block always returns false" do
-            hash.any? { |key, value| key == "D" && value == "dee" }.should == false
+            expect(hash.any? { |key, value| key == "D" && value == "dee" }).to eq(false)
           end
         end
 
         it "propagates exceptions raised in the block" do
-          -> { hash.any? { |k,v| raise "help" } }.should raise_error(RuntimeError)
+          expect { hash.any? { |k,v| raise "help" } }.to raise_error(RuntimeError)
         end
 
         it "stops iterating as soon as the block returns true" do
           yielded = []
           hash.any? { |k,v| yielded << k; true }
-          yielded.size.should == 1
+          expect(yielded.size).to eq(1)
         end
       end
 
       context "with no block" do
         it "returns true" do
-          hash.any?.should == true
+          expect(hash.any?).to eq(true)
         end
       end
     end

--- a/spec/lib/hamster/hash/assoc_spec.rb
+++ b/spec/lib/hamster/hash/assoc_spec.rb
@@ -6,47 +6,47 @@ describe Hamster::Hash do
 
   describe "#assoc" do
     it "searches for a key/val pair with a given key" do
-      hash.assoc(:a).should == [:a, 3]
-      hash.assoc(:b).should == [:b, 2]
-      hash.assoc(:c).should == [:c, 1]
+      expect(hash.assoc(:a)).to eq([:a, 3])
+      expect(hash.assoc(:b)).to eq([:b, 2])
+      expect(hash.assoc(:c)).to eq([:c, 1])
     end
 
     it "returns nil if a matching key is not found" do
-      hash.assoc(:d).should be_nil
-      hash.assoc(nil).should be_nil
-      hash.assoc(0).should be_nil
+      expect(hash.assoc(:d)).to be_nil
+      expect(hash.assoc(nil)).to be_nil
+      expect(hash.assoc(0)).to be_nil
     end
 
     it "returns nil even if there is a default" do
-      H.new(a: 1, b: 2) { fail }.assoc(:c).should be_nil
+      expect(H.new(a: 1, b: 2) { fail }.assoc(:c)).to be_nil
     end
 
     it "uses #== to compare keys with provided object" do
-      hash.assoc(EqualNotEql.new).should_not be_nil
-      hash.assoc(EqlNotEqual.new).should be_nil
+      expect(hash.assoc(EqualNotEql.new)).not_to be_nil
+      expect(hash.assoc(EqlNotEqual.new)).to be_nil
     end
   end
 
   describe "#rassoc" do
     it "searches for a key/val pair with a given value" do
-      hash.rassoc(1).should == [:c, 1]
-      hash.rassoc(2).should == [:b, 2]
-      hash.rassoc(3).should == [:a, 3]
+      expect(hash.rassoc(1)).to eq([:c, 1])
+      expect(hash.rassoc(2)).to eq([:b, 2])
+      expect(hash.rassoc(3)).to eq([:a, 3])
     end
 
     it "returns nil if a matching value is not found" do
-      hash.rassoc(0).should be_nil
-      hash.rassoc(4).should be_nil
-      hash.rassoc(nil).should be_nil
+      expect(hash.rassoc(0)).to be_nil
+      expect(hash.rassoc(4)).to be_nil
+      expect(hash.rassoc(nil)).to be_nil
     end
 
     it "returns nil even if there is a default" do
-      H.new(a: 1, b: 2) { fail }.rassoc(3).should be_nil
+      expect(H.new(a: 1, b: 2) { fail }.rassoc(3)).to be_nil
     end
 
     it "uses #== to compare values with provided object" do
-      hash.rassoc(EqualNotEql.new).should_not be_nil
-      hash.rassoc(EqlNotEqual.new).should be_nil
+      expect(hash.rassoc(EqualNotEql.new)).not_to be_nil
+      expect(hash.rassoc(EqlNotEqual.new)).to be_nil
     end
   end
 end

--- a/spec/lib/hamster/hash/clear_spec.rb
+++ b/spec/lib/hamster/hash/clear_spec.rb
@@ -14,29 +14,29 @@ describe Hamster::Hash do
 
         it "preserves the original" do
           result
-          original.should eql(H[*values])
+          expect(original).to eql(H[*values])
         end
 
         it "returns an empty hash" do
-          result.should equal(H.empty)
-          result.should be_empty
+          expect(result).to equal(H.empty)
+          expect(result).to be_empty
         end
       end
     end
 
     it "maintains the default Proc, if there is one" do
       hash = H.new(a: 1) { 1 }
-      hash.clear[:b].should == 1
-      hash.clear[:c].should == 1
-      hash.clear.default_proc.should_not be_nil
+      expect(hash.clear[:b]).to eq(1)
+      expect(hash.clear[:c]).to eq(1)
+      expect(hash.clear.default_proc).not_to be_nil
     end
 
     context "on a subclass" do
       it "returns an empty instance of the subclass" do
         subclass = Class.new(Hamster::Hash)
         instance = subclass.new(a: 1, b: 2)
-        instance.clear.class.should be(subclass)
-        instance.clear.should be_empty
+        expect(instance.clear.class).to be(subclass)
+        expect(instance.clear).to be_empty
       end
     end
   end

--- a/spec/lib/hamster/hash/construction_spec.rb
+++ b/spec/lib/hamster/hash/construction_spec.rb
@@ -5,8 +5,8 @@ describe Hamster::Hash do
   describe ".hash" do
     context "with nothing" do
       it "returns the canonical empty hash" do
-        H.empty.should be_empty
-        H.empty.should equal(Hamster::EmptyHash)
+        expect(H.empty).to be_empty
+        expect(H.empty).to equal(Hamster::EmptyHash)
       end
     end
 
@@ -14,8 +14,8 @@ describe Hamster::Hash do
       let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 
       it "is equivalent to repeatedly using #put" do
-        hash.should eql(H.empty.put("A", "aye").put("B", "bee").put("C", "see"))
-        hash.size.should == 3
+        expect(hash).to eql(H.empty.put("A", "aye").put("B", "bee").put("C", "see"))
+        expect(hash.size).to eq(3)
       end
     end
 
@@ -23,7 +23,7 @@ describe Hamster::Hash do
       let(:hash) { H[[[:a, 1], [:b, 2]]] }
 
       it "initializes a new Hash" do
-        hash.should eql(H[a: 1, b: 2])
+        expect(hash).to eql(H[a: 1, b: 2])
       end
     end
 
@@ -32,7 +32,7 @@ describe Hamster::Hash do
       let(:other) { H[hash] }
 
       it "initializes an equivalent Hash" do
-        hash.should eql(other)
+        expect(hash).to eql(other)
       end
     end
   end

--- a/spec/lib/hamster/hash/copying_spec.rb
+++ b/spec/lib/hamster/hash/copying_spec.rb
@@ -7,7 +7,7 @@ describe Hamster::Hash do
   [:dup, :clone].each do |method|
     describe "##{method}" do
       it "returns self" do
-        hash.send(method).should equal(hash)
+        expect(hash.send(method)).to equal(hash)
       end
     end
   end

--- a/spec/lib/hamster/hash/default_proc_spec.rb
+++ b/spec/lib/hamster/hash/default_proc_spec.rb
@@ -6,67 +6,67 @@ describe Hamster::Hash do
     let(:hash) { H.new(1 => 2, 2 => 4) { |k| k * 2 } }
 
     it "returns the default block given when the Hash was created" do
-      hash.default_proc.class.should be(Proc)
-      hash.default_proc.call(3).should == 6
+      expect(hash.default_proc.class).to be(Proc)
+      expect(hash.default_proc.call(3)).to eq(6)
     end
 
     it "returns nil if no default block was given" do
-      H.empty.default_proc.should be_nil
+      expect(H.empty.default_proc).to be_nil
     end
 
     context "after a key/val pair are inserted" do
       it "doesn't change" do
         other = hash.put(3, 6)
-        other.default_proc.should be(hash.default_proc)
-        other.default_proc.call(4).should == 8
+        expect(other.default_proc).to be(hash.default_proc)
+        expect(other.default_proc.call(4)).to eq(8)
       end
     end
 
     context "after all key/val pairs are filtered out" do
       it "doesn't change" do
         other = hash.reject { true }
-        other.default_proc.should be(hash.default_proc)
-        other.default_proc.call(4).should == 8
+        expect(other.default_proc).to be(hash.default_proc)
+        expect(other.default_proc.call(4)).to eq(8)
       end
     end
 
     context "after Hash is inverted" do
       it "doesn't change" do
         other = hash.invert
-        other.default_proc.should be(hash.default_proc)
-        other.default_proc.call(4).should == 8
+        expect(other.default_proc).to be(hash.default_proc)
+        expect(other.default_proc.call(4)).to eq(8)
       end
     end
 
     context "when a slice is taken" do
       it "doesn't change" do
         other = hash.slice(1)
-        other.default_proc.should be(hash.default_proc)
-        other.default_proc.call(5).should == 10
+        expect(other.default_proc).to be(hash.default_proc)
+        expect(other.default_proc.call(5)).to eq(10)
       end
     end
 
     context "when keys are removed with #except" do
       it "doesn't change" do
         other = hash.except(1, 2)
-        other.default_proc.should be(hash.default_proc)
-        other.default_proc.call(5).should == 10
+        expect(other.default_proc).to be(hash.default_proc)
+        expect(other.default_proc.call(5)).to eq(10)
       end
     end
 
     context "when Hash is mapped" do
       it "doesn't change" do
         other = hash.map { |k,v| [k + 10, v] }
-        other.default_proc.should be(hash.default_proc)
-        other.default_proc.call(5).should == 10
+        expect(other.default_proc).to be(hash.default_proc)
+        expect(other.default_proc.call(5)).to eq(10)
       end
     end
 
     context "when another Hash is merged in" do
       it "doesn't change" do
         other = hash.merge(3 => 6, 4 => 8)
-        other.default_proc.should be(hash.default_proc)
-        other.default_proc.call(5).should == 10
+        expect(other.default_proc).to be(hash.default_proc)
+        expect(other.default_proc.call(5)).to eq(10)
       end
     end
   end

--- a/spec/lib/hamster/hash/delete_spec.rb
+++ b/spec/lib/hamster/hash/delete_spec.rb
@@ -9,11 +9,11 @@ describe Hamster::Hash do
       let(:result) { hash.delete("B") }
 
       it "preserves the original" do
-        hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see"])
+        expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see"])
       end
 
       it "returns a copy with the remaining key/value pairs" do
-        result.should eql(H["A" => "aye", "C" => "see"])
+        expect(result).to eql(H["A" => "aye", "C" => "see"])
       end
     end
 
@@ -21,18 +21,18 @@ describe Hamster::Hash do
       let(:result) { hash.delete("D") }
 
       it "preserves the original values" do
-        hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see"])
+        expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see"])
       end
 
       it "returns self" do
-        result.should equal(hash)
+        expect(result).to equal(hash)
       end
     end
 
     context "when removing the last key" do
       context "from a Hash with no default block" do
         it "returns the canonical empty Hash" do
-          hash.delete('A').delete('B').delete('C').should be(Hamster::EmptyHash)
+          expect(hash.delete('A').delete('B').delete('C')).to be(Hamster::EmptyHash)
         end
       end
     end

--- a/spec/lib/hamster/hash/each_spec.rb
+++ b/spec/lib/hamster/hash/each_spec.rb
@@ -8,39 +8,39 @@ describe Hamster::Hash do
     describe "##{method}" do
       context "with a block (internal iteration)" do
         it "returns self" do
-          hash.send(method) {}.should be(hash)
+          expect(hash.send(method) {}).to be(hash)
         end
 
         it "yields all key/value pairs" do
           actual_pairs = {}
           hash.send(method) { |key, value| actual_pairs[key] = value }
-          actual_pairs.should == { "A" => "aye", "B" => "bee", "C" => "see" }
+          expect(actual_pairs).to eq({ "A" => "aye", "B" => "bee", "C" => "see" })
         end
 
         it "yields key/value pairs in the same order as #each_key and #each_value" do
-          hash.each.to_a.should eql(hash.each_key.zip(hash.each_value))
+          expect(hash.each.to_a).to eql(hash.each_key.zip(hash.each_value))
         end
 
         it "yields both of a pair of colliding keys" do
           yielded = []
           hash = H[DeterministicHash.new('a', 1) => 1, DeterministicHash.new('b', 1) => 1]
           hash.each { |k,v| yielded << k }
-          yielded.size.should == 2
-          yielded.map { |x| x.value }.sort.should == ['a', 'b']
+          expect(yielded.size).to eq(2)
+          expect(yielded.map { |x| x.value }.sort).to eq(['a', 'b'])
         end
 
         it "yields only the key to a block expecting |key,|" do
           keys = []
           hash.each { |key,| keys << key }
-          keys.sort.should == ["A", "B", "C"]
+          expect(keys.sort).to eq(["A", "B", "C"])
         end
       end
 
       context "with no block" do
         it "returns an Enumerator" do
           @result = hash.send(method)
-          @result.class.should be(Enumerator)
-          @result.to_a.should == hash.to_a
+          expect(@result.class).to be(Enumerator)
+          expect(@result.to_a).to eq(hash.to_a)
         end
       end
     end
@@ -50,13 +50,13 @@ describe Hamster::Hash do
     it "yields all keys" do
       keys = []
       hash.each_key { |k| keys << k }
-      keys.sort.should == ['A', 'B', 'C']
+      expect(keys.sort).to eq(['A', 'B', 'C'])
     end
 
     context "with no block" do
       it "returns an Enumerator" do
-        hash.each_key.class.should be(Enumerator)
-        hash.each_key.to_a.sort.should == ['A', 'B', 'C']
+        expect(hash.each_key.class).to be(Enumerator)
+        expect(hash.each_key.to_a.sort).to eq(['A', 'B', 'C'])
       end
     end
   end
@@ -65,13 +65,13 @@ describe Hamster::Hash do
     it "yields all values" do
       values = []
       hash.each_value { |v| values << v }
-      values.sort.should == ['aye', 'bee', 'see']
+      expect(values.sort).to eq(['aye', 'bee', 'see'])
     end
 
     context "with no block" do
       it "returns an Enumerator" do
-        hash.each_value.class.should be(Enumerator)
-        hash.each_value.to_a.sort.should == ['aye', 'bee', 'see']
+        expect(hash.each_value.class).to be(Enumerator)
+        expect(hash.each_value.to_a.sort).to eq(['aye', 'bee', 'see'])
       end
     end
   end

--- a/spec/lib/hamster/hash/each_with_index_spec.rb
+++ b/spec/lib/hamster/hash/each_with_index_spec.rb
@@ -7,23 +7,23 @@ describe Hamster::Hash do
 
     describe "with a block (internal iteration)" do
       it "returns self" do
-        hash.each_with_index {}.should be(hash)
+        expect(hash.each_with_index {}).to be(hash)
       end
 
       it "yields all key/value pairs with numeric indexes" do
         actual_pairs = {}
         indexes = []
         hash.each_with_index { |(key, value), index| actual_pairs[key] = value; indexes << index }
-        actual_pairs.should == { "A" => "aye", "B" => "bee", "C" => "see" }
-        indexes.sort.should == [0, 1, 2]
+        expect(actual_pairs).to eq({ "A" => "aye", "B" => "bee", "C" => "see" })
+        expect(indexes.sort).to eq([0, 1, 2])
       end
     end
 
     describe "with no block" do
       it "returns an Enumerator" do
-        hash.each_with_index.should be_kind_of(Enumerator)
-        hash.each_with_index.to_a.map(&:first).sort.should eql([["A", "aye"], ["B", "bee"], ["C", "see"]])
-        hash.each_with_index.to_a.map(&:last).should eql([0,1,2])
+        expect(hash.each_with_index).to be_kind_of(Enumerator)
+        expect(hash.each_with_index.to_a.map(&:first).sort).to eql([["A", "aye"], ["B", "bee"], ["C", "see"]])
+        expect(hash.each_with_index.to_a.map(&:last)).to eql([0,1,2])
       end
     end
   end

--- a/spec/lib/hamster/hash/empty_spec.rb
+++ b/spec/lib/hamster/hash/empty_spec.rb
@@ -9,26 +9,26 @@ describe Hamster::Hash do
       [["A" => "aye", "B" => "bee", "C" => "see"], false],
     ].each do |pairs, result|
       it "returns #{result} for #{pairs.inspect}" do
-        H[*pairs].empty?.should == result
+        expect(H[*pairs].empty?).to eq(result)
       end
     end
 
     it "returns true for empty hashes which have a default block" do
-      H.new { 'default' }.empty?.should == true
+      expect(H.new { 'default' }.empty?).to eq(true)
     end
   end
 
   describe ".empty" do
     it "returns the canonical empty Hash" do
-      H.empty.should be_empty
-      H.empty.should be(Hamster::EmptyHash)
+      expect(H.empty).to be_empty
+      expect(H.empty).to be(Hamster::EmptyHash)
     end
 
     context "from a subclass" do
       it "returns an empty instance of the subclass" do
         subclass = Class.new(Hamster::Hash)
-        subclass.empty.class.should be subclass
-        subclass.empty.should be_empty
+        expect(subclass.empty.class).to be subclass
+        expect(subclass.empty).to be_empty
       end
 
       it "calls overridden #initialize when creating empty Hash" do
@@ -37,7 +37,7 @@ describe Hamster::Hash do
             @variable = 'value'
           end
         end
-        subclass.empty.instance_variable_get(:@variable).should == 'value'
+        expect(subclass.empty.instance_variable_get(:@variable)).to eq('value')
       end
     end
   end

--- a/spec/lib/hamster/hash/eql_spec.rb
+++ b/spec/lib/hamster/hash/eql_spec.rb
@@ -6,33 +6,33 @@ describe Hamster::Hash do
 
   describe "#eql?" do
     it "returns false when comparing with a standard hash" do
-      hash.eql?("A" => "aye", "B" => "bee", "C" => "see").should == false
+      expect(hash.eql?("A" => "aye", "B" => "bee", "C" => "see")).to eq(false)
     end
 
     it "returns false when comparing with an arbitrary object" do
-      hash.eql?(Object.new).should == false
+      expect(hash.eql?(Object.new)).to eq(false)
     end
 
     it "returns false when comparing with a subclass of Hamster::Hash" do
       subclass = Class.new(Hamster::Hash)
       instance = subclass.new("A" => "aye", "B" => "bee", "C" => "see")
-      hash.eql?(instance).should == false
+      expect(hash.eql?(instance)).to eq(false)
     end
   end
 
   describe "#==" do
     it "returns true when comparing with a standard hash" do
-      (hash == {"A" => "aye", "B" => "bee", "C" => "see"}).should == true
+      expect(hash == {"A" => "aye", "B" => "bee", "C" => "see"}).to eq(true)
     end
 
     it "returns false when comparing with an arbitrary object" do
-      (hash == Object.new).should == false
+      expect(hash == Object.new).to eq(false)
     end
 
     it "returns true when comparing with a subclass of Hamster::Hash" do
       subclass = Class.new(Hamster::Hash)
       instance = subclass.new("A" => "aye", "B" => "bee", "C" => "see")
-      (hash == instance).should == true
+      expect(hash == instance).to eq(true)
     end
   end
 
@@ -51,11 +51,11 @@ describe Hamster::Hash do
       ].each do |a, b, expected|
         describe "returns #{expected.inspect}" do
           it "for #{a.inspect} and #{b.inspect}" do
-            H[a].send(method, H[b]).should == expected
+            expect(H[a].send(method, H[b])).to eq(expected)
           end
 
           it "for #{b.inspect} and #{a.inspect}" do
-            H[b].send(method, H[a]).should == expected
+            expect(H[b].send(method, H[a])).to eq(expected)
           end
         end
       end
@@ -64,7 +64,7 @@ describe Hamster::Hash do
 
   it "returns true on a large hash which is modified and then modified back again" do
     hash = H.new((1..1000).zip(2..1001))
-    hash.put('a', 1).delete('a').should == hash
-    hash.put('b', 2).delete('b').should eql(hash)
+    expect(hash.put('a', 1).delete('a')).to eq(hash)
+    expect(hash.put('b', 2).delete('b')).to eql(hash)
   end
 end

--- a/spec/lib/hamster/hash/except_spec.rb
+++ b/spec/lib/hamster/hash/except_spec.rb
@@ -7,23 +7,23 @@ describe Hamster::Hash do
 
     context "with only keys that the Hash has" do
       it "returns a Hash without those values" do
-        hash.except("B", nil).should eql(H["A" => "aye", "C" => "see"])
+        expect(hash.except("B", nil)).to eql(H["A" => "aye", "C" => "see"])
       end
 
       it "doesn't change the original Hash" do
         hash.except("B", nil)
-        hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see", nil => "NIL"])
+        expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see", nil => "NIL"])
       end
     end
 
     context "with keys that the Hash doesn't have" do
       it "returns a Hash without the values that it had keys for" do
-        hash.except("B", "A", 3).should eql(H["C" => "see", nil => "NIL"])
+        expect(hash.except("B", "A", 3)).to eql(H["C" => "see", nil => "NIL"])
       end
 
       it "doesn't change the original Hash" do
         hash.except("B", "A", 3)
-        hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see", nil => "NIL"])
+        expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see", nil => "NIL"])
       end
     end
 
@@ -33,11 +33,11 @@ describe Hamster::Hash do
       100.times do
         to_remove = rand(100).times.collect { keys.sample }
         result    = original.except(*to_remove)
-        result.size.should == original.size - to_remove.uniq.size
-        to_remove.each { |key| result.key?(key).should == false }
-        (keys.sample(100) - to_remove).each { |key| result.key?(key).should == true }
+        expect(result.size).to eq(original.size - to_remove.uniq.size)
+        to_remove.each { |key| expect(result.key?(key)).to eq(false) }
+        (keys.sample(100) - to_remove).each { |key| expect(result.key?(key)).to eq(true) }
       end
-      original.should eql(H.new(keys.zip(2..1001))) # shouldn't have changed
+      expect(original).to eql(H.new(keys.zip(2..1001))) # shouldn't have changed
     end
   end
 end

--- a/spec/lib/hamster/hash/fetch_spec.rb
+++ b/spec/lib/hamster/hash/fetch_spec.rb
@@ -6,13 +6,13 @@ describe Hamster::Hash do
     context "with no default provided" do
       context "when the key exists" do
         it "returns the value associated with the key" do
-          H["A" => "aye"].fetch("A").should == "aye"
+          expect(H["A" => "aye"].fetch("A")).to eq("aye")
         end
       end
 
       context "when the key does not exist" do
         it "raises a KeyError" do
-          -> { H["A" => "aye"].fetch("B") }.should raise_error(KeyError)
+          expect { H["A" => "aye"].fetch("B") }.to raise_error(KeyError)
         end
       end
     end
@@ -20,13 +20,13 @@ describe Hamster::Hash do
     context "with a default value" do
       context "when the key exists" do
         it "returns the value associated with the key" do
-          H["A" => "aye"].fetch("A", "default").should == "aye"
+          expect(H["A" => "aye"].fetch("A", "default")).to eq("aye")
         end
       end
 
       context "when the key does not exist" do
         it "returns the default value" do
-          H["A" => "aye"].fetch("B", "default").should == "default"
+          expect(H["A" => "aye"].fetch("B", "default")).to eq("default")
         end
       end
     end
@@ -34,25 +34,25 @@ describe Hamster::Hash do
     context "with a default block" do
       context "when the key exists" do
         it "returns the value associated with the key" do
-          H["A" => "aye"].fetch("A") { "default".upcase }.should == "aye"
+          expect(H["A" => "aye"].fetch("A") { "default".upcase }).to eq("aye")
         end
       end
 
       context "when the key does not exist" do
         it "invokes the default block with the missing key as paramter" do
-          H["A" => "aye"].fetch("B") { |key| key.should == "B" }
-          H["A" => "aye"].fetch("B") { "default".upcase }.should == "DEFAULT"
+          H["A" => "aye"].fetch("B") { |key| expect(key).to eq("B") }
+          expect(H["A" => "aye"].fetch("B") { "default".upcase }).to eq("DEFAULT")
         end
       end
     end
 
     it "gives precedence to default block over default argument if passed both" do
-      H["A" => "aye"].fetch("B", 'one') { 'two' }.should == 'two'
+      expect(H["A" => "aye"].fetch("B", 'one') { 'two' }).to eq('two')
     end
 
     it "raises an ArgumentError when not passed one or 2 arguments" do
-      -> { H.empty.fetch }.should raise_error(ArgumentError)
-      -> { H.empty.fetch(1, 2, 3) }.should raise_error(ArgumentError)
+      expect { H.empty.fetch }.to raise_error(ArgumentError)
+      expect { H.empty.fetch(1, 2, 3) }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/lib/hamster/hash/fetch_values_spec.rb
+++ b/spec/lib/hamster/hash/fetch_values_spec.rb
@@ -6,16 +6,16 @@ describe Hamster::Hash do
     context "when the all the requests keys exist" do
       it "returns a vector of values for the given keys" do
         h = H[:a => 9, :b => 'a', :c => -10, :d => nil]
-        h.fetch_values.should be_kind_of(Hamster::Vector)
-        h.fetch_values.should eql(V.empty)
-        h.fetch_values(:a, :d, :b).should be_kind_of(Hamster::Vector)
-        h.fetch_values(:a, :d, :b).should eql(V[9, nil, 'a'])
+        expect(h.fetch_values).to be_kind_of(Hamster::Vector)
+        expect(h.fetch_values).to eql(V.empty)
+        expect(h.fetch_values(:a, :d, :b)).to be_kind_of(Hamster::Vector)
+        expect(h.fetch_values(:a, :d, :b)).to eql(V[9, nil, 'a'])
       end
     end
 
     context "when the key does not exist" do
       it "raises a KeyError" do
-        -> { H["A" => "aye", "C" => "Cee"].fetch_values("A", "B") }.should raise_error(KeyError)
+        expect { H["A" => "aye", "C" => "Cee"].fetch_values("A", "B") }.to raise_error(KeyError)
       end
     end
   end

--- a/spec/lib/hamster/hash/find_spec.rb
+++ b/spec/lib/hamster/hash/find_spec.rb
@@ -20,15 +20,15 @@ describe Hamster::Hash do
 
           describe "with a block" do
             it "returns #{expected.inspect}" do
-              hash.send(method) { |k, v| k == key }.should == expected
+              expect(hash.send(method) { |k, v| k == key }).to eq(expected)
             end
           end
 
           describe "without a block" do
             it "returns an Enumerator" do
               result = hash.send(method)
-              result.class.should be(Enumerator)
-              result.each { |k,v| k == key }.should == expected
+              expect(result.class).to be(Enumerator)
+              expect(result.each { |k,v| k == key }).to eq(expected)
             end
           end
         end
@@ -37,7 +37,7 @@ describe Hamster::Hash do
       it "stops iterating when the block returns true" do
         yielded = []
         H[a: 1, b: 2].find { |k,v| yielded << k; true }
-        yielded.size.should == 1
+        expect(yielded.size).to eq(1)
       end
     end
   end

--- a/spec/lib/hamster/hash/flat_map_spec.rb
+++ b/spec/lib/hamster/hash/flat_map_spec.rb
@@ -8,29 +8,29 @@ describe Hamster::Hash do
     it "yields each key/val pair" do
       passed = []
       hash.flat_map { |pair| passed << pair }
-      passed.sort.should == [['A', 'aye'], ['B', 'bee'], ['C', 'see']]
+      expect(passed.sort).to eq([['A', 'aye'], ['B', 'bee'], ['C', 'see']])
     end
 
     it "returns the concatenation of block return values" do
-      hash.flat_map { |k,v| [k,v] }.sort.should == ['A', 'B', 'C', 'aye', 'bee', 'see']
-      hash.flat_map { |k,v| L[k,v] }.sort.should == ['A', 'B', 'C', 'aye', 'bee', 'see']
-      hash.flat_map { |k,v| V[k,v] }.sort.should == ['A', 'B', 'C', 'aye', 'bee', 'see']
+      expect(hash.flat_map { |k,v| [k,v] }.sort).to eq(['A', 'B', 'C', 'aye', 'bee', 'see'])
+      expect(hash.flat_map { |k,v| L[k,v] }.sort).to eq(['A', 'B', 'C', 'aye', 'bee', 'see'])
+      expect(hash.flat_map { |k,v| V[k,v] }.sort).to eq(['A', 'B', 'C', 'aye', 'bee', 'see'])
     end
 
     it "doesn't change the receiver" do
       hash.flat_map { |k,v| [k,v] }
-      hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see"])
+      expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see"])
     end
 
     context "with no block" do
       it "returns an Enumerator" do
-        hash.flat_map.class.should be(Enumerator)
-        hash.flat_map.each { |k,v| [k] }.sort.should == ['A', 'B', 'C']
+        expect(hash.flat_map.class).to be(Enumerator)
+        expect(hash.flat_map.each { |k,v| [k] }.sort).to eq(['A', 'B', 'C'])
       end
     end
 
     it "returns an empty array if only empty arrays are returned by block" do
-      hash.flat_map { [] }.should eql([])
+      expect(hash.flat_map { [] }).to eql([])
     end
   end
 end

--- a/spec/lib/hamster/hash/flatten_spec.rb
+++ b/spec/lib/hamster/hash/flatten_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::Hash do
     context "with flatten depth of zero" do
       it "returns a vector of keys/value" do
         hash = H[a: 1, b: 2]
-        hash.flatten(0).sort.should eql(V[[:a, 1], [:b, 2]])
+        expect(hash.flatten(0).sort).to eql(V[[:a, 1], [:b, 2]])
       end
     end
 
@@ -19,80 +19,80 @@ describe Hamster::Hash do
          [:b, 2, :c, 3, :a, 1],
          [:c, 3, :a, 1, :b, 2],
          [:c, 3, :b, 2, :a, 1]]
-        possibilities.include?(hash.flatten).should == true
-        possibilities.include?(hash.flatten(1)).should == true
-        possibilities.include?(hash.flatten(2)).should == true
-        hash.flatten(2).class.should be(Hamster::Vector)
-        possibilities.include?(hash.flatten(10)).should == true
+        expect(possibilities.include?(hash.flatten)).to eq(true)
+        expect(possibilities.include?(hash.flatten(1))).to eq(true)
+        expect(possibilities.include?(hash.flatten(2))).to eq(true)
+        expect(hash.flatten(2).class).to be(Hamster::Vector)
+        expect(possibilities.include?(hash.flatten(10))).to eq(true)
       end
 
       it "doesn't modify the receiver" do
         hash = H[a: 1, b: 2, c: 3]
         hash.flatten(1)
         hash.flatten(2)
-        hash.should eql(H[a: 1, b: 2, c: 3])
+        expect(hash).to eql(H[a: 1, b: 2, c: 3])
       end
     end
 
     context "on an empty Hash" do
       it "returns an empty Vector" do
-        H.empty.flatten.should eql(V.empty)
+        expect(H.empty.flatten).to eql(V.empty)
       end
     end
 
     context "with array keys" do
       it "flattens array keys into returned vector if flatten depth is sufficient" do
         hash = H[[1, 2] => 3, [4, 5] => 6]
-        [[[1, 2], 3, [4, 5], 6], [[4, 5], 6, [1, 2], 3]].include?(hash.flatten(1)).should == true
-        [[[1, 2], 3, [4, 5], 6], [[4, 5], 6, [1, 2], 3]].include?(hash.flatten).should == true
-        hash.flatten(1).class.should be(Hamster::Vector)
-        [[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(2)).should == true
-        [[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(3)).should == true
+        expect([[[1, 2], 3, [4, 5], 6], [[4, 5], 6, [1, 2], 3]].include?(hash.flatten(1))).to eq(true)
+        expect([[[1, 2], 3, [4, 5], 6], [[4, 5], 6, [1, 2], 3]].include?(hash.flatten)).to eq(true)
+        expect(hash.flatten(1).class).to be(Hamster::Vector)
+        expect([[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(2))).to eq(true)
+        expect([[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(3))).to eq(true)
       end
 
       it "doesn't modify the receiver (or its contents)" do
         hash = H[[1, 2] => 3, [4, 5] => 6]
         hash.flatten(1)
         hash.flatten(2)
-        hash.should eql(H[[1, 2] => 3, [4, 5] => 6])
+        expect(hash).to eql(H[[1, 2] => 3, [4, 5] => 6])
       end
     end
 
     context "with array values" do
       it "flattens array values into returned vector if flatten depth is sufficient" do
         hash = H[1 => [2, 3], 4 => [5, 6]]
-        [[1, [2, 3], 4, [5, 6]], [4, [5, 6], 1, [2, 3]]].include?(hash.flatten(1)).should == true
-        [[1, [2, 3], 4, [5, 6]], [4, [5, 6], 1, [2, 3]]].include?(hash.flatten).should == true
-        [[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(2)).should == true
-        [[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(3)).should == true
-        hash.flatten(3).class.should be(Hamster::Vector)
+        expect([[1, [2, 3], 4, [5, 6]], [4, [5, 6], 1, [2, 3]]].include?(hash.flatten(1))).to eq(true)
+        expect([[1, [2, 3], 4, [5, 6]], [4, [5, 6], 1, [2, 3]]].include?(hash.flatten)).to eq(true)
+        expect([[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(2))).to eq(true)
+        expect([[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(3))).to eq(true)
+        expect(hash.flatten(3).class).to be(Hamster::Vector)
       end
 
       it "doesn't modify the receiver (or its contents)" do
         hash = H[1 => [2, 3], 4 => [5, 6]]
         hash.flatten(1)
         hash.flatten(2)
-        hash.should eql(H[1 => [2, 3], 4 => [5, 6]])
+        expect(hash).to eql(H[1 => [2, 3], 4 => [5, 6]])
       end
     end
 
     context "with vector keys" do
       it "flattens vector keys into returned vector if flatten depth is sufficient" do
         hash = H[V[1, 2] => 3, V[4, 5] => 6]
-        [[V[1, 2], 3, V[4, 5], 6], [V[4, 5], 6, V[1, 2], 3]].include?(hash.flatten).should == true
-        [[V[1, 2], 3, V[4, 5], 6], [V[4, 5], 6, V[1, 2], 3]].include?(hash.flatten(1)).should == true
-        [[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(2)).should == true
-        [[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(3)).should == true
+        expect([[V[1, 2], 3, V[4, 5], 6], [V[4, 5], 6, V[1, 2], 3]].include?(hash.flatten)).to eq(true)
+        expect([[V[1, 2], 3, V[4, 5], 6], [V[4, 5], 6, V[1, 2], 3]].include?(hash.flatten(1))).to eq(true)
+        expect([[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(2))).to eq(true)
+        expect([[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(3))).to eq(true)
       end
     end
 
     context "with vector values" do
       it "flattens vector values into returned vector if flatten depth is sufficient" do
         hash = H[1 => V[2, 3], 4 => V[5, 6]]
-        [[1, V[2, 3], 4, V[5, 6]], [4, V[5, 6], 1, V[2, 3]]].include?(hash.flatten(1)).should == true
-        [[1, V[2, 3], 4, V[5, 6]], [4, V[5, 6], 1, V[2, 3]]].include?(hash.flatten).should == true
-        [[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(2)).should == true
-        [[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(3)).should == true
+        expect([[1, V[2, 3], 4, V[5, 6]], [4, V[5, 6], 1, V[2, 3]]].include?(hash.flatten(1))).to eq(true)
+        expect([[1, V[2, 3], 4, V[5, 6]], [4, V[5, 6], 1, V[2, 3]]].include?(hash.flatten)).to eq(true)
+        expect([[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(2))).to eq(true)
+        expect([[1, 2, 3, 4, 5, 6], [4, 5, 6, 1, 2, 3]].include?(hash.flatten(3))).to eq(true)
       end
     end
   end

--- a/spec/lib/hamster/hash/get_spec.rb
+++ b/spec/lib/hamster/hash/get_spec.rb
@@ -9,7 +9,7 @@ describe Hamster::Hash do
 
         context "when the key exists" do
           it "returns the value associated with the key" do
-            hash.send(method, "A").should == "aye"
+            expect(hash.send(method, "A")).to eq("aye")
           end
 
           it "does not call the default block even if the key is 'nil'" do
@@ -26,7 +26,7 @@ describe Hamster::Hash do
           end
 
           it "returns the value from the default block" do
-            hash.send(method, "B").should == "bee"
+            expect(hash.send(method, "B")).to eq("bee")
           end
         end
       end
@@ -41,39 +41,39 @@ describe Hamster::Hash do
           [nil, "NIL"]
         ].each do |key, value|
           it "returns the value (#{value.inspect}) for an existing key (#{key.inspect})" do
-            hash.send(method, key).should == value
+            expect(hash.send(method, key)).to eq(value)
           end
         end
 
         it "returns nil for a non-existing key" do
-          hash.send(method, "D").should be_nil
+          expect(hash.send(method, "D")).to be_nil
         end
       end
 
       it "uses #hash to look up keys" do
         x = double('0')
-        x.should_receive(:hash).and_return(0)
-        H[foo: :bar].send(method, x).should be_nil
+        expect(x).to receive(:hash).and_return(0)
+        expect(H[foo: :bar].send(method, x)).to be_nil
       end
 
       it "uses #eql? to compare keys with the same hash code" do
         x = double('x', hash: 42)
-        x.should_not_receive(:eql?)
+        expect(x).not_to receive(:eql?)
 
         y = double('y', hash: 42)
-        y.should_receive(:eql?).and_return(true)
+        expect(y).to receive(:eql?).and_return(true)
 
-        H[y => 1][x].should == 1
+        expect(H[y => 1][x]).to eq(1)
       end
 
       it "does not use #eql? to compare keys with different hash codes" do
         x = double('x', hash: 0)
-        x.should_not_receive(:eql?)
+        expect(x).not_to receive(:eql?)
 
         y = double('y', hash: 1)
-        y.should_not_receive(:eql?)
+        expect(y).not_to receive(:eql?)
 
-        H[y => 1][x].should be_nil
+        expect(H[y => 1][x]).to be_nil
       end
     end
   end

--- a/spec/lib/hamster/hash/has_key_spec.rb
+++ b/spec/lib/hamster/hash/has_key_spec.rb
@@ -8,24 +8,24 @@ describe Hamster::Hash do
 
       ["A", "B", "C", nil, 2.0].each do |key|
         it "returns true for an existing key (#{key.inspect})" do
-          hash.send(method, key).should == true
+          expect(hash.send(method, key)).to eq(true)
         end
       end
 
       it "returns false for a non-existing key" do
-        hash.send(method, "D").should == false
+        expect(hash.send(method, "D")).to eq(false)
       end
 
       it "uses #eql? for equality" do
-        hash.send(method, 2).should == false
+        expect(hash.send(method, 2)).to eq(false)
       end
 
       it "returns true if the key is found and maps to nil" do
-        H["A" => nil].send(method, "A").should == true
+        expect(H["A" => nil].send(method, "A")).to eq(true)
       end
 
       it "returns true if the key is found and maps to false" do
-        H["A" => false].send(method, "A").should == true
+        expect(H["A" => false].send(method, "A")).to eq(true)
       end
     end
   end

--- a/spec/lib/hamster/hash/has_value_spec.rb
+++ b/spec/lib/hamster/hash/has_value_spec.rb
@@ -7,21 +7,21 @@ describe Hamster::Hash do
   [:value?, :has_value?].each do |method|
     describe "##{method}" do
       it "returns true if any key/val pair in Hash has the same value" do
-        hash.send(method, 'strawberry').should == true
+        expect(hash.send(method, 'strawberry')).to eq(true)
       end
 
       it "returns false if no key/val pair in Hash has the same value" do
-        hash.send(method, 'marmalade').should == false
+        expect(hash.send(method, 'marmalade')).to eq(false)
       end
 
       it "uses #== to check equality" do
-        H[a: EqualNotEql.new].send(method, EqualNotEql.new).should == true
-        H[a: EqlNotEqual.new].send(method, EqlNotEqual.new).should == false
+        expect(H[a: EqualNotEql.new].send(method, EqualNotEql.new)).to eq(true)
+        expect(H[a: EqlNotEqual.new].send(method, EqlNotEqual.new)).to eq(false)
       end
 
       it "works on a large hash" do
         large = H.new((1..1000).zip(2..1001))
-        [2, 100, 200, 500, 900, 1000, 1001].each { |n| large.value?(n).should == true }
+        [2, 100, 200, 500, 900, 1000, 1001].each { |n| expect(large.value?(n)).to eq(true) }
       end
     end
   end

--- a/spec/lib/hamster/hash/hash_spec.rb
+++ b/spec/lib/hamster/hash/hash_spec.rb
@@ -4,26 +4,26 @@ require "hamster/hash"
 describe Hamster::Hash do
   describe "#hash" do
     it "values are sufficiently distributed" do
-      (1..4000).each_slice(4).map { |ka, va, kb, vb| H[ka => va, kb => vb].hash }.uniq.size.should == 1000
+      expect((1..4000).each_slice(4).map { |ka, va, kb, vb| H[ka => va, kb => vb].hash }.uniq.size).to eq(1000)
     end
 
     it "differs given the same keys and different values" do
-      H["ka" => "va"].hash.should_not == H["ka" => "vb"].hash
+      expect(H["ka" => "va"].hash).not_to eq(H["ka" => "vb"].hash)
     end
 
     it "differs given the same values and different keys" do
-      H["ka" => "va"].hash.should_not == H["kb" => "va"].hash
+      expect(H["ka" => "va"].hash).not_to eq(H["kb" => "va"].hash)
     end
 
     it "generates the same hash value for a hash regardless of the order things were added to it" do
       key1 = DeterministicHash.new('abc', 1)
       key2 = DeterministicHash.new('xyz', 1)
-      H.empty.put(key1, nil).put(key2, nil).hash.should == H.empty.put(key2, nil).put(key1, nil).hash
+      expect(H.empty.put(key1, nil).put(key2, nil).hash).to eq(H.empty.put(key2, nil).put(key1, nil).hash)
     end
 
     describe "on an empty hash" do
       it "returns 0" do
-        H.empty.hash.should == 0
+        expect(H.empty.hash).to eq(0)
       end
     end
   end

--- a/spec/lib/hamster/hash/immutable_spec.rb
+++ b/spec/lib/hamster/hash/immutable_spec.rb
@@ -4,6 +4,6 @@ require "hamster/hash"
 
 describe Hamster::Hash do
   it "includes Immutable" do
-    Hamster::Hash.should include(Hamster::Immutable)
+    expect(Hamster::Hash).to include(Hamster::Immutable)
   end
 end

--- a/spec/lib/hamster/hash/inspect_spec.rb
+++ b/spec/lib/hamster/hash/inspect_spec.rb
@@ -10,7 +10,7 @@ describe Hamster::Hash do
     ].each do |values, expected|
       describe "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          H[*values].inspect.should == expected
+          expect(H[*values].inspect).to eq(expected)
         end
       end
     end
@@ -23,7 +23,7 @@ describe Hamster::Hash do
       describe "on #{values.inspect}" do
         it "returns a string which can be eval'd to get an equivalent object" do
           original = H.new(values)
-          eval(original.inspect).should eql(original)
+          expect(eval(original.inspect)).to eql(original)
         end
       end
     end

--- a/spec/lib/hamster/hash/invert_spec.rb
+++ b/spec/lib/hamster/hash/invert_spec.rb
@@ -6,25 +6,25 @@ describe Hamster::Hash do
     let(:hash) { H[a: 3, b: 2, c: 1] }
 
     it "uses the existing keys as values and values as keys" do
-      hash.invert.should eql(H[3 => :a, 2 => :b, 1 => :c])
+      expect(hash.invert).to eql(H[3 => :a, 2 => :b, 1 => :c])
     end
 
     it "will select one key/value pair among multiple which have same value" do
-      [H[1 => :a],
+      expect([H[1 => :a],
        H[1 => :b],
-       H[1 => :c]].include?(H[a: 1, b: 1, c: 1].invert).should == true
+       H[1 => :c]].include?(H[a: 1, b: 1, c: 1].invert)).to eq(true)
     end
 
     it "doesn't change the original Hash" do
       hash.invert
-      hash.should eql(H[a: 3, b: 2, c: 1])
+      expect(hash).to eql(H[a: 3, b: 2, c: 1])
     end
 
     context "from a subclass of Hash" do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Hash)
         instance = subclass.new(a: 1, b: 2)
-        instance.invert.class.should be(subclass)
+        expect(instance.invert.class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/hash/key_spec.rb
+++ b/spec/lib/hamster/hash/key_spec.rb
@@ -6,23 +6,23 @@ describe Hamster::Hash do
     let(:hash) { H[a: 1, b: 1, c: 2, d: 3] }
 
     it "returns a key associated with the given value, if there is one" do
-      [:a, :b].include?(hash.key(1)).should == true
-      hash.key(2).should be(:c)
-      hash.key(3).should be(:d)
+      expect([:a, :b].include?(hash.key(1))).to eq(true)
+      expect(hash.key(2)).to be(:c)
+      expect(hash.key(3)).to be(:d)
     end
 
     it "returns nil if there is no key associated with the given value" do
-      hash.key(5).should be_nil
-      hash.key(0).should be_nil
+      expect(hash.key(5)).to be_nil
+      expect(hash.key(0)).to be_nil
     end
 
     it "uses #== to compare values for equality" do
-      hash.key(EqualNotEql.new).should_not be_nil
-      hash.key(EqlNotEqual.new).should be_nil
+      expect(hash.key(EqualNotEql.new)).not_to be_nil
+      expect(hash.key(EqlNotEqual.new)).to be_nil
     end
 
     it "doesn't use default block if value is not found" do
-      H.new(a: 1) { fail }.key(2).should be_nil
+      expect(H.new(a: 1) { fail }.key(2)).to be_nil
     end
   end
 end

--- a/spec/lib/hamster/hash/keys_spec.rb
+++ b/spec/lib/hamster/hash/keys_spec.rb
@@ -7,11 +7,11 @@ describe Hamster::Hash do
     let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 
     it "returns the keys as a set" do
-      hash.keys.should eql(S["A", "B", "C"])
+      expect(hash.keys).to eql(S["A", "B", "C"])
     end
 
     it "returns frozen String keys" do
-      hash.keys.each { |s| s.should be_frozen }
+      hash.keys.each { |s| expect(s).to be_frozen }
     end
   end
 end

--- a/spec/lib/hamster/hash/map_spec.rb
+++ b/spec/lib/hamster/hash/map_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::Hash do
     describe "##{method}" do
       context "when empty" do
         it "returns self" do
-          H.empty.send(method) {}.should equal(H.empty)
+          expect(H.empty.send(method) {}).to equal(H.empty)
         end
       end
 
@@ -18,18 +18,18 @@ describe Hamster::Hash do
 
           it "preserves the original values" do
             mapped
-            hash.should eql(H["A" => "aye", "B"  => "bee", "C" => "see"])
+            expect(hash).to eql(H["A" => "aye", "B"  => "bee", "C" => "see"])
           end
 
           it "returns a new hash with the mapped values" do
-            mapped.should eql(H["a" => "AYE", "b"  => "BEE", "c" => "SEE"])
+            expect(mapped).to eql(H["a" => "AYE", "b"  => "BEE", "c" => "SEE"])
           end
         end
 
         context "with no block" do
           it "returns an Enumerator" do
-            hash.send(method).class.should be(Enumerator)
-            hash.send(method).each { |k,v| [k.downcase, v] }.should == hash.map { |k,v| [k.downcase, v] }
+            expect(hash.send(method).class).to be(Enumerator)
+            expect(hash.send(method).each { |k,v| [k.downcase, v] }).to eq(hash.map { |k,v| [k.downcase, v] })
           end
         end
       end
@@ -38,7 +38,7 @@ describe Hamster::Hash do
         it "returns an instance of the subclass" do
           subclass = Class.new(Hamster::Hash)
           instance = subclass.new('a' => 'aye', 'b' => 'bee')
-          instance.map { |k,v| [k, v.upcase] }.class.should be(subclass)
+          expect(instance.map { |k,v| [k, v.upcase] }.class).to be(subclass)
         end
       end
     end

--- a/spec/lib/hamster/hash/merge_spec.rb
+++ b/spec/lib/hamster/hash/merge_spec.rb
@@ -16,17 +16,17 @@ describe Hamster::Hash do
         let(:result) { hash_a.merge(hash_b) }
 
         it "returns #{expected.inspect} when passed a Hamster::Hash"  do
-          result.should eql(H[expected])
+          expect(result).to eql(H[expected])
         end
 
         it "returns #{expected.inspect} when passed a Ruby Hash" do
-          H[a].merge(::Hash[b]).should eql(H[expected])
+          expect(H[a].merge(::Hash[b])).to eql(H[expected])
         end
 
         it "doesn't change the original Hashes" do
           result
-          hash_a.should eql(H[a])
-          hash_b.should eql(H[b])
+          expect(hash_a).to eql(H[a])
+          expect(hash_b).to eql(H[b])
         end
       end
     end
@@ -34,7 +34,7 @@ describe Hamster::Hash do
     context "when merging with an empty Hash" do
       it "returns self" do
         hash = H[a: 1, b: 2]
-        hash.merge(H.empty).should be(hash)
+        expect(hash.merge(H.empty)).to be(hash)
       end
     end
 
@@ -42,7 +42,7 @@ describe Hamster::Hash do
       it "returns self" do
         big_hash   = H[(1..300).zip(1..300)]
         small_hash = H[(1..200).zip(1..200)]
-        big_hash.merge(small_hash).should be(big_hash)
+        expect(big_hash.merge(small_hash)).to be(big_hash)
       end
     end
 
@@ -50,7 +50,7 @@ describe Hamster::Hash do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Hash)
         instance = subclass.new(a: 1, b: 2)
-        instance.merge(c: 3, d: 4).class.should be(subclass)
+        expect(instance.merge(c: 3, d: 4).class).to be(subclass)
       end
     end
 
@@ -58,17 +58,17 @@ describe Hamster::Hash do
       h1 = H[a: 2, b: 1, d: 5]
       h2 = H[a: -2, b: 4, c: -3]
       r = h1.merge(h2) { |k,x,y| nil }
-      r.should eql(H[a: nil, b: nil, c: -3, d: 5])
+      expect(r).to eql(H[a: nil, b: nil, c: -3, d: 5])
 
       r = h1.merge(h2) { |k,x,y| "#{k}:#{x+2*y}" }
-      r.should eql(H[a: "a:-2", b: "b:9", c: -3, d: 5])
+      expect(r).to eql(H[a: "a:-2", b: "b:9", c: -3, d: 5])
 
-      lambda {
+      expect {
         h1.merge(h2) { |k, x, y| raise(IndexError) }
-      }.should raise_error(IndexError)
+      }.to raise_error(IndexError)
 
       r = h1.merge(h1) { |k,x,y| :x }
-      r.should eql(H[a: :x, b: :x, d: :x])
+      expect(r).to eql(H[a: :x, b: :x, d: :x])
     end
 
     it "yields key/value pairs in the same order as #each" do
@@ -77,7 +77,7 @@ describe Hamster::Hash do
       merge_pairs = []
       hash.each { |k, v| each_pairs << [k, v] }
       hash.merge(hash) { |k, v1, v2| merge_pairs << [k, v1] }
-      each_pairs.should == merge_pairs
+      expect(each_pairs).to eq(merge_pairs)
     end
   end
 end

--- a/spec/lib/hamster/hash/min_max_spec.rb
+++ b/spec/lib/hamster/hash/min_max_spec.rb
@@ -6,41 +6,41 @@ describe Hamster::Hash do
 
   describe "#min" do
     it "returns the smallest key/val pair" do
-      hash.min.should == ["a", 3]
+      expect(hash.min).to eq(["a", 3])
     end
   end
 
   describe "#max" do
     it "returns the largest key/val pair" do
-      hash.max.should == ["c", 1]
+      expect(hash.max).to eq(["c", 1])
     end
   end
 
   describe "#min_by" do
     it "returns the smallest key/val pair (after passing it through a key function)" do
-      hash.min_by { |k,v| v }.should == ["c", 1]
+      expect(hash.min_by { |k,v| v }).to eq(["c", 1])
     end
 
     it "returns the first key/val pair yielded by #each in case of a tie" do
-      hash.min_by { 0 }.should == hash.each.first
+      expect(hash.min_by { 0 }).to eq(hash.each.first)
     end
 
     it "returns nil if the hash is empty" do
-      H.empty.min_by { |k,v| v }.should be_nil
+      expect(H.empty.min_by { |k,v| v }).to be_nil
     end
   end
 
   describe "#max_by" do
     it "returns the largest key/val pair (after passing it through a key function)" do
-      hash.max_by { |k,v| v }.should == ["a", 3]
+      expect(hash.max_by { |k,v| v }).to eq(["a", 3])
     end
 
     it "returns the first key/val pair yielded by #each in case of a tie" do
-      hash.max_by { 0 }.should == hash.each.first
+      expect(hash.max_by { 0 }).to eq(hash.each.first)
     end
 
     it "returns nil if the hash is empty" do
-      H.empty.max_by { |k,v| v }.should be_nil
+      expect(H.empty.max_by { |k,v| v }).to be_nil
     end
   end
 end

--- a/spec/lib/hamster/hash/new_spec.rb
+++ b/spec/lib/hamster/hash/new_spec.rb
@@ -10,62 +10,62 @@ describe Hamster::Hash do
         end
       end
 
-      SnazzyHash.new['snazzy?'].should == 'oh yeah'
+      expect(SnazzyHash.new['snazzy?']).to eq('oh yeah')
     end
 
     context "from a subclass" do
       it "returns a frozen instance of the subclass" do
         subclass = Class.new(Hamster::Hash)
         instance = subclass.new("some" => "values")
-        instance.class.should be(subclass)
-        instance.frozen?.should be true
+        expect(instance.class).to be(subclass)
+        expect(instance.frozen?).to be true
       end
     end
 
     it "accepts an array as initializer" do
-      H.new([['a', 'b'], ['c', 'd']]).should eql(H['a' => 'b', 'c' => 'd'])
+      expect(H.new([['a', 'b'], ['c', 'd']])).to eql(H['a' => 'b', 'c' => 'd'])
     end
 
     it "returns a Hash which doesn't change even if initializer is mutated" do
       rbhash = {a: 1, b: 2}
       hash = H.new(rbhash)
       rbhash[:a] = 'BAD'
-      hash.should eql(H[a: 1, b: 2])
+      expect(hash).to eql(H[a: 1, b: 2])
     end
   end
 
   describe ".[]" do
     it "accepts a Ruby Hash as initializer" do
       hash = H[a: 1, b: 2]
-      hash.class.should be(Hamster::Hash)
-      hash.size.should == 2
-      hash.key?(:a).should == true
-      hash.key?(:b).should == true
+      expect(hash.class).to be(Hamster::Hash)
+      expect(hash.size).to eq(2)
+      expect(hash.key?(:a)).to eq(true)
+      expect(hash.key?(:b)).to eq(true)
     end
 
     it "accepts a Hamster::Hash as initializer" do
       hash = H[H.new(a: 1, b: 2)]
-      hash.class.should be(Hamster::Hash)
-      hash.size.should == 2
-      hash.key?(:a).should == true
-      hash.key?(:b).should == true
+      expect(hash.class).to be(Hamster::Hash)
+      expect(hash.size).to eq(2)
+      expect(hash.key?(:a)).to eq(true)
+      expect(hash.key?(:b)).to eq(true)
     end
 
     it "accepts an array as initializer" do
       hash = H[[[:a, 1], [:b, 2]]]
-      hash.class.should be(Hamster::Hash)
-      hash.size.should == 2
-      hash.key?(:a).should == true
-      hash.key?(:b).should == true
+      expect(hash.class).to be(Hamster::Hash)
+      expect(hash.size).to eq(2)
+      expect(hash.key?(:a)).to eq(true)
+      expect(hash.key?(:b)).to eq(true)
     end
 
     it "can be used with a subclass of Hamster::Hash" do
       subclass = Class.new(Hamster::Hash)
       instance = subclass[a: 1, b: 2]
-      instance.class.should be(subclass)
-      instance.size.should == 2
-      instance.key?(:a).should == true
-      instance.key?(:b).should == true
+      expect(instance.class).to be(subclass)
+      expect(instance.size).to eq(2)
+      expect(instance.key?(:a)).to eq(true)
+      expect(instance.key?(:b)).to eq(true)
     end
   end
 end

--- a/spec/lib/hamster/hash/none_spec.rb
+++ b/spec/lib/hamster/hash/none_spec.rb
@@ -5,11 +5,11 @@ describe Hamster::Hash do
   describe "#none?" do
     context "when empty" do
       it "with a block returns true" do
-        H.empty.none? {}.should == true
+        expect(H.empty.none? {}).to eq(true)
       end
 
       it "with no block returns true" do
-        H.empty.none?.should == true
+        expect(H.empty.none?).to eq(true)
       end
     end
 
@@ -24,24 +24,24 @@ describe Hamster::Hash do
           [nil, "NIL"],
         ].each do |pair|
           it "returns false if the block ever returns true (#{pair.inspect})" do
-            hash.none? { |key, value| key == pair.first && value == pair.last }.should == false
+            expect(hash.none? { |key, value| key == pair.first && value == pair.last }).to eq(false)
           end
 
           it "returns true if the block always returns false" do
-            hash.none? { |key, value| key == "D" && value == "dee" }.should == true
+            expect(hash.none? { |key, value| key == "D" && value == "dee" }).to eq(true)
           end
 
           it "stops iterating as soon as the block returns true" do
             yielded = []
             hash.none? { |k,v| yielded << k; true }
-            yielded.size.should == 1
+            expect(yielded.size).to eq(1)
           end
         end
       end
 
       context "with no block" do
         it "returns false" do
-          hash.none?.should == false
+          expect(hash.none?).to eq(false)
         end
       end
     end

--- a/spec/lib/hamster/hash/partition_spec.rb
+++ b/spec/lib/hamster/hash/partition_spec.rb
@@ -7,21 +7,21 @@ describe Hamster::Hash do
 
   describe "#partition" do
     it "returns a pair of Hamster::Hashes" do
-      partition.each { |h| h.class.should be(Hamster::Hash) }
-      partition.should be_frozen
+      partition.each { |h| expect(h.class).to be(Hamster::Hash) }
+      expect(partition).to be_frozen
     end
 
     it "returns key/val pairs for which predicate is true in first Hash" do
-      partition[0].should == {"b" => 2, "d" => 4}
+      expect(partition[0]).to eq({"b" => 2, "d" => 4})
     end
 
     it "returns key/val pairs for which predicate is false in second Hash" do
-      partition[1].should == {"a" => 1, "c" => 3}
+      expect(partition[1]).to eq({"a" => 1, "c" => 3})
     end
 
     it "doesn't modify the original Hash" do
       partition
-      hash.should eql(H["a" => 1, "b" => 2, "c" => 3, "d" => 4])
+      expect(hash).to eql(H["a" => 1, "b" => 2, "c" => 3, "d" => 4])
     end
 
     context "from a subclass" do
@@ -29,7 +29,7 @@ describe Hamster::Hash do
         subclass  = Class.new(Hamster::Hash)
         instance  = subclass.new("a" => 1, "b" => 2, "c" => 3, "d" => 4)
         partition = instance.partition { |k,v| v % 2 == 0 }
-        partition.each { |h| h.class.should be(subclass) }
+        partition.each { |h| expect(h.class).to be(subclass) }
       end
     end
   end

--- a/spec/lib/hamster/hash/pretty_print_spec.rb
+++ b/spec/lib/hamster/hash/pretty_print_spec.rb
@@ -11,25 +11,25 @@ describe Hamster::Hash do
 
     it "prints the whole Hash on one line if it fits" do
       PP.pp(hash, stringio, 80)
-      stringio.string.chomp.should == 'Hamster::Hash[1 => "tin", 2 => "earwax", 3 => "neanderthal"]'
+      expect(stringio.string.chomp).to eq('Hamster::Hash[1 => "tin", 2 => "earwax", 3 => "neanderthal"]')
     end
 
     it "prints each key/val pair on its own line, if not" do
       PP.pp(hash, stringio, 20)
-      stringio.string.chomp.should == 'Hamster::Hash[
+      expect(stringio.string.chomp).to eq('Hamster::Hash[
  1 => "tin",
  2 => "earwax",
- 3 => "neanderthal"]'
+ 3 => "neanderthal"]')
     end
 
     it "prints keys and vals on separate lines, if space is very tight" do
       PP.pp(hash, stringio, 15)
       # the trailing space after "3 =>" below is needed, don't remove it
-      stringio.string.chomp.should == 'Hamster::Hash[
+      expect(stringio.string.chomp).to eq('Hamster::Hash[
  1 => "tin",
  2 => "earwax",
  3 => 
-  "neanderthal"]'
+  "neanderthal"]')
     end
   end
 end

--- a/spec/lib/hamster/hash/put_spec.rb
+++ b/spec/lib/hamster/hash/put_spec.rb
@@ -14,27 +14,27 @@ describe Hamster::Hash do
 
     context "with a block" do
       it "passes the value to the block" do
-        hash.put("A") { |value| value.should == "aye" }
+        hash.put("A") { |value| expect(value).to eq("aye") }
       end
 
       it "replaces the value with the result of the block" do
         result = hash.put("A") { |value| "FLIBBLE" }
-        result.get("A").should == "FLIBBLE"
+        expect(result.get("A")).to eq("FLIBBLE")
       end
 
       it "supports to_proc methods" do
         result = hash.put("A", &:upcase)
-        result.get("A").should == "AYE"
+        expect(result.get("A")).to eq("AYE")
       end
 
       context "if there is no existing association" do
         it "passes nil to the block" do
-          hash.put("D") { |value| value.should be_nil }
+          hash.put("D") { |value| expect(value).to be_nil }
         end
 
         it "stores the result of the block as the new value" do
           result = hash.put("D") { |value| "FLIBBLE" }
-          result.get("D").should == "FLIBBLE"
+          expect(result.get("D")).to eq("FLIBBLE")
         end
       end
     end
@@ -44,11 +44,11 @@ describe Hamster::Hash do
 
       it "preserves the original" do
         result
-        hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see"])
+        expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see"])
       end
 
       it "returns a copy with the superset of key/value pairs" do
-        result.should eql(H["A" => "aye", "B" => "bee", "C" => "see", "D" => "dee"])
+        expect(result).to eql(H["A" => "aye", "B" => "bee", "C" => "see", "D" => "dee"])
       end
     end
 
@@ -57,11 +57,11 @@ describe Hamster::Hash do
 
       it "preserves the original" do
         result
-        hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see"])
+        expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see"])
       end
 
       it "returns a copy with the superset of key/value pairs" do
-        result.should eql(H["A" => "aye", "B" => "bee", "C" => "sea"])
+        expect(result).to eql(H["A" => "aye", "B" => "bee", "C" => "sea"])
       end
     end
 
@@ -70,7 +70,7 @@ describe Hamster::Hash do
       let(:result) { hash.put("X", 1) }
 
       it "returns the original hash unmodified" do
-        result.should be(hash)
+        expect(result).to be(hash)
       end
 
       context "with big hash (force nested tries)" do
@@ -81,7 +81,7 @@ describe Hamster::Hash do
         it "returns the original hash unmodified for all changes" do
           keys.each_with_index do |key, index|
             result = hash.put(key, values[index])
-            result.should be(hash)
+            expect(result).to be(hash)
           end
         end
       end
@@ -92,8 +92,8 @@ describe Hamster::Hash do
 
       it "stores and can retrieve both" do
         result = hash.put(DeterministicHash.new('b', 1), 'bee')
-        result.get(DeterministicHash.new('a', 1)).should eql('aye')
-        result.get(DeterministicHash.new('b', 1)).should eql('bee')
+        expect(result.get(DeterministicHash.new('a', 1))).to eql('aye')
+        expect(result.get(DeterministicHash.new('b', 1))).to eql('bee')
       end
     end
 
@@ -102,8 +102,8 @@ describe Hamster::Hash do
         string = "a string!"
         hash = H.empty.put(string, 'a value!')
         string.upcase!
-        hash['a string!'].should == 'a value!'
-        hash['A STRING!'].should be_nil
+        expect(hash['a string!']).to eq('a value!')
+        expect(hash['A STRING!']).to be_nil
       end
     end
   end

--- a/spec/lib/hamster/hash/reduce_spec.rb
+++ b/spec/lib/hamster/hash/reduce_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::Hash do
     describe "##{method}" do
       context "when empty" do
         it "returns the memo" do
-          H.empty.send(method, "ABC") {}.should == "ABC"
+          expect(H.empty.send(method, "ABC") {}).to eq("ABC")
         end
       end
 
@@ -15,7 +15,7 @@ describe Hamster::Hash do
 
         context "with a block" do
           it "returns the final memo" do
-            hash.send(method, 0) { |memo, key, value| memo + 1 }.should == 3
+            expect(hash.send(method, 0) { |memo, key, value| memo + 1 }).to eq(3)
           end
         end
 
@@ -23,11 +23,11 @@ describe Hamster::Hash do
           let(:hash) { H[a: 1, b: 2] }
 
           it "uses a passed string as the name of a method to use instead" do
-            [[:a, 1, :b, 2], [:b, 2, :a, 1]].include?(hash.send(method, "+")).should == true
+            expect([[:a, 1, :b, 2], [:b, 2, :a, 1]].include?(hash.send(method, "+"))).to eq(true)
           end
 
           it "uses a passed symbol as the name of a method to use instead" do
-            [[:a, 1, :b, 2], [:b, 2, :a, 1]].include?(hash.send(method, :+)).should == true
+            expect([[:a, 1, :b, 2], [:b, 2, :a, 1]].include?(hash.send(method, :+))).to eq(true)
           end
         end
       end

--- a/spec/lib/hamster/hash/reject_spec.rb
+++ b/spec/lib/hamster/hash/reject_spec.rb
@@ -8,7 +8,7 @@ describe Hamster::Hash do
 
       context "when nothing matches" do
         it "returns self" do
-          hash.send(method) { |key, value| false }.should equal(hash)
+          expect(hash.send(method) { |key, value| false }).to equal(hash)
         end
       end
 
@@ -18,11 +18,11 @@ describe Hamster::Hash do
 
           it "preserves the original" do
             result
-            hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see"])
+            expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see"])
           end
 
           it "returns a set with the matching values" do
-            result.should eql(H["B" => "bee", "C" => "see"])
+            expect(result).to eql(H["B" => "bee", "C" => "see"])
           end
 
           it "yields entries in the same order as #each" do
@@ -30,15 +30,15 @@ describe Hamster::Hash do
             remove_pairs = []
             hash.each_pair { |k,v| each_pairs << [k,v] }
             hash.send(method) { |k,v| remove_pairs << [k,v] }
-            each_pairs.should == remove_pairs
+            expect(each_pairs).to eq(remove_pairs)
           end
         end
 
         context "with no block" do
           it "returns an Enumerator" do
-            hash.send(method).class.should be(Enumerator)
-            hash.send(method).to_a.sort.should == [['A', 'aye'], ['B', 'bee'], ['C', 'see']]
-            hash.send(method).each { true }.should eql(H.empty)
+            expect(hash.send(method).class).to be(Enumerator)
+            expect(hash.send(method).to_a.sort).to eq([['A', 'aye'], ['B', 'bee'], ['C', 'see']])
+            expect(hash.send(method).each { true }).to eql(H.empty)
           end
         end
 
@@ -48,12 +48,12 @@ describe Hamster::Hash do
             hash  = H.new(array)
             [0, 10, 100, 200, 500, 800, 900, 999, 1000].each do |threshold|
               result = hash.send(method) { |k,v| k >= threshold}
-              result.size.should == threshold
-              0.upto(threshold-1) { |n| result.key?(n).should == true }
-              threshold.upto(1000) { |n| result.key?(n).should == false }
+              expect(result.size).to eq(threshold)
+              0.upto(threshold-1) { |n| expect(result.key?(n)).to eq(true) }
+              threshold.upto(1000) { |n| expect(result.key?(n)).to eq(false) }
             end
             # shouldn't have changed
-            hash.should eql(H.new(1000.times.collect { |n| [n, n] }))
+            expect(hash).to eql(H.new(1000.times.collect { |n| [n, n] }))
           end
         end
       end

--- a/spec/lib/hamster/hash/reverse_each_spec.rb
+++ b/spec/lib/hamster/hash/reverse_each_spec.rb
@@ -7,21 +7,21 @@ describe Hamster::Hash do
   describe "#reverse_each" do
     context "with a block" do
       it "returns self" do
-        hash.reverse_each {}.should be(hash)
+        expect(hash.reverse_each {}).to be(hash)
       end
 
       it "yields all key/value pairs in the opposite order as #each" do
         result = []
         hash.reverse_each { |entry| result << entry }
-        result.should eql(hash.to_a.reverse)
+        expect(result).to eql(hash.to_a.reverse)
       end
     end
 
     context "with no block" do
       it "returns an Enumerator" do
         result = hash.reverse_each
-        result.class.should be(Enumerator)
-        result.to_a.should eql(hash.to_a.reverse)
+        expect(result.class).to be(Enumerator)
+        expect(result.to_a).to eql(hash.to_a.reverse)
       end
     end
   end

--- a/spec/lib/hamster/hash/sample_spec.rb
+++ b/spec/lib/hamster/hash/sample_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::Hash do
 
     it "returns a randomly chosen item" do
       chosen = 250.times.map { hash.sample }.sort.uniq
-      chosen.each { |item| hash.include?(item[0]).should == true }
-      hash.each { |item| chosen.include?(item).should == true }
+      chosen.each { |item| expect(hash.include?(item[0])).to eq(true) }
+      hash.each { |item| expect(chosen.include?(item)).to eq(true) }
     end
   end
 end

--- a/spec/lib/hamster/hash/select_spec.rb
+++ b/spec/lib/hamster/hash/select_spec.rb
@@ -8,7 +8,7 @@ describe Hamster::Hash do
 
       context "when everything matches" do
         it "returns self" do
-          original.send(method) { |key, value| true }.should equal(original)
+          expect(original.send(method) { |key, value| true }).to equal(original)
         end
       end
 
@@ -17,26 +17,26 @@ describe Hamster::Hash do
           let(:result) { original.send(method) { |key, value| key == "A" && value == "aye" }}
 
           it "preserves the original" do
-            original.should eql(H["A" => "aye", "B" => "bee", "C" => "see"])
+            expect(original).to eql(H["A" => "aye", "B" => "bee", "C" => "see"])
           end
 
           it "returns a set with the matching values" do
-            result.should eql(H["A" => "aye"])
+            expect(result).to eql(H["A" => "aye"])
           end
         end
 
         it "yields entries as [key, value] pairs" do
           original.send(method) do |e|
-            e.should be_kind_of(Array)
-            ["A", "B", "C"].include?(e[0]).should == true
-            ["aye", "bee", "see"].include?(e[1]).should == true
+            expect(e).to be_kind_of(Array)
+            expect(["A", "B", "C"].include?(e[0])).to eq(true)
+            expect(["aye", "bee", "see"].include?(e[1])).to eq(true)
           end
         end
 
         context "with no block" do
           it "returns an Enumerator" do
-            original.send(method).class.should be(Enumerator)
-            original.send(method).to_a.sort.should == [['A', 'aye'], ['B', 'bee'], ['C', 'see']]
+            expect(original.send(method).class).to be(Enumerator)
+            expect(original.send(method).to_a.sort).to eq([['A', 'aye'], ['B', 'bee'], ['C', 'see']])
           end
         end
       end
@@ -47,11 +47,11 @@ describe Hamster::Hash do
         25.times do
           threshold = rand(1000)
           result    = original.send(method) { |k,v| k <= threshold }
-          result.size.should == threshold
-          result.each_key { |k| k.should <= threshold }
-          (threshold+1).upto(1000) { |k| result.key?(k).should == false }
+          expect(result.size).to eq(threshold)
+          result.each_key { |k| expect(k).to be <= threshold }
+          (threshold+1).upto(1000) { |k| expect(result.key?(k)).to eq(false) }
         end
-        original.should eql(H.new(keys.zip(2..1001))) # shouldn't have changed
+        expect(original).to eql(H.new(keys.zip(2..1001))) # shouldn't have changed
       end
     end
   end

--- a/spec/lib/hamster/hash/size_spec.rb
+++ b/spec/lib/hamster/hash/size_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::Hash do
       ].each do |values, result|
 
         it "returns #{result} for #{values.inspect}" do
-          H[*values].send(method).should == result
+          expect(H[*values].send(method)).to eq(result)
         end
       end
 
@@ -24,7 +24,7 @@ describe Hamster::Hash do
         random_things.each do |thing|
           h = h.put(thing, thing * 2)
         end
-        h.size.should == 10_842
+        expect(h.size).to eq(10_842)
       end
 
       random_actions = (lots.map { |x|[:add, x] } + lots.map { |x|[:add, x] } + lots.map { |x|[:remove, x] }).sort_by { |x|rand }
@@ -45,7 +45,7 @@ describe Hamster::Hash do
             h = h.delete(ob)
           end
         end
-        h.size.should == ending_size
+        expect(h.size).to eq(ending_size)
       end
     end
   end

--- a/spec/lib/hamster/hash/slice_spec.rb
+++ b/spec/lib/hamster/hash/slice_spec.rb
@@ -16,7 +16,7 @@ describe Hamster::Hash do
 
       it "doesn't modify the original Hash" do
         slice
-        hash.should eql(H.new("A" => "aye", "B" => "bee", "C" => "see", nil => "NIL"))
+        expect(hash).to eql(H.new("A" => "aye", "B" => "bee", "C" => "see", nil => "NIL"))
       end
     end
 
@@ -29,7 +29,7 @@ describe Hamster::Hash do
 
       it "doesn't modify the original Hash" do
         slice
-        hash.should eql(H.new("A" => "aye", "B" => "bee", "C" => "see", nil => "NIL"))
+        expect(hash).to eql(H.new("A" => "aye", "B" => "bee", "C" => "see", nil => "NIL"))
       end
     end
 

--- a/spec/lib/hamster/hash/sort_spec.rb
+++ b/spec/lib/hamster/hash/sort_spec.rb
@@ -6,22 +6,22 @@ describe Hamster::Hash do
 
   describe "#sort" do
     it "returns a Vector of sorted key/val pairs" do
-      hash.sort.should eql(V[[:a, 3], [:b, 2], [:c, 1]])
+      expect(hash.sort).to eql(V[[:a, 3], [:b, 2], [:c, 1]])
     end
 
     it "works on large hashes" do
       array = (1..1000).map { |n| [n,n] }
-      H.new(array.shuffle).sort.should eql(V.new(array))
+      expect(H.new(array.shuffle).sort).to eql(V.new(array))
     end
 
     it "uses block as comparator to sort if passed a block" do
-      hash.sort { |a,b| b <=> a }.should eql(V[[:c, 1], [:b, 2], [:a, 3]])
+      expect(hash.sort { |a,b| b <=> a }).to eql(V[[:c, 1], [:b, 2], [:a, 3]])
     end
   end
 
   describe "#sort_by" do
     it "returns a Vector of key/val pairs, sorted using the block as a key function" do
-      hash.sort_by { |k,v| v }.should eql(V[[:c, 1], [:b, 2], [:a, 3]])
+      expect(hash.sort_by { |k,v| v }).to eql(V[[:c, 1], [:b, 2], [:a, 3]])
     end
   end
 end

--- a/spec/lib/hamster/hash/store_spec.rb
+++ b/spec/lib/hamster/hash/store_spec.rb
@@ -10,11 +10,11 @@ describe Hamster::Hash do
 
       it "preserves the original" do
         result
-        hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see"])
+        expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see"])
       end
 
       it "returns a copy with the superset of key/value pairs" do
-        result.should eql(H["A" => "aye", "B" => "bee", "C" => "see", "D" => "dee"])
+        expect(result).to eql(H["A" => "aye", "B" => "bee", "C" => "see", "D" => "dee"])
       end
     end
 
@@ -23,11 +23,11 @@ describe Hamster::Hash do
 
       it "preserves the original" do
         result
-        hash.should eql(H["A" => "aye", "B" => "bee", "C" => "see"])
+        expect(hash).to eql(H["A" => "aye", "B" => "bee", "C" => "see"])
       end
 
       it "returns a copy with the superset of key/value pairs" do
-        result.should eql(H["A" => "aye", "B" => "bee", "C" => "sea"])
+        expect(result).to eql(H["A" => "aye", "B" => "bee", "C" => "sea"])
       end
     end
 
@@ -36,7 +36,7 @@ describe Hamster::Hash do
       let(:result) { hash.store("X", 1) }
 
       it "returns the original hash unmodified" do
-        result.should be(hash)
+        expect(result).to be(hash)
       end
 
       context "with big hash (force nested tries)" do
@@ -47,7 +47,7 @@ describe Hamster::Hash do
         it "returns the original hash unmodified for all changes" do
           keys.each_with_index do |key, index|
             result = hash.store(key, values[index])
-            result.should be(hash)
+            expect(result).to be(hash)
           end
         end
       end
@@ -58,8 +58,8 @@ describe Hamster::Hash do
 
       it "stores and can retrieve both" do
         result = hash.store(DeterministicHash.new('b', 1), 'bee')
-        result.get(DeterministicHash.new('a', 1)).should eql('aye')
-        result.get(DeterministicHash.new('b', 1)).should eql('bee')
+        expect(result.get(DeterministicHash.new('a', 1))).to eql('aye')
+        expect(result.get(DeterministicHash.new('b', 1))).to eql('bee')
       end
     end
 
@@ -68,8 +68,8 @@ describe Hamster::Hash do
         string = "a string!"
         hash = H.empty.store(string, 'a value!')
         string.upcase!
-        hash['a string!'].should == 'a value!'
-        hash['A STRING!'].should be_nil
+        expect(hash['a string!']).to eq('a value!')
+        expect(hash['A STRING!']).to be_nil
       end
     end
   end

--- a/spec/lib/hamster/hash/take_spec.rb
+++ b/spec/lib/hamster/hash/take_spec.rb
@@ -6,11 +6,11 @@ describe Hamster::Hash do
 
   describe "#take" do
     it "returns the first N key/val pairs from hash" do
-      hash.take(0).should == []
-      [[['A', 'aye']], [['B', 'bee']], [['C', 'see']]].include?(hash.take(1)).should == true
-      [['A', 'aye'], ['B', 'bee'], ['C', 'see']].combination(2).include?(hash.take(2).sort).should == true
-      hash.take(3).sort.should == [['A', 'aye'], ['B', 'bee'], ['C', 'see']]
-      hash.take(4).sort.should == [['A', 'aye'], ['B', 'bee'], ['C', 'see']]
+      expect(hash.take(0)).to eq([])
+      expect([[['A', 'aye']], [['B', 'bee']], [['C', 'see']]].include?(hash.take(1))).to eq(true)
+      expect([['A', 'aye'], ['B', 'bee'], ['C', 'see']].combination(2).include?(hash.take(2).sort)).to eq(true)
+      expect(hash.take(3).sort).to eq([['A', 'aye'], ['B', 'bee'], ['C', 'see']])
+      expect(hash.take(4).sort).to eq([['A', 'aye'], ['B', 'bee'], ['C', 'see']])
     end
   end
 
@@ -18,19 +18,19 @@ describe Hamster::Hash do
     it "passes elements to the block until the block returns nil/false" do
       passed = nil
       hash.take_while { |k,v| passed = k; false }
-      ['A', 'B', 'C'].include?(passed).should == true
+      expect(['A', 'B', 'C'].include?(passed)).to eq(true)
     end
 
     it "returns an array of all elements before the one which returned nil/false" do
       count = 0
       result = hash.take_while { count += 1; count < 3 }
-      [['A', 'aye'], ['B', 'bee'], ['C', 'see']].combination(2).include?(result.sort).should == true
+      expect([['A', 'aye'], ['B', 'bee'], ['C', 'see']].combination(2).include?(result.sort)).to eq(true)
     end
 
     it "passes all elements if the block never returns nil/false" do
       passed = []
-      hash.take_while { |k,v| passed << [k, v]; true }.should == hash.to_a
-      passed.sort.should == [['A', 'aye'], ['B', 'bee'], ['C', 'see']]
+      expect(hash.take_while { |k,v| passed << [k, v]; true }).to eq(hash.to_a)
+      expect(passed.sort).to eq([['A', 'aye'], ['B', 'bee'], ['C', 'see']])
     end
   end
 end

--- a/spec/lib/hamster/hash/to_a_spec.rb
+++ b/spec/lib/hamster/hash/to_a_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::Hash do
       hash = H[:a => 1, 1 => :a, 3 => :b, :b => 5]
       pairs = []
       hash.each_pair { |k,v| pairs << [k,v] }
-      hash.to_a.should be_kind_of(Array)
-      hash.to_a.should == pairs
+      expect(hash.to_a).to be_kind_of(Array)
+      expect(hash.to_a).to eq(pairs)
     end
   end
 end

--- a/spec/lib/hamster/hash/to_hash_spec.rb
+++ b/spec/lib/hamster/hash/to_hash_spec.rb
@@ -5,17 +5,17 @@ describe Hamster::Hash do
   [:to_hash, :to_h].each do |method|
     describe "##{method}" do
       it "converts an empty Hamster::Hash to an empty Ruby Hash" do
-        H.empty.send(method).should eql({})
+        expect(H.empty.send(method)).to eql({})
       end
 
       it "converts a non-empty Hamster::Hash to a Hash with the same keys and values" do
-        H[a: 1, b: 2].send(method).should eql({a: 1, b: 2})
+        expect(H[a: 1, b: 2].send(method)).to eql({a: 1, b: 2})
       end
 
       it "doesn't modify the receiver" do
         hash = H[a: 1, b: 2]
         hash.send(method)
-        hash.should eql(H[a: 1, b: 2])
+        expect(hash).to eql(H[a: 1, b: 2])
       end
     end
   end

--- a/spec/lib/hamster/hash/to_proc_spec.rb
+++ b/spec/lib/hamster/hash/to_proc_spec.rb
@@ -7,15 +7,15 @@ describe Hamster::Hash do
       let(:hash) { H.new("A" => "aye") }
 
       it "returns a Proc instance" do
-        hash.to_proc.should be_kind_of(Proc)
+        expect(hash.to_proc).to be_kind_of(Proc)
       end
 
       it "returns a Proc that returns the value of an existing key" do
-        hash.to_proc.call("A").should == "aye"
+        expect(hash.to_proc.call("A")).to eq("aye")
       end
 
       it "returns a Proc that returns nil for a missing key" do
-        hash.to_proc.call("B").should be_nil
+        expect(hash.to_proc.call("B")).to be_nil
       end
     end
 
@@ -23,16 +23,16 @@ describe Hamster::Hash do
       let(:hash) { H.new("A" => "aye") { |key| "#{key}-VAL" } }
 
       it "returns a Proc instance" do
-        hash.to_proc.should be_kind_of(Proc)
+        expect(hash.to_proc).to be_kind_of(Proc)
       end
 
       it "returns a Proc that returns the value of an existing key" do
-        hash.to_proc.call("A").should == "aye"
+        expect(hash.to_proc.call("A")).to eq("aye")
       end
 
       it "returns a Proc that returns the result of the hash's default proc for a missing key" do
-        hash.to_proc.call("B").should == "B-VAL"
-        hash.should == H.new("A" => "aye")
+        expect(hash.to_proc.call("B")).to eq("B-VAL")
+        expect(hash).to eq(H.new("A" => "aye"))
       end
     end
   end

--- a/spec/lib/hamster/hash/values_at_spec.rb
+++ b/spec/lib/hamster/hash/values_at_spec.rb
@@ -7,18 +7,18 @@ describe Hamster::Hash do
       let(:hash) { H[:a => 9, :b => 'a', :c => -10, :d => nil] }
 
       it "returns an empty vector when no keys are given" do
-        hash.values_at.should be_kind_of(Hamster::Vector)
-        hash.values_at.should eql(V.empty)
+        expect(hash.values_at).to be_kind_of(Hamster::Vector)
+        expect(hash.values_at).to eql(V.empty)
       end
 
       it "returns a vector of values for the given keys" do
-        hash.values_at(:a, :d, :b).should be_kind_of(Hamster::Vector)
-        hash.values_at(:a, :d, :b).should eql(V[9, nil, 'a'])
+        expect(hash.values_at(:a, :d, :b)).to be_kind_of(Hamster::Vector)
+        expect(hash.values_at(:a, :d, :b)).to eql(V[9, nil, 'a'])
       end
 
       it "fills nil when keys are missing" do
-        hash.values_at(:x, :a, :y, :b).should be_kind_of(Hamster::Vector)
-        hash.values_at(:x, :a, :y, :b).should eql(V[nil, 9, nil, 'a'])
+        expect(hash.values_at(:x, :a, :y, :b)).to be_kind_of(Hamster::Vector)
+        expect(hash.values_at(:x, :a, :y, :b)).to eql(V[nil, 9, nil, 'a'])
       end
     end
 
@@ -26,8 +26,8 @@ describe Hamster::Hash do
       let(:hash) { Hamster::Hash.new(:a => 9) { |key| "#{key}-VAL" } }
 
       it "fills the result of the default proc when keys are missing" do
-        hash.values_at(:x, :a, :y).should be_kind_of(Hamster::Vector)
-        hash.values_at(:x, :a, :y).should eql(V['x-VAL', 9, 'y-VAL'])
+        expect(hash.values_at(:x, :a, :y)).to be_kind_of(Hamster::Vector)
+        expect(hash.values_at(:x, :a, :y)).to eql(V['x-VAL', 9, 'y-VAL'])
       end
     end
   end

--- a/spec/lib/hamster/hash/values_spec.rb
+++ b/spec/lib/hamster/hash/values_spec.rb
@@ -8,8 +8,8 @@ describe Hamster::Hash do
     let(:result) { hash.values }
 
     it "returns the keys as a Vector" do
-      result.should be_a Hamster::Vector
-      result.to_a.sort.should == %w(aye bee see)
+      expect(result).to be_a Hamster::Vector
+      expect(result.to_a.sort).to eq(%w(aye bee see))
     end
 
     context "with duplicates" do
@@ -17,8 +17,8 @@ describe Hamster::Hash do
       let(:result) { hash.values }
 
       it "returns the keys as a Vector" do
-        result.class.should be(Hamster::Vector)
-        result.to_a.sort.should == [15, 15, 19]
+        expect(result.class).to be(Hamster::Vector)
+        expect(result.to_a.sort).to eq([15, 15, 19])
       end
     end
   end

--- a/spec/lib/hamster/immutable/copying_spec.rb
+++ b/spec/lib/hamster/immutable/copying_spec.rb
@@ -14,7 +14,7 @@ describe Hamster::Immutable do
       end
 
       it "returns self" do
-        @result.should equal(@original)
+        expect(@result).to equal(@original)
       end
     end
   end

--- a/spec/lib/hamster/immutable/immutable_spec.rb
+++ b/spec/lib/hamster/immutable/immutable_spec.rb
@@ -13,7 +13,7 @@ describe Hamster::Immutable do
       end
 
       it "returns true" do
-        @fixture.should be_immutable
+        expect(@fixture).to be_immutable
       end
     end
 
@@ -27,7 +27,7 @@ describe Hamster::Immutable do
 
       describe "that are not frozen" do
         it "returns false" do
-          @fixture.should_not be_immutable
+          expect(@fixture).not_to be_immutable
         end
       end
 
@@ -37,7 +37,7 @@ describe Hamster::Immutable do
         end
 
         it "returns true" do
-          @fixture.should be_immutable
+          expect(@fixture).to be_immutable
         end
       end
     end

--- a/spec/lib/hamster/list/add_spec.rb
+++ b/spec/lib/hamster/list/add_spec.rb
@@ -14,11 +14,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.add(new_value)
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.add(new_value).should eql(L[*expected])
+          expect(list.add(new_value)).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/all_spec.rb
+++ b/spec/lib/hamster/list/all_spec.rb
@@ -7,17 +7,17 @@ describe Hamster::List do
       let(:list) { Hamster.interval(0, STACK_OVERFLOW_DEPTH) }
 
       it "doesn't run out of stack" do
-        -> { list.all? }.should_not raise_error
+        expect { list.all? }.not_to raise_error
       end
     end
 
     context "when empty" do
       it "with a block returns true" do
-        L.empty.all? {}.should == true
+        expect(L.empty.all? {}).to eq(true)
       end
 
       it "with no block returns true" do
-        L.empty.all?.should == true
+        expect(L.empty.all?).to eq(true)
       end
     end
 
@@ -27,13 +27,13 @@ describe Hamster::List do
 
         context "if the block always returns true" do
           it "returns true" do
-            list.all? { |item| true }.should == true
+            expect(list.all? { |item| true }).to eq(true)
           end
         end
 
         context "if the block ever returns false" do
           it "returns false" do
-            list.all? { |item| item == "D" }.should == false
+            expect(list.all? { |item| item == "D" }).to eq(false)
           end
         end
       end
@@ -41,14 +41,14 @@ describe Hamster::List do
       context "with no block" do
         context "if all values are truthy" do
           it "returns true" do
-            L[true, "A"].all?.should == true
+            expect(L[true, "A"].all?).to eq(true)
           end
         end
 
         [nil, false].each do |value|
           context "if any value is #{value.inspect}" do
             it "returns false" do
-              L[value, true, "A"].all?.should == false
+              expect(L[value, true, "A"].all?).to eq(false)
             end
           end
         end

--- a/spec/lib/hamster/list/any_spec.rb
+++ b/spec/lib/hamster/list/any_spec.rb
@@ -7,17 +7,17 @@ describe Hamster::List do
       let(:list) { Hamster.interval(0, STACK_OVERFLOW_DEPTH) }
 
       it "doesn't run out of stack" do
-        -> { list.any? { false } }.should_not raise_error
+        expect { list.any? { false } }.not_to raise_error
       end
     end
 
     context "when empty" do
       it "with a block returns false" do
-       L.empty.any? {}.should == false
+       expect(L.empty.any? {}).to eq(false)
       end
 
       it "with no block returns false" do
-        L.empty.any?.should == false
+        expect(L.empty.any?).to eq(false)
       end
     end
 
@@ -27,22 +27,22 @@ describe Hamster::List do
 
         ["A", "B", "C", nil].each do |value|
           it "returns true if the block ever returns true (#{value.inspect})" do
-            list.any? { |item| item == value }.should == true
+            expect(list.any? { |item| item == value }).to eq(true)
           end
         end
 
         it "returns false if the block always returns false" do
-          list.any? { |item| item == "D" }.should == false
+          expect(list.any? { |item| item == "D" }).to eq(false)
         end
       end
 
       context "with no block" do
         it "returns true if any value is truthy" do
-          L[nil, false, "A", true].any?.should == true
+          expect(L[nil, false, "A", true].any?).to eq(true)
         end
 
         it "returns false if all values are falsey" do
-          L[nil, false].any?.should == false
+          expect(L[nil, false].any?).to eq(false)
         end
       end
     end

--- a/spec/lib/hamster/list/append_spec.rb
+++ b/spec/lib/hamster/list/append_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   [:append, :concat, :+].each do |method|
     describe "##{method}" do
       it "is lazy" do
-        -> { Hamster.stream { fail }.append(Hamster.stream { fail }) }.should_not raise_error
+        expect { Hamster.stream { fail }.append(Hamster.stream { fail }) }.not_to raise_error
       end
 
       [
@@ -21,16 +21,16 @@ describe Hamster::List do
 
           it "preserves the left" do
             result
-            left.should eql(L[*left_values])
+            expect(left).to eql(L[*left_values])
           end
 
           it "preserves the right" do
             result
-            right.should eql(L[*right_values])
+            expect(right).to eql(L[*right_values])
           end
 
           it "returns #{expected.inspect}" do
-            result.should eql(L[*expected])
+            expect(result).to eql(L[*expected])
           end
         end
       end

--- a/spec/lib/hamster/list/at_spec.rb
+++ b/spec/lib/hamster/list/at_spec.rb
@@ -7,7 +7,7 @@ describe Hamster::List do
       let(:list) { Hamster.interval(0, STACK_OVERFLOW_DEPTH) }
 
       it "doesn't run out of stack" do
-        -> { list.at(STACK_OVERFLOW_DEPTH) }.should_not raise_error
+        expect { list.at(STACK_OVERFLOW_DEPTH) }.not_to raise_error
       end
     end
 
@@ -22,7 +22,7 @@ describe Hamster::List do
     ].each do |values, number, expected|
       describe "#{values.inspect} with #{number}" do
         it "returns #{expected.inspect}" do
-          L[*values].at(number).should == expected
+          expect(L[*values].at(number)).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/list/break_spec.rb
+++ b/spec/lib/hamster/list/break_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#break" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.break { |item| false } }.should_not raise_error
+      expect { Hamster.stream { fail }.break { |item| false } }.not_to raise_error
     end
 
     [
@@ -27,21 +27,21 @@ describe Hamster::List do
 
           it "preserves the original" do
             result
-            list.should eql(L[*values])
+            expect(list).to eql(L[*values])
           end
 
           it "returns a frozen array with two items" do
-            result.class.should be(Array)
-            result.should be_frozen
-            result.size.should be(2)
+            expect(result.class).to be(Array)
+            expect(result).to be_frozen
+            expect(result.size).to be(2)
           end
 
           it "correctly identifies the prefix" do
-            prefix.should eql(L[*expected_prefix])
+            expect(prefix).to eql(L[*expected_prefix])
           end
 
           it "correctly identifies the remainder" do
-            remainder.should eql(L[*expected_remainder])
+            expect(remainder).to eql(L[*expected_remainder])
           end
         end
 
@@ -51,17 +51,17 @@ describe Hamster::List do
           let(:remainder) { result.last }
 
           it "returns a frozen array with two items" do
-            result.class.should be(Array)
-            result.should be_frozen
-            result.size.should be(2)
+            expect(result.class).to be(Array)
+            expect(result).to be_frozen
+            expect(result.size).to be(2)
           end
 
           it "returns self as the prefix" do
-            prefix.should equal(list)
+            expect(prefix).to equal(list)
           end
 
           it "leaves the remainder empty" do
-            remainder.should be_empty
+            expect(remainder).to be_empty
           end
         end
       end

--- a/spec/lib/hamster/list/cadr_spec.rb
+++ b/spec/lib/hamster/list/cadr_spec.rb
@@ -19,7 +19,7 @@ describe Hamster::List do
   ].each do |values, method, expected|
     describe "##{method}" do
       it "is responded to" do
-        L.empty.respond_to?(method).should == true
+        expect(L.empty.respond_to?(method)).to eq(true)
       end
 
       context "on #{values.inspect}" do
@@ -27,11 +27,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.send(method)
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.send(method).should == expected
+          expect(list.send(method)).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/list/chunk_spec.rb
+++ b/spec/lib/hamster/list/chunk_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#chunk" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.chunk(2) }.should_not raise_error
+      expect { Hamster.stream { fail }.chunk(2) }.not_to raise_error
     end
 
     [
@@ -17,11 +17,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.chunk(2)
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.chunk(2).should eql(L[*expected])
+          expect(list.chunk(2)).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/clear_spec.rb
+++ b/spec/lib/hamster/list/clear_spec.rb
@@ -13,11 +13,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.clear
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns an empty list" do
-          list.clear.should equal(L.empty)
+          expect(list.clear).to equal(L.empty)
         end
       end
     end

--- a/spec/lib/hamster/list/combination_spec.rb
+++ b/spec/lib/hamster/list/combination_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#combination" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.combination(2) }.should_not raise_error
+      expect { Hamster.stream { fail }.combination(2) }.not_to raise_error
     end
 
     [
@@ -22,11 +22,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.combination(number)
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.combination(number).should eql(L[*expected])
+          expect(list.combination(number)).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/compact_spec.rb
+++ b/spec/lib/hamster/list/compact_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#compact" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.compact }.should_not raise_error
+      expect { Hamster.stream { fail }.compact }.not_to raise_error
     end
 
     [
@@ -23,11 +23,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.compact
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.compact.should eql(L[*expected])
+          expect(list.compact).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/compare_spec.rb
+++ b/spec/lib/hamster/list/compare_spec.rb
@@ -11,19 +11,19 @@ describe Hamster::List do
     ].each do |items1, items2|
       context "with #{items1} and #{items2}" do
         it "returns -1" do
-          (L[*items1] <=> L[*items2]).should be(-1)
+          expect(L[*items1] <=> L[*items2]).to be(-1)
         end
       end
 
       context "with #{items2} and #{items1}" do
         it "returns 1" do
-          (L[*items2] <=> L[*items1]).should be(1)
+          expect(L[*items2] <=> L[*items1]).to be(1)
         end
       end
 
       context "with #{items1} and #{items1}" do
         it "returns 0" do
-          (L[*items1] <=> L[*items1]).should be(0)
+          expect(L[*items1] <=> L[*items1]).to be(0)
         end
       end
     end

--- a/spec/lib/hamster/list/cons_spec.rb
+++ b/spec/lib/hamster/list/cons_spec.rb
@@ -14,11 +14,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.cons(new_value)
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.cons(new_value).should eql(L[*expected])
+          expect(list.cons(new_value)).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/construction_spec.rb
+++ b/spec/lib/hamster/list/construction_spec.rb
@@ -5,21 +5,21 @@ describe Hamster do
   describe ".list" do
     context "with no arguments" do
       it "always returns the same instance" do
-        L.empty.should equal(L.empty)
+        expect(L.empty).to equal(L.empty)
       end
 
       it "returns an empty list" do
-        L.empty.should be_empty
+        expect(L.empty).to be_empty
       end
     end
 
     context "with a number of items" do
       it "always returns a different instance" do
-        L["A", "B", "C"].should_not equal(L["A", "B", "C"])
+        expect(L["A", "B", "C"]).not_to equal(L["A", "B", "C"])
       end
 
       it "is the same as repeatedly using #cons" do
-        L["A", "B", "C"].should eql(L.empty.cons("C").cons("B").cons("A"))
+        expect(L["A", "B", "C"]).to eql(L.empty.cons("C").cons("B").cons("A"))
       end
     end
   end
@@ -27,7 +27,7 @@ describe Hamster do
   describe ".stream" do
     context "with no block" do
       it "returns an empty list" do
-        Hamster.stream.should eql(L.empty)
+        expect(Hamster.stream).to eql(L.empty)
       end
     end
 
@@ -35,7 +35,7 @@ describe Hamster do
       let(:list) { count = 0; Hamster.stream { count += 1 }}
 
       it "repeatedly calls the block" do
-        list.take(5).should eql(L[1, 2, 3, 4, 5])
+        expect(list.take(5)).to eql(L[1, 2, 3, 4, 5])
       end
     end
   end
@@ -43,32 +43,32 @@ describe Hamster do
   describe ".interval" do
     context "for numbers" do
       it "is equivalent to a list with explicit values" do
-        Hamster.interval(98, 102).should eql(L[98, 99, 100, 101, 102])
+        expect(Hamster.interval(98, 102)).to eql(L[98, 99, 100, 101, 102])
       end
     end
 
     context "for strings" do
       it "is equivalent to a list with explicit values" do
-        Hamster.interval("A", "AA").should eql(L["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "AA"])
+        expect(Hamster.interval("A", "AA")).to eql(L["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "AA"])
       end
     end
   end
 
   describe ".repeat" do
     it "returns an infinite list with specified value for each element" do
-      Hamster.repeat("A").take(5).should eql(L["A", "A", "A", "A", "A"])
+      expect(Hamster.repeat("A").take(5)).to eql(L["A", "A", "A", "A", "A"])
     end
   end
 
   describe ".replicate" do
     it "returns a list with the specified value repeated the specified number of times" do
-      Hamster.replicate(5, "A").should eql(L["A", "A", "A", "A", "A"])
+      expect(Hamster.replicate(5, "A")).to eql(L["A", "A", "A", "A", "A"])
     end
   end
 
   describe ".iterate" do
     it "returns an infinite list where the first item is calculated by applying the block on the initial argument, the second item by applying the function on the previous result and so on" do
-      Hamster.iterate(1) { |item| item * 2 }.take(10).should eql(L[1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
+      expect(Hamster.iterate(1) { |item| item * 2 }.take(10)).to eql(L[1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
     end
   end
 
@@ -98,14 +98,14 @@ describe Hamster do
   describe "[]" do
     it "takes a variable number of items and returns a list" do
       list = Hamster::List[1,2,3]
-      list.should be_kind_of(Hamster::List)
-      list.size.should be(3)
-      list.to_a.should == [1,2,3]
+      expect(list).to be_kind_of(Hamster::List)
+      expect(list.size).to be(3)
+      expect(list.to_a).to eq([1,2,3])
     end
 
     it "returns an empty list when called without arguments" do
-      L[].should be_kind_of(Hamster::List)
-      L[].should be_empty
+      expect(L[]).to be_kind_of(Hamster::List)
+      expect(L[]).to be_empty
     end
   end
 end

--- a/spec/lib/hamster/list/copying_spec.rb
+++ b/spec/lib/hamster/list/copying_spec.rb
@@ -12,7 +12,7 @@ describe Hamster::List do
         let(:list) { L[*values] }
 
         it "returns self" do
-          list.send(method).should equal(list)
+          expect(list.send(method)).to equal(list)
         end
       end
     end

--- a/spec/lib/hamster/list/count_spec.rb
+++ b/spec/lib/hamster/list/count_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#count" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).count }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).count }.not_to raise_error
       end
     end
 
@@ -22,13 +22,13 @@ describe Hamster::List do
 
         context "with a block" do
           it "returns #{expected.inspect}" do
-            list.count(&:odd?).should == expected
+            expect(list.count(&:odd?)).to eq(expected)
           end
         end
 
         context "without a block" do
           it "returns length" do
-            list.count.should == list.length
+            expect(list.count).to eq(list.length)
           end
         end
       end

--- a/spec/lib/hamster/list/cycle_spec.rb
+++ b/spec/lib/hamster/list/cycle_spec.rb
@@ -4,12 +4,12 @@ require "hamster/list"
 describe Hamster do
   describe "#cycle" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.cycle }.should_not raise_error
+      expect { Hamster.stream { fail }.cycle }.not_to raise_error
     end
 
     context "with an empty list" do
       it "returns an empty list" do
-        L.empty.cycle.should be_empty
+        expect(L.empty.cycle).to be_empty
       end
     end
 
@@ -18,11 +18,11 @@ describe Hamster do
 
       it "preserves the original" do
         list.cycle
-        list.should == L["A", "B", "C"]
+        expect(list).to eq(L["A", "B", "C"])
       end
 
       it "infinitely cycles through all values" do
-        list.cycle.take(7).should == L["A", "B", "C", "A", "B", "C", "A"]
+        expect(list.cycle.take(7)).to eq(L["A", "B", "C", "A", "B", "C", "A"])
       end
     end
   end

--- a/spec/lib/hamster/list/delete_at_spec.rb
+++ b/spec/lib/hamster/list/delete_at_spec.rb
@@ -6,14 +6,14 @@ describe Hamster::List do
     let(:list) { L[1,2,3,4,5] }
 
     it "removes the element at the specified index" do
-      list.delete_at(0).should eql(L[2,3,4,5])
-      list.delete_at(2).should eql(L[1,2,4,5])
-      list.delete_at(-1).should eql(L[1,2,3,4])
+      expect(list.delete_at(0)).to eql(L[2,3,4,5])
+      expect(list.delete_at(2)).to eql(L[1,2,4,5])
+      expect(list.delete_at(-1)).to eql(L[1,2,3,4])
     end
 
     it "makes no modification if the index is out of range" do
-      list.delete_at(5).should eql(list)
-      list.delete_at(-6).should eql(list)
+      expect(list.delete_at(5)).to eql(list)
+      expect(list.delete_at(-6)).to eql(list)
     end
   end
 end

--- a/spec/lib/hamster/list/delete_spec.rb
+++ b/spec/lib/hamster/list/delete_spec.rb
@@ -4,14 +4,14 @@ require "hamster/list"
 describe Hamster::List do
   describe "#delete" do
     it "removes elements that are #== to the argument" do
-      L[1,2,3].delete(1).should eql(L[2,3])
-      L[1,2,3].delete(2).should eql(L[1,3])
-      L[1,2,3].delete(3).should eql(L[1,2])
-      L[1,2,3].delete(0).should eql(L[1,2,3])
-      L['a','b','a','c','a','a','d'].delete('a').should eql(L['b','c','d'])
+      expect(L[1,2,3].delete(1)).to eql(L[2,3])
+      expect(L[1,2,3].delete(2)).to eql(L[1,3])
+      expect(L[1,2,3].delete(3)).to eql(L[1,2])
+      expect(L[1,2,3].delete(0)).to eql(L[1,2,3])
+      expect(L['a','b','a','c','a','a','d'].delete('a')).to eql(L['b','c','d'])
 
-      L[EqualNotEql.new, EqualNotEql.new].delete(:something).should eql(L[])
-      L[EqlNotEqual.new, EqlNotEqual.new].delete(:something).should_not be_empty
+      expect(L[EqualNotEql.new, EqualNotEql.new].delete(:something)).to eql(L[])
+      expect(L[EqlNotEqual.new, EqlNotEqual.new].delete(:something)).not_to be_empty
     end
   end
 end

--- a/spec/lib/hamster/list/drop_spec.rb
+++ b/spec/lib/hamster/list/drop_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#drop" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.drop(1) }.should_not raise_error
+      expect { Hamster.stream { fail }.drop(1) }.not_to raise_error
     end
 
     [
@@ -19,11 +19,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.drop(number)
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.drop(number).should == L[*expected]
+          expect(list.drop(number)).to eq(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/drop_while_spec.rb
+++ b/spec/lib/hamster/list/drop_while_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#drop_while" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.drop_while { false } }.should_not raise_error
+      expect { Hamster.stream { fail }.drop_while { false } }.not_to raise_error
     end
 
     [
@@ -18,19 +18,19 @@ describe Hamster::List do
         context "with a block" do
           it "preserves the original" do
             list.drop_while { |item| item < "C" }
-            list.should eql(L[*values])
+            expect(list).to eql(L[*values])
           end
 
           it "returns #{expected.inspect}" do
-            list.drop_while { |item| item < "C" }.should eql(L[*expected])
+            expect(list.drop_while { |item| item < "C" }).to eql(L[*expected])
           end
         end
 
         context "without a block" do
           it "returns an Enumerator" do
-            list.drop_while.class.should be(Enumerator)
-            list.drop_while.each { false }.should eql(list)
-            list.drop_while.each { true  }.should be_empty
+            expect(list.drop_while.class).to be(Enumerator)
+            expect(list.drop_while.each { false }).to eql(list)
+            expect(list.drop_while.each { true  }).to be_empty
           end
         end
       end

--- a/spec/lib/hamster/list/each_slice_spec.rb
+++ b/spec/lib/hamster/list/each_slice_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::List do
     describe "##{method}" do
       context "on a really big list" do
         it "doesn't run out of stack" do
-          -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method, 1) { |item| } }.should_not raise_error
+          expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method, 1) { |item| } }.not_to raise_error
         end
       end
 
@@ -20,29 +20,29 @@ describe Hamster::List do
 
           context "with a block" do
             it "preserves the original" do
-              list.should eql(L[*values])
+              expect(list).to eql(L[*values])
             end
 
             it "iterates over the items in order" do
               yielded = []
               list.send(method, 2) { |item| yielded << item }
-              yielded.should eql(expected)
+              expect(yielded).to eql(expected)
             end
 
             it "returns self" do
-              list.send(method, 2) { |item| item }.should be(list)
+              expect(list.send(method, 2) { |item| item }).to be(list)
             end
           end
 
           context "without a block" do
             it "preserves the original" do
               list.send(method, 2)
-              list.should eql(L[*values])
+              expect(list).to eql(L[*values])
             end
 
             it "returns an Enumerator" do
-              list.send(method, 2).class.should be(Enumerator)
-              list.send(method, 2).to_a.should eql(expected)
+              expect(list.send(method, 2).class).to be(Enumerator)
+              expect(list.send(method, 2).to_a).to eql(expected)
             end
           end
         end

--- a/spec/lib/hamster/list/each_spec.rb
+++ b/spec/lib/hamster/list/each_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#each" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).each { |item| } }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).each { |item| } }.not_to raise_error
       end
     end
 
@@ -21,18 +21,18 @@ describe Hamster::List do
           it "iterates over the items in order" do
             yielded = []
             list.each { |item| yielded << item }
-            yielded.should == values
+            expect(yielded).to eq(values)
           end
 
           it "returns nil" do
-            list.each { |item| item }.should be_nil
+            expect(list.each { |item| item }).to be_nil
           end
         end
 
         context "without a block" do
           it "returns an Enumerator" do
-            list.each.class.should be(Enumerator)
-            Hamster::List[*list.each].should eql(list)
+            expect(list.each.class).to be(Enumerator)
+            expect(Hamster::List[*list.each]).to eql(list)
           end
         end
       end

--- a/spec/lib/hamster/list/each_with_index_spec.rb
+++ b/spec/lib/hamster/list/each_with_index_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::List do
       let(:list) { L["A", "B", "C"] }
 
       it "returns an Enumerator" do
-        list.each_with_index.class.should be(Enumerator)
-        list.each_with_index.to_a.should == [['A', 0], ['B', 1], ['C', 2]]
+        expect(list.each_with_index.class).to be(Enumerator)
+        expect(list.each_with_index.to_a).to eq([['A', 0], ['B', 1], ['C', 2]])
       end
     end
 
@@ -16,13 +16,13 @@ describe Hamster::List do
       let(:list) { Hamster.interval(1, 1025) }
 
       it "returns self" do
-        list.each_with_index { |item, index| item }.should be(list)
+        expect(list.each_with_index { |item, index| item }).to be(list)
       end
 
       it "iterates over the items in order, yielding item and index" do
         yielded = []
         list.each_with_index { |item, index| yielded << [item, index] }
-        yielded.should == (1..list.size).zip(0..list.size.pred)
+        expect(yielded).to eq((1..list.size).zip(0..list.size.pred))
       end
     end
   end

--- a/spec/lib/hamster/list/empty_spec.rb
+++ b/spec/lib/hamster/list/empty_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#empty?" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).select(&:nil?).empty? }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).select(&:nil?).empty? }.not_to raise_error
       end
     end
 
@@ -16,7 +16,7 @@ describe Hamster::List do
     ].each do |values, expected|
       context "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          L[*values].empty?.should == expected
+          expect(L[*values].empty?).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/list/eql_spec.rb
+++ b/spec/lib/hamster/list/eql_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#eql?" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).eql?(Hamster.interval(0, STACK_OVERFLOW_DEPTH)) }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).eql?(Hamster.interval(0, STACK_OVERFLOW_DEPTH)) }.not_to raise_error
       end
     end
   end

--- a/spec/lib/hamster/list/fill_spec.rb
+++ b/spec/lib/hamster/list/fill_spec.rb
@@ -6,45 +6,45 @@ describe Hamster::List do
     let(:list) { L[1, 2, 3, 4, 5, 6] }
 
     it "can replace a range of items at the beginning of a list" do
-      list.fill(:a, 0, 3).should eql(L[:a, :a, :a, 4, 5, 6])
+      expect(list.fill(:a, 0, 3)).to eql(L[:a, :a, :a, 4, 5, 6])
     end
 
     it "can replace a range of items in the middle of a list" do
-      list.fill(:a, 3, 2).should eql(L[1, 2, 3, :a, :a, 6])
+      expect(list.fill(:a, 3, 2)).to eql(L[1, 2, 3, :a, :a, 6])
     end
 
     it "can replace a range of items at the end of a list" do
-      list.fill(:a, 4, 2).should eql(L[1, 2, 3, 4, :a, :a])
+      expect(list.fill(:a, 4, 2)).to eql(L[1, 2, 3, 4, :a, :a])
     end
 
     it "can replace all the items in a list" do
-      list.fill(:a, 0, 6).should eql(L[:a, :a, :a, :a, :a, :a])
+      expect(list.fill(:a, 0, 6)).to eql(L[:a, :a, :a, :a, :a, :a])
     end
 
     it "can fill past the end of the list" do
-      list.fill(:a, 3, 6).should eql(L[1, 2, 3, :a, :a, :a, :a, :a, :a])
+      expect(list.fill(:a, 3, 6)).to eql(L[1, 2, 3, :a, :a, :a, :a, :a, :a])
     end
 
     context "with 1 argument" do
       it "replaces all the items in the list by default" do
-        list.fill(:a).should eql(L[:a, :a, :a, :a, :a, :a])
+        expect(list.fill(:a)).to eql(L[:a, :a, :a, :a, :a, :a])
       end
     end
 
     context "with 2 arguments" do
       it "replaces up to the end of the list by default" do
-        list.fill(:a, 4).should eql(L[1, 2, 3, 4, :a, :a])
+        expect(list.fill(:a, 4)).to eql(L[1, 2, 3, 4, :a, :a])
       end
     end
 
     context "when index and length are 0" do
       it "leaves the list unmodified" do
-        list.fill(:a, 0, 0).should eql(list)
+        expect(list.fill(:a, 0, 0)).to eql(list)
       end
     end
 
     it "is lazy" do
-      -> { Hamster.stream { fail }.fill(:a, 0, 1) }.should_not raise_error
+      expect { Hamster.stream { fail }.fill(:a, 0, 1) }.not_to raise_error
     end
   end
 end

--- a/spec/lib/hamster/list/find_index_spec.rb
+++ b/spec/lib/hamster/list/find_index_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::List do
     describe "##{method}" do
       context "on a really big list" do
         it "doesn't run out of stack" do
-          -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method) { |item| false } }.should_not raise_error
+          expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method) { |item| false } }.not_to raise_error
         end
       end
 
@@ -27,7 +27,7 @@ describe Hamster::List do
       ].each do |values, item, expected|
         context "looking for #{item.inspect} in #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].send(method) { |x| x == item }.should == expected
+            expect(L[*values].send(method) { |x| x == item }).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/list/find_spec.rb
+++ b/spec/lib/hamster/list/find_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::List do
     describe "##{method}" do
       context "on a really big list" do
         it "doesn't run out of stack" do
-          -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method) { false } }.should_not raise_error
+          expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method) { false } }.not_to raise_error
         end
       end
 
@@ -26,14 +26,14 @@ describe Hamster::List do
 
           context "with a block" do
             it "returns #{expected.inspect}" do
-              list.send(method) { |x| x == item }.should == expected
+              expect(list.send(method) { |x| x == item }).to eq(expected)
             end
           end
 
           context "without a block" do
             it "returns an Enumerator" do
-              list.send(method).class.should be(Enumerator)
-              list.send(method).each { |x| x == item }.should == expected
+              expect(list.send(method).class).to be(Enumerator)
+              expect(list.send(method).each { |x| x == item }).to eq(expected)
             end
           end
         end

--- a/spec/lib/hamster/list/flatten_spec.rb
+++ b/spec/lib/hamster/list/flatten_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster do
   describe "#flatten" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.flatten }.should_not raise_error
+      expect { Hamster.stream { fail }.flatten }.not_to raise_error
     end
 
     [
@@ -19,11 +19,11 @@ describe Hamster do
 
         it "preserves the original" do
           list.flatten
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns an empty list" do
-          list.flatten.should eql(L[*expected])
+          expect(list.flatten).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/grep_spec.rb
+++ b/spec/lib/hamster/list/grep_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#grep" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.grep(Object) { |item| item } }.should_not raise_error
+      expect { Hamster.stream { fail }.grep(Object) { |item| item } }.not_to raise_error
     end
 
     context "without a block" do
@@ -16,7 +16,7 @@ describe Hamster::List do
       ].each do |values, expected|
         context "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].grep(String).should eql(L[*expected])
+            expect(L[*values].grep(String)).to eql(L[*expected])
           end
         end
       end
@@ -34,11 +34,11 @@ describe Hamster::List do
 
           it "preserves the original" do
             list.grep(String, &:downcase)
-            list.should eql(L[*values])
+            expect(list).to eql(L[*values])
           end
 
           it "returns #{expected.inspect}" do
-            list.grep(String, &:downcase).should eql(L[*expected])
+            expect(list.grep(String, &:downcase)).to eql(L[*expected])
           end
         end
       end

--- a/spec/lib/hamster/list/group_by_spec.rb
+++ b/spec/lib/hamster/list/group_by_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::List do
     describe "##{method}" do
       context "on a really big list" do
         it "doesn't run out of stack" do
-          -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method) }.should_not raise_error
+          expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method) }.not_to raise_error
         end
       end
 
@@ -18,7 +18,7 @@ describe Hamster::List do
         ].each do |values, expected|
           context "on #{values.inspect}" do
             it "returns #{expected.inspect}" do
-              L[*values].send(method, &:odd?).should eql(H[*expected])
+              expect(L[*values].send(method, &:odd?)).to eql(H[*expected])
             end
           end
         end
@@ -32,7 +32,7 @@ describe Hamster::List do
         ].each do |values, expected|
           context "on #{values.inspect}" do
             it "returns #{expected.inspect}" do
-              L[*values].send(method).should eql(H[*expected])
+              expect(L[*values].send(method)).to eql(H[*expected])
             end
           end
         end

--- a/spec/lib/hamster/list/hash_spec.rb
+++ b/spec/lib/hamster/list/hash_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#hash" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).hash }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).hash }.not_to raise_error
       end
     end
 
@@ -16,7 +16,7 @@ describe Hamster::List do
     end
 
     it "values are sufficiently distributed" do
-      (1..4000).each_slice(4).map { |a, b, c, d| L[a, b, c, d].hash }.uniq.size.should == 1000
+      expect((1..4000).each_slice(4).map { |a, b, c, d| L[a, b, c, d].hash }.uniq.size).to eq(1000)
     end
   end
 end

--- a/spec/lib/hamster/list/head_spec.rb
+++ b/spec/lib/hamster/list/head_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::List do
       ].each do |values, expected|
         context "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].send(method).should == expected
+            expect(L[*values].send(method)).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/list/include_spec.rb
+++ b/spec/lib/hamster/list/include_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::List do
     describe "##{method}" do
       context "on a really big list" do
         it "doesn't run out of stack" do
-          -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method, nil) }.should_not raise_error
+          expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method, nil) }.not_to raise_error
         end
       end
 
@@ -27,7 +27,7 @@ describe Hamster::List do
       ].each do |values, item, expected|
         context "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].send(method, item).should == expected
+            expect(L[*values].send(method, item)).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/list/index_spec.rb
+++ b/spec/lib/hamster/list/index_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#index" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).index(nil) }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).index(nil) }.not_to raise_error
       end
     end
 
@@ -29,7 +29,7 @@ describe Hamster::List do
           if RUBY_ENGINE == 'jruby' && RUBY_VERSION <= '2.2.2' && values[0].is_a?(Fixnum) && item.is_a?(Float)
             skip "On JRuby, Enumerable#find_index doesn't test equality properly"
           else
-            L[*values].index(item).should == expected
+            expect(L[*values].index(item)).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/list/indices_spec.rb
+++ b/spec/lib/hamster/list/indices_spec.rb
@@ -7,12 +7,12 @@ describe Hamster::List do
       it "is lazy" do
         count = 0
         Hamster.stream { count += 1 }.indices { |item| true }
-        count.should <= 1
+        expect(count).to be <= 1
       end
 
       context "on a large list which doesn't contain desired item" do
         it "doesn't blow the stack" do
-          -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).indices { |x| x < 0 }.size }.should_not raise_error
+          expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).indices { |x| x < 0 }.size }.not_to raise_error
         end
       end
 
@@ -28,7 +28,7 @@ describe Hamster::List do
       ].each do |values, item, expected|
         context "looking for #{item.inspect} in #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].indices { |x| x == item }.should eql(L[*expected])
+            expect(L[*values].indices { |x| x == item }).to eql(L[*expected])
           end
         end
       end
@@ -38,7 +38,7 @@ describe Hamster::List do
       it "is lazy" do
         count = 0
         Hamster.stream { count += 1 }.indices(nil)
-        count.should <= 1
+        expect(count).to be <= 1
       end
 
       [
@@ -53,7 +53,7 @@ describe Hamster::List do
       ].each do |values, item, expected|
         context "looking for #{item.inspect} in #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].indices(item).should eql(L[*expected])
+            expect(L[*values].indices(item)).to eql(L[*expected])
           end
         end
       end

--- a/spec/lib/hamster/list/init_spec.rb
+++ b/spec/lib/hamster/list/init_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#init" do
     it "is lazy" do
-      -> { Hamster.stream { false }.init }.should_not raise_error
+      expect { Hamster.stream { false }.init }.not_to raise_error
     end
 
     [
@@ -17,11 +17,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.init
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns the list without the last element: #{expected.inspect}" do
-          list.init.should eql(L[*expected])
+          expect(list.init).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/inits_spec.rb
+++ b/spec/lib/hamster/list/inits_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#inits" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.inits }.should_not raise_error
+      expect { Hamster.stream { fail }.inits }.not_to raise_error
     end
 
     [
@@ -17,11 +17,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.inits
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.inits.should eql(L[*expected])
+          expect(list.inits).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/insert_spec.rb
+++ b/spec/lib/hamster/list/insert_spec.rb
@@ -7,33 +7,33 @@ describe Hamster::List do
 
     it "can add items at the beginning of a list" do
       list = original.insert(0, :a, :b)
-      list.size.should be(5)
-      list.at(0).should be(:a)
-      list.at(2).should be(1)
+      expect(list.size).to be(5)
+      expect(list.at(0)).to be(:a)
+      expect(list.at(2)).to be(1)
     end
 
     it "can add items in the middle of a list" do
       list = original.insert(1, :a, :b, :c)
-      list.size.should be(6)
-      list.to_a.should == [1, :a, :b, :c, 2, 3]
+      expect(list.size).to be(6)
+      expect(list.to_a).to eq([1, :a, :b, :c, 2, 3])
     end
 
     it "can add items at the end of a list" do
       list = original.insert(3, :a, :b, :c)
-      list.size.should be(6)
-      list.to_a.should == [1, 2, 3, :a, :b, :c]
+      expect(list.size).to be(6)
+      expect(list.to_a).to eq([1, 2, 3, :a, :b, :c])
     end
 
     it "can add items past the end of a list" do
       list = original.insert(6, :a, :b)
-      list.size.should be(8)
-      list.to_a.should == [1, 2, 3, nil, nil, nil, :a, :b]
+      expect(list.size).to be(8)
+      expect(list.to_a).to eq([1, 2, 3, nil, nil, nil, :a, :b])
     end
 
     it "accepts a negative index, which counts back from the end of the list" do
       list = original.insert(-2, :a)
-      list.size.should be(4)
-      list.to_a.should == [1, :a, 2, 3]
+      expect(list.size).to be(4)
+      expect(list.to_a).to eq([1, :a, 2, 3])
     end
 
     it "raises IndexError if a negative index is too great" do
@@ -41,7 +41,7 @@ describe Hamster::List do
     end
 
     it "is lazy" do
-      -> { Hamster.stream { fail }.insert(0, :a) }.should_not raise_error
+      expect { Hamster.stream { fail }.insert(0, :a) }.not_to raise_error
     end
   end
 end

--- a/spec/lib/hamster/list/inspect_spec.rb
+++ b/spec/lib/hamster/list/inspect_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#inspect" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).inspect }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).inspect }.not_to raise_error
       end
     end
 
@@ -18,11 +18,11 @@ describe Hamster::List do
         let(:list) { L[*values] }
 
         it "returns #{expected.inspect}" do
-          list.inspect.should == expected
+          expect(list.inspect).to eq(expected)
         end
 
         it "returns a string which can be eval'd to get an equivalent object" do
-          eval(list.inspect).should eql(list)
+          expect(eval(list.inspect)).to eql(list)
         end
       end
     end

--- a/spec/lib/hamster/list/intersperse_spec.rb
+++ b/spec/lib/hamster/list/intersperse_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#intersperse" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.intersperse("") }.should_not raise_error
+      expect { Hamster.stream { fail }.intersperse("") }.not_to raise_error
     end
 
     [
@@ -17,11 +17,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.intersperse("|")
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.intersperse("|").should eql(L[*expected])
+          expect(list.intersperse("|")).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/join_spec.rb
+++ b/spec/lib/hamster/list/join_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#join" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).join }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).join }.not_to raise_error
       end
     end
 
@@ -20,11 +20,11 @@ describe Hamster::List do
 
           it "preserves the original" do
             list.join("|")
-            list.should eql(L[*values])
+            expect(list).to eql(L[*values])
           end
 
           it "returns #{expected.inspect}" do
-            list.join("|").should == expected
+            expect(list.join("|")).to eq(expected)
           end
         end
       end
@@ -41,11 +41,11 @@ describe Hamster::List do
 
           it "preserves the original" do
             list.join
-            list.should eql(L[*values])
+            expect(list).to eql(L[*values])
           end
 
           it "returns #{expected.inspect}" do
-            list.join.should == expected
+            expect(list.join).to eq(expected)
           end
         end
       end
@@ -57,7 +57,7 @@ describe Hamster::List do
       after  { $, = nil }
 
       it "uses the default global separator" do
-        list.join.should == "A**B**C"
+        expect(list.join).to eq("A**B**C")
       end
     end
   end

--- a/spec/lib/hamster/list/last_spec.rb
+++ b/spec/lib/hamster/list/last_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#last" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).last }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).last }.not_to raise_error
       end
     end
 
@@ -16,7 +16,7 @@ describe Hamster::List do
     ].each do |values, expected|
       context "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          L[*values].last.should == expected
+          expect(L[*values].last).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/list/ltlt_spec.rb
+++ b/spec/lib/hamster/list/ltlt_spec.rb
@@ -5,15 +5,15 @@ describe Hamster::List do
   describe "#<<" do
     it "adds an item onto the end of a list" do
       list = L["a", "b"]
-      (list << "c").should eql(L["a", "b", "c"])
-      list.should eql(L["a", "b"])
+      expect(list << "c").to eql(L["a", "b", "c"])
+      expect(list).to eql(L["a", "b"])
     end
 
     context "on an empty list" do
       it "returns a list with one item" do
         list = L.empty
-        (list << "c").should eql(L["c"])
-        list.should eql(L.empty)
+        expect(list << "c").to eql(L["c"])
+        expect(list).to eql(L.empty)
       end
     end
   end

--- a/spec/lib/hamster/list/map_spec.rb
+++ b/spec/lib/hamster/list/map_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   [:map, :collect].each do |method|
     describe "##{method}" do
       it "is lazy" do
-        -> { Hamster.stream { fail }.map { |item| item } }.should_not raise_error
+        expect { Hamster.stream { fail }.map { |item| item } }.not_to raise_error
       end
 
       [
@@ -19,24 +19,24 @@ describe Hamster::List do
           context "with a block" do
             it "preserves the original" do
               list.send(method, &:downcase)
-              list.should eql(L[*values])
+              expect(list).to eql(L[*values])
             end
 
             it "returns #{expected.inspect}" do
-              list.send(method, &:downcase).should eql(L[*expected])
+              expect(list.send(method, &:downcase)).to eql(L[*expected])
             end
 
             it "is lazy" do
               count = 0
               list.send(method) { |item| count += 1 }
-              count.should <= 1
+              expect(count).to be <= 1
             end
           end
 
           context "without a block" do
             it "returns an Enumerator" do
-              list.send(method).class.should be(Enumerator)
-              list.send(method).each(&:downcase).should eql(L[*expected])
+              expect(list.send(method).class).to be(Enumerator)
+              expect(list.send(method).each(&:downcase)).to eql(L[*expected])
             end
           end
         end

--- a/spec/lib/hamster/list/maximum_spec.rb
+++ b/spec/lib/hamster/list/maximum_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#max" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).max }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).max }.not_to raise_error
       end
     end
 
@@ -17,7 +17,7 @@ describe Hamster::List do
       ].each do |values, expected|
         context "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].max { |maximum, item| maximum.length <=> item.length }.should == expected
+            expect(L[*values].max { |maximum, item| maximum.length <=> item.length }).to eq(expected)
           end
         end
       end
@@ -31,7 +31,7 @@ describe Hamster::List do
       ].each do |values, expected|
         context "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].max.should == expected
+            expect(L[*values].max).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/list/merge_by_spec.rb
+++ b/spec/lib/hamster/list/merge_by_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   context "without a comparator" do
     context "on an empty list" do
       it "returns an empty list" do
-        L.empty.merge_by.should be_empty
+        expect(L.empty.merge_by).to be_empty
       end
     end
 
@@ -13,7 +13,7 @@ describe Hamster::List do
       let(:list) { L[1, 2, 3] }
 
       it "returns the list" do
-        L[list].merge_by.should eql(list)
+        expect(L[list].merge_by).to eql(list)
       end
     end
 
@@ -21,7 +21,7 @@ describe Hamster::List do
       subject { L[L[3, 6, 7, 8], L[1, 2, 4, 5, 9]] }
 
       it "merges the lists based on natural sort order" do
-        subject.merge_by.should == L[1, 2, 3, 4, 5, 6, 7, 8, 9]
+        expect(subject.merge_by).to eq(L[1, 2, 3, 4, 5, 6, 7, 8, 9])
       end
     end
   end
@@ -29,7 +29,7 @@ describe Hamster::List do
   context "with a comparator" do
     context "on an empty list" do
       it "returns an empty list" do
-        L.empty.merge_by { |item| fail("should never be called") }.should be_empty
+        expect(L.empty.merge_by { |item| fail("should never be called") }).to be_empty
       end
     end
 
@@ -37,7 +37,7 @@ describe Hamster::List do
       let(:list) { L[1, 2, 3] }
 
       it "returns the list" do
-        L[list].merge_by { |item| -item }.should == L[1, 2, 3]
+        expect(L[list].merge_by { |item| -item }).to eq(L[1, 2, 3])
       end
     end
 
@@ -45,7 +45,7 @@ describe Hamster::List do
       subject { L[L[8, 7, 6, 3], L[9, 5, 4, 2, 1]] }
 
       it "merges the lists based on the specified transformer" do
-        subject.merge_by { |item| -item }.should == L[9, 8, 7, 6, 5, 4, 3, 2, 1]
+        expect(subject.merge_by { |item| -item }).to eq(L[9, 8, 7, 6, 5, 4, 3, 2, 1])
       end
     end
   end

--- a/spec/lib/hamster/list/merge_spec.rb
+++ b/spec/lib/hamster/list/merge_spec.rb
@@ -7,7 +7,7 @@ describe Hamster::List do
       subject { L.empty }
 
       it "returns an empty list" do
-        subject.merge.should be_empty
+        expect(subject.merge).to be_empty
       end
     end
 
@@ -17,7 +17,7 @@ describe Hamster::List do
       subject { L[list] }
 
       it "returns the list" do
-        subject.merge.should == list
+        expect(subject.merge).to eq(list)
       end
     end
 
@@ -25,7 +25,7 @@ describe Hamster::List do
       subject { L[L[3, 6, 7, 8], L[1, 2, 4, 5, 9]] }
 
       it "merges the lists based on natural sort order" do
-        subject.merge.should == L[1, 2, 3, 4, 5, 6, 7, 8, 9]
+        expect(subject.merge).to eq(L[1, 2, 3, 4, 5, 6, 7, 8, 9])
       end
     end
   end
@@ -35,7 +35,7 @@ describe Hamster::List do
       subject { L.empty }
 
       it "returns an empty list" do
-        subject.merge { |a, b| fail("should never be called") }.should be_empty
+        expect(subject.merge { |a, b| fail("should never be called") }).to be_empty
       end
     end
 
@@ -45,7 +45,7 @@ describe Hamster::List do
       subject { L[list] }
 
       it "returns the list" do
-        subject.merge { |a, b| fail("should never be called") }.should == list
+        expect(subject.merge { |a, b| fail("should never be called") }).to eq(list)
       end
     end
 
@@ -53,7 +53,7 @@ describe Hamster::List do
       subject { L[L[8, 7, 6, 3], L[9, 5, 4, 2, 1]] }
 
       it "merges the lists based on the specified comparator" do
-        subject.merge { |a, b| b <=> a }.should == L[9, 8, 7, 6, 5, 4, 3, 2, 1]
+        expect(subject.merge { |a, b| b <=> a }).to eq(L[9, 8, 7, 6, 5, 4, 3, 2, 1])
       end
     end
   end

--- a/spec/lib/hamster/list/minimum_spec.rb
+++ b/spec/lib/hamster/list/minimum_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#min" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).min }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).min }.not_to raise_error
       end
     end
 
@@ -17,7 +17,7 @@ describe Hamster::List do
       ].each do |values, expected|
         context "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].min { |minimum, item| minimum.length <=> item.length }.should == expected
+            expect(L[*values].min { |minimum, item| minimum.length <=> item.length }).to eq(expected)
           end
         end
       end
@@ -31,7 +31,7 @@ describe Hamster::List do
       ].each do |values, expected|
         context "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].min.should == expected
+            expect(L[*values].min).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/list/multithreading_spec.rb
+++ b/spec/lib/hamster/list/multithreading_spec.rb
@@ -15,8 +15,8 @@ describe Hamster::List do
     end
     threads.each(&:join)
 
-    counter.get.should == 10000
-    list.sum.should == 100010000
+    expect(counter.get).to eq(10000)
+    expect(list.sum).to eq(100010000)
   end
 
   it "doesn't go into an infinite loop if lazy list block raises an exception" do
@@ -24,7 +24,7 @@ describe Hamster::List do
 
     threads = 10.times.collect do
       Thread.new do
-        -> { list.head }.should raise_error(RuntimeError)
+        expect { list.head }.to raise_error(RuntimeError)
       end
     end
     threads.each(&:join)
@@ -43,6 +43,6 @@ describe Hamster::List do
     threads.each(&:join)
 
     elapsed = Time.now - start
-    elapsed.should_not > 0.3
+    expect(elapsed).not_to be > 0.3
   end
 end

--- a/spec/lib/hamster/list/none_spec.rb
+++ b/spec/lib/hamster/list/none_spec.rb
@@ -5,17 +5,17 @@ describe Hamster::List do
   describe "#none?" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).none? { false } }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).none? { false } }.not_to raise_error
       end
     end
 
     context "when empty" do
       it "with a block returns true" do
-        L.empty.none? {}.should == true
+        expect(L.empty.none? {}).to eq(true)
       end
 
       it "with no block returns true" do
-        L.empty.none?.should == true
+        expect(L.empty.none?).to eq(true)
       end
     end
 
@@ -25,22 +25,22 @@ describe Hamster::List do
 
         ["A", "B", "C", nil].each do |value|
           it "returns false if the block ever returns true (#{value.inspect})" do
-            list.none? { |item| item == value }.should == false
+            expect(list.none? { |item| item == value }).to eq(false)
           end
         end
 
         it "returns true if the block always returns false" do
-          list.none? { |item| item == "D" }.should == true
+          expect(list.none? { |item| item == "D" }).to eq(true)
         end
       end
 
       context "with no block" do
         it "returns false if any value is truthy" do
-          L[nil, false, true, "A"].none?.should == false
+          expect(L[nil, false, true, "A"].none?).to eq(false)
         end
 
         it "returns true if all values are falsey" do
-          L[nil, false].none?.should == true
+          expect(L[nil, false].none?).to eq(true)
         end
       end
     end

--- a/spec/lib/hamster/list/one_spec.rb
+++ b/spec/lib/hamster/list/one_spec.rb
@@ -5,17 +5,17 @@ describe Hamster::List do
   describe "#one?" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).one? { false } }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).one? { false } }.not_to raise_error
       end
     end
 
     context "when empty" do
       it "with a block returns false" do
-        L.empty.one? {}.should == false
+        expect(L.empty.one? {}).to eq(false)
       end
 
       it "with no block returns false" do
-        L.empty.one?.should == false
+        expect(L.empty.one?).to eq(false)
       end
     end
 
@@ -24,25 +24,25 @@ describe Hamster::List do
         let(:list) { L["A", "B", "C"] }
 
         it "returns false if the block returns true more than once" do
-          list.one? { |item| true }.should == false
+          expect(list.one? { |item| true }).to eq(false)
         end
 
         it "returns false if the block never returns true" do
-          list.one? { |item| false }.should == false
+          expect(list.one? { |item| false }).to eq(false)
         end
 
         it "returns true if the block only returns true once" do
-          list.one? { |item| item == "A" }.should == true
+          expect(list.one? { |item| item == "A" }).to eq(true)
         end
       end
 
       context "with no block" do
         it "returns false if more than one value is truthy" do
-          L[nil, true, "A"].one?.should == false
+          expect(L[nil, true, "A"].one?).to eq(false)
         end
 
         it "returns true if only one value is truthy" do
-          L[nil, true, false].one?.should == true
+          expect(L[nil, true, false].one?).to eq(true)
         end
       end
     end

--- a/spec/lib/hamster/list/partition_spec.rb
+++ b/spec/lib/hamster/list/partition_spec.rb
@@ -5,14 +5,14 @@ require "thread"
 describe Hamster::List do
   describe "#partition" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.partition }.should_not raise_error
+      expect { Hamster.stream { fail }.partition }.not_to raise_error
     end
 
     it "calls the passed block only once for each item" do
       count = 0
       a,b = L[1, 2, 3].partition { |item| count += 1; item.odd? }
-      (a.size + b.size).should be(3) # force realization of lazy lists
-      count.should be(3)
+      expect(a.size + b.size).to be(3) # force realization of lazy lists
+      expect(count).to be(3)
     end
 
     # note: Lists are not as lazy as they could be!
@@ -21,19 +21,19 @@ describe Hamster::List do
     it "returns a lazy list of items for which predicate is true" do
       count = 0
       a,b = L[1, 2, 3, 4].partition { |item| count += 1; item.odd? }
-      a.take(1).should == [1]
-      count.should be(3) # would be 1 if lists were lazier
-      a.take(2).should == [1, 3]
-      count.should be(4) # would be 3 if lists were lazier
+      expect(a.take(1)).to eq([1])
+      expect(count).to be(3) # would be 1 if lists were lazier
+      expect(a.take(2)).to eq([1, 3])
+      expect(count).to be(4) # would be 3 if lists were lazier
     end
 
     it "returns a lazy list of items for which predicate is false" do
       count = 0
       a,b = L[1, 2, 3, 4].partition { |item| count += 1; item.odd? }
-      b.take(1).should == [2]
-      count.should be(4) # would be 2 if lists were lazier
-      b.take(2).should == [2, 4]
-      count.should be(4)
+      expect(b.take(1)).to eq([2])
+      expect(count).to be(4) # would be 2 if lists were lazier
+      expect(b.take(2)).to eq([2, 4])
+      expect(count).to be(4)
     end
 
     it "calls the passed block only once for each item, even with multiple threads" do
@@ -54,17 +54,17 @@ describe Hamster::List do
           # make sure that only one thread will run the above "iterate" block at a
           # time, regardless
           if i % 2 == 0
-            left.take(100).sum.should == 10000
+            expect(left.take(100).sum).to eq(10000)
           else
-            right.take(100).sum.should == 9900
+            expect(right.take(100).sum).to eq(9900)
           end
         end
       end.each(&:join)
 
       # if no threads "stepped on" each other, the following should be true
       # make some allowance for "lazy" lists which actually realize a little bit ahead:
-      (200..203).include?(yielded.size).should == true
-      yielded.should == (0..(yielded.size-1)).to_a
+      expect((200..203).include?(yielded.size)).to eq(true)
+      expect(yielded).to eq((0..(yielded.size-1)).to_a)
     end
 
     [
@@ -86,28 +86,28 @@ describe Hamster::List do
           let(:remainder) { result.last }
 
           it "preserves the original" do
-            list.should eql(L[*values])
+            expect(list).to eql(L[*values])
           end
 
           it "returns a frozen array with two items" do
-            result.class.should be(Array)
-            result.should be_frozen
-            result.size.should be(2)
+            expect(result.class).to be(Array)
+            expect(result).to be_frozen
+            expect(result.size).to be(2)
           end
 
           it "correctly identifies the matches" do
-            matches.should eql(L[*expected_matches])
+            expect(matches).to eql(L[*expected_matches])
           end
 
           it "correctly identifies the remainder" do
-            remainder.should eql(L[*expected_remainder])
+            expect(remainder).to eql(L[*expected_remainder])
           end
         end
 
         context "without a block" do
           it "returns an Enumerator" do
-            list.partition.class.should be(Enumerator)
-            list.partition.each(&:odd?).should eql([L[*expected_matches], L[*expected_remainder]])
+            expect(list.partition.class).to be(Enumerator)
+            expect(list.partition.each(&:odd?)).to eql([L[*expected_matches], L[*expected_remainder]])
           end
         end
       end

--- a/spec/lib/hamster/list/permutation_spec.rb
+++ b/spec/lib/hamster/list/permutation_spec.rb
@@ -7,49 +7,49 @@ describe Hamster::List do
 
     context "with no block" do
       it "returns an Enumerator" do
-        list.permutation.class.should be(Enumerator)
-        list.permutation.to_a.sort.should == [1,2,3,4].permutation.to_a.sort
+        expect(list.permutation.class).to be(Enumerator)
+        expect(list.permutation.to_a.sort).to eq([1,2,3,4].permutation.to_a.sort)
       end
     end
 
     context "with no argument" do
       it "yields all permutations of the list" do
         perms = list.permutation.to_a
-        perms.size.should be(24)
-        perms.sort.should == [1,2,3,4].permutation.to_a.sort
-        perms.each { |item| item.should be_kind_of(Hamster::List) }
+        expect(perms.size).to be(24)
+        expect(perms.sort).to eq([1,2,3,4].permutation.to_a.sort)
+        perms.each { |item| expect(item).to be_kind_of(Hamster::List) }
       end
     end
 
     context "with a length argument" do
       it "yields all N-size permutations of the list" do
         perms = list.permutation(2).to_a
-        perms.size.should be(12)
-        perms.sort.should == [1,2,3,4].permutation(2).to_a.sort
-        perms.each { |item| item.should be_kind_of(Hamster::List) }
+        expect(perms.size).to be(12)
+        expect(perms.sort).to eq([1,2,3,4].permutation(2).to_a.sort)
+        perms.each { |item| expect(item).to be_kind_of(Hamster::List) }
       end
     end
 
     context "with a length argument greater than length of list" do
       it "yields nothing" do
-        list.permutation(5).to_a.should be_empty
+        expect(list.permutation(5).to_a).to be_empty
       end
     end
 
     context "with a length argument of 0" do
       it "yields an empty list" do
         perms = list.permutation(0).to_a
-        perms.size.should be(1)
-        perms[0].should be_kind_of(Hamster::List)
-        perms[0].should be_empty
+        expect(perms.size).to be(1)
+        expect(perms[0]).to be_kind_of(Hamster::List)
+        expect(perms[0]).to be_empty
       end
     end
 
     context "with a block" do
       it "returns the original list" do
-        list.permutation(0) {}.should be(list)
-        list.permutation(1) {}.should be(list)
-        list.permutation {}.should be(list)
+        expect(list.permutation(0) {}).to be(list)
+        expect(list.permutation(1) {}).to be(list)
+        expect(list.permutation {}).to be(list)
       end
     end
   end

--- a/spec/lib/hamster/list/product_spec.rb
+++ b/spec/lib/hamster/list/product_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#product" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).product }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).product }.not_to raise_error
       end
     end
 
@@ -16,7 +16,7 @@ describe Hamster::List do
     ].each do |values, expected|
       context "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          L[*values].product.should == expected
+          expect(L[*values].product).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/list/reduce_spec.rb
+++ b/spec/lib/hamster/list/reduce_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::List do
     describe "##{method}" do
       context "on a really big list" do
         it "doesn't run out of stack" do
-          -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method, &:+) }.should_not raise_error
+          expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).send(method, &:+) }.not_to raise_error
         end
       end
 
@@ -18,7 +18,7 @@ describe Hamster::List do
         context "on #{values.inspect}" do
           context "with an initial value of #{initial} and a block" do
             it "returns #{expected.inspect}" do
-              L[*values].send(method, initial) { |memo, item| memo - item }.should == expected
+              expect(L[*values].send(method, initial) { |memo, item| memo - item }).to eq(expected)
             end
           end
         end
@@ -32,7 +32,7 @@ describe Hamster::List do
         context "on #{values.inspect}" do
           context "with no initial value and a block" do
             it "returns #{expected.inspect}" do
-              L[*values].send(method) { |memo, item| memo - item }.should == expected
+              expect(L[*values].send(method) { |memo, item| memo - item }).to eq(expected)
             end
           end
         end
@@ -40,13 +40,13 @@ describe Hamster::List do
 
       context "with no block and a symbol argument" do
         it "uses the symbol as the name of a method to reduce with" do
-          L[1, 2, 3].send(method, :+).should == 6
+          expect(L[1, 2, 3].send(method, :+)).to eq(6)
         end
       end
 
       context "with no block and a string argument" do
         it "uses the string as the name of a method to reduce with" do
-          L[1, 2, 3].send(method, '+').should == 6
+          expect(L[1, 2, 3].send(method, '+')).to eq(6)
         end
       end
     end

--- a/spec/lib/hamster/list/reject_spec.rb
+++ b/spec/lib/hamster/list/reject_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   [:reject, :delete_if].each do |method|
     describe "##{method}" do
       it "is lazy" do
-        -> { Hamster.stream { fail }.send(method) { |item| false } }.should_not raise_error
+        expect { Hamster.stream { fail }.send(method) { |item| false } }.not_to raise_error
       end
 
       [
@@ -20,7 +20,7 @@ describe Hamster::List do
 
           context "with a block" do
             it "returns #{expected.inspect}" do
-              list.send(method) { |item| item == item.downcase }.should eql(L[*expected])
+              expect(list.send(method) { |item| item == item.downcase }).to eql(L[*expected])
             end
 
             it "is lazy" do
@@ -29,14 +29,14 @@ describe Hamster::List do
                 count += 1
                 false
               end
-              count.should <= 1
+              expect(count).to be <= 1
             end
           end
 
           context "without a block" do
             it "returns an Enumerator" do
-              list.send(method).class.should be(Enumerator)
-              list.send(method).each { |item| item == item.downcase }.should eql(L[*expected])
+              expect(list.send(method).class).to be(Enumerator)
+              expect(list.send(method).each { |item| item == item.downcase }).to eql(L[*expected])
             end
           end
         end

--- a/spec/lib/hamster/list/reverse_spec.rb
+++ b/spec/lib/hamster/list/reverse_spec.rb
@@ -5,12 +5,12 @@ describe Hamster::List do
   describe "#reverse" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).reverse }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).reverse }.not_to raise_error
       end
     end
 
     it "is lazy" do
-      -> { Hamster.stream { fail }.reverse }.should_not raise_error
+      expect { Hamster.stream { fail }.reverse }.not_to raise_error
     end
 
     [
@@ -23,11 +23,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.reverse { |item| item.downcase }
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.reverse { |item| item.downcase }.should == L[*expected]
+          expect(list.reverse { |item| item.downcase }).to eq(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/rotate_spec.rb
+++ b/spec/lib/hamster/list/rotate_spec.rb
@@ -7,30 +7,30 @@ describe Hamster::List do
 
     context "when passed no argument" do
       it "returns a new list with the first element moved to the end" do
-        list.rotate.should eql(L[2,3,4,5,1])
+        expect(list.rotate).to eql(L[2,3,4,5,1])
       end
     end
 
     context "with an integral argument n" do
       it "returns a new list with the first (n % size) elements moved to the end" do
-        list.rotate(2).should eql(L[3,4,5,1,2])
-        list.rotate(3).should eql(L[4,5,1,2,3])
-        list.rotate(4).should eql(L[5,1,2,3,4])
-        list.rotate(5).should eql(L[1,2,3,4,5])
-        list.rotate(-1).should eql(L[5,1,2,3,4])
+        expect(list.rotate(2)).to eql(L[3,4,5,1,2])
+        expect(list.rotate(3)).to eql(L[4,5,1,2,3])
+        expect(list.rotate(4)).to eql(L[5,1,2,3,4])
+        expect(list.rotate(5)).to eql(L[1,2,3,4,5])
+        expect(list.rotate(-1)).to eql(L[5,1,2,3,4])
       end
     end
 
     context "with a non-numeric argument" do
       it "raises a TypeError" do
-        -> { list.rotate('hello') }.should raise_error(TypeError)
+        expect { list.rotate('hello') }.to raise_error(TypeError)
       end
     end
 
     context "with an argument of zero (or one evenly divisible by list length)" do
       it "it returns self" do
-        list.rotate(0).should be(list)
-        list.rotate(5).should be(list)
+        expect(list.rotate(0)).to be(list)
+        expect(list.rotate(5)).to be(list)
       end
     end
   end

--- a/spec/lib/hamster/list/sample_spec.rb
+++ b/spec/lib/hamster/list/sample_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::List do
 
     it "returns a randomly chosen item" do
       chosen = 100.times.map { list.sample }
-      chosen.each { |item| list.include?(item).should == true }
-      list.each { |item| chosen.include?(item).should == true }
+      chosen.each { |item| expect(list.include?(item)).to eq(true) }
+      list.each { |item| expect(chosen.include?(item)).to eq(true) }
     end
   end
 end

--- a/spec/lib/hamster/list/size_spec.rb
+++ b/spec/lib/hamster/list/size_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::List do
     describe "##{method}" do
       context "on a really big list" do
         it "doesn't run out of stack" do
-          -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).size }.should_not raise_error
+          expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).size }.not_to raise_error
         end
       end
 
@@ -17,7 +17,7 @@ describe Hamster::List do
       ].each do |values, expected|
         context "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            L[*values].send(method).should == expected
+            expect(L[*values].send(method)).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/list/slice_spec.rb
+++ b/spec/lib/hamster/list/slice_spec.rb
@@ -9,212 +9,212 @@ describe Hamster::List do
     describe "##{method}" do
       context "when passed a positive integral index" do
         it "returns the element at that index" do
-          list.send(method, 0).should be(1)
-          list.send(method, 1).should be(2)
-          list.send(method, 2).should be(3)
-          list.send(method, 3).should be(4)
-          list.send(method, 4).should be(nil)
-          list.send(method, 10).should be(nil)
+          expect(list.send(method, 0)).to be(1)
+          expect(list.send(method, 1)).to be(2)
+          expect(list.send(method, 2)).to be(3)
+          expect(list.send(method, 3)).to be(4)
+          expect(list.send(method, 4)).to be(nil)
+          expect(list.send(method, 10)).to be(nil)
 
-          big.send(method, 0).should be(1)
-          big.send(method, 9999).should be(10000)
+          expect(big.send(method, 0)).to be(1)
+          expect(big.send(method, 9999)).to be(10000)
         end
 
         it "leaves the original unchanged" do
-          list.should eql(L[1,2,3,4])
+          expect(list).to eql(L[1,2,3,4])
         end
       end
 
       context "when passed a negative integral index" do
         it "returns the element which is number (index.abs) counting from the end of the list" do
-          list.send(method, -1).should be(4)
-          list.send(method, -2).should be(3)
-          list.send(method, -3).should be(2)
-          list.send(method, -4).should be(1)
-          list.send(method, -5).should be(nil)
-          list.send(method, -10).should be(nil)
+          expect(list.send(method, -1)).to be(4)
+          expect(list.send(method, -2)).to be(3)
+          expect(list.send(method, -3)).to be(2)
+          expect(list.send(method, -4)).to be(1)
+          expect(list.send(method, -5)).to be(nil)
+          expect(list.send(method, -10)).to be(nil)
 
-          big.send(method, -1).should be(10000)
-          big.send(method, -10000).should be(1)
+          expect(big.send(method, -1)).to be(10000)
+          expect(big.send(method, -10000)).to be(1)
         end
       end
 
       context "when passed a positive integral index and count" do
         it "returns 'count' elements starting from 'index'" do
-          list.send(method, 0, 0).should eql(L.empty)
-          list.send(method, 0, 1).should eql(L[1])
-          list.send(method, 0, 2).should eql(L[1,2])
-          list.send(method, 0, 4).should eql(L[1,2,3,4])
-          list.send(method, 0, 6).should eql(L[1,2,3,4])
-          list.send(method, 0, -1).should be_nil
-          list.send(method, 0, -2).should be_nil
-          list.send(method, 0, -4).should be_nil
-          list.send(method, 2, 0).should eql(L.empty)
-          list.send(method, 2, 1).should eql(L[3])
-          list.send(method, 2, 2).should eql(L[3,4])
-          list.send(method, 2, 4).should eql(L[3,4])
-          list.send(method, 2, -1).should be_nil
-          list.send(method, 4, 0).should eql(L.empty)
-          list.send(method, 4, 2).should eql(L.empty)
-          list.send(method, 4, -1).should be_nil
-          list.send(method, 5, 0).should be_nil
-          list.send(method, 5, 2).should be_nil
-          list.send(method, 5, -1).should be_nil
-          list.send(method, 6, 0).should be_nil
-          list.send(method, 6, 2).should be_nil
-          list.send(method, 6, -1).should be_nil
+          expect(list.send(method, 0, 0)).to eql(L.empty)
+          expect(list.send(method, 0, 1)).to eql(L[1])
+          expect(list.send(method, 0, 2)).to eql(L[1,2])
+          expect(list.send(method, 0, 4)).to eql(L[1,2,3,4])
+          expect(list.send(method, 0, 6)).to eql(L[1,2,3,4])
+          expect(list.send(method, 0, -1)).to be_nil
+          expect(list.send(method, 0, -2)).to be_nil
+          expect(list.send(method, 0, -4)).to be_nil
+          expect(list.send(method, 2, 0)).to eql(L.empty)
+          expect(list.send(method, 2, 1)).to eql(L[3])
+          expect(list.send(method, 2, 2)).to eql(L[3,4])
+          expect(list.send(method, 2, 4)).to eql(L[3,4])
+          expect(list.send(method, 2, -1)).to be_nil
+          expect(list.send(method, 4, 0)).to eql(L.empty)
+          expect(list.send(method, 4, 2)).to eql(L.empty)
+          expect(list.send(method, 4, -1)).to be_nil
+          expect(list.send(method, 5, 0)).to be_nil
+          expect(list.send(method, 5, 2)).to be_nil
+          expect(list.send(method, 5, -1)).to be_nil
+          expect(list.send(method, 6, 0)).to be_nil
+          expect(list.send(method, 6, 2)).to be_nil
+          expect(list.send(method, 6, -1)).to be_nil
 
-          big.send(method, 0, 3).should eql(L[1,2,3])
-          big.send(method, 1023, 4).should eql(L[1024,1025,1026,1027])
-          big.send(method, 1024, 4).should eql(L[1025,1026,1027,1028])
+          expect(big.send(method, 0, 3)).to eql(L[1,2,3])
+          expect(big.send(method, 1023, 4)).to eql(L[1024,1025,1026,1027])
+          expect(big.send(method, 1024, 4)).to eql(L[1025,1026,1027,1028])
         end
 
         it "leaves the original unchanged" do
-          list.should eql(L[1,2,3,4])
+          expect(list).to eql(L[1,2,3,4])
         end
       end
 
       context "when passed a negative integral index and count" do
         it "returns 'count' elements, starting from index which is number 'index.abs' counting from the end of the array" do
-          list.send(method, -1, 0).should eql(L.empty)
-          list.send(method, -1, 1).should eql(L[4])
-          list.send(method, -1, 2).should eql(L[4])
-          list.send(method, -1, -1).should be_nil
-          list.send(method, -2, 0).should eql(L.empty)
-          list.send(method, -2, 1).should eql(L[3])
-          list.send(method, -2, 2).should eql(L[3,4])
-          list.send(method, -2, 4).should eql(L[3,4])
-          list.send(method, -2, -1).should be_nil
-          list.send(method, -4, 0).should eql(L.empty)
-          list.send(method, -4, 1).should eql(L[1])
-          list.send(method, -4, 2).should eql(L[1,2])
-          list.send(method, -4, 4).should eql(L[1,2,3,4])
-          list.send(method, -4, 6).should eql(L[1,2,3,4])
-          list.send(method, -4, -1).should be_nil
-          list.send(method, -5, 0).should be_nil
-          list.send(method, -5, 1).should be_nil
-          list.send(method, -5, 10).should be_nil
-          list.send(method, -5, -1).should be_nil
+          expect(list.send(method, -1, 0)).to eql(L.empty)
+          expect(list.send(method, -1, 1)).to eql(L[4])
+          expect(list.send(method, -1, 2)).to eql(L[4])
+          expect(list.send(method, -1, -1)).to be_nil
+          expect(list.send(method, -2, 0)).to eql(L.empty)
+          expect(list.send(method, -2, 1)).to eql(L[3])
+          expect(list.send(method, -2, 2)).to eql(L[3,4])
+          expect(list.send(method, -2, 4)).to eql(L[3,4])
+          expect(list.send(method, -2, -1)).to be_nil
+          expect(list.send(method, -4, 0)).to eql(L.empty)
+          expect(list.send(method, -4, 1)).to eql(L[1])
+          expect(list.send(method, -4, 2)).to eql(L[1,2])
+          expect(list.send(method, -4, 4)).to eql(L[1,2,3,4])
+          expect(list.send(method, -4, 6)).to eql(L[1,2,3,4])
+          expect(list.send(method, -4, -1)).to be_nil
+          expect(list.send(method, -5, 0)).to be_nil
+          expect(list.send(method, -5, 1)).to be_nil
+          expect(list.send(method, -5, 10)).to be_nil
+          expect(list.send(method, -5, -1)).to be_nil
 
-          big.send(method, -1, 1).should eql(L[10000])
-          big.send(method, -1, 2).should eql(L[10000])
-          big.send(method, -6, 2).should eql(L[9995,9996])
+          expect(big.send(method, -1, 1)).to eql(L[10000])
+          expect(big.send(method, -1, 2)).to eql(L[10000])
+          expect(big.send(method, -6, 2)).to eql(L[9995,9996])
         end
       end
 
       context "when passed a Range" do
         it "returns the elements whose indexes are within the given Range" do
-          list.send(method, 0..-1).should eql(L[1,2,3,4])
-          list.send(method, 0..-10).should eql(L.empty)
-          list.send(method, 0..0).should eql(L[1])
-          list.send(method, 0..1).should eql(L[1,2])
-          list.send(method, 0..2).should eql(L[1,2,3])
-          list.send(method, 0..3).should eql(L[1,2,3,4])
-          list.send(method, 0..4).should eql(L[1,2,3,4])
-          list.send(method, 0..10).should eql(L[1,2,3,4])
-          list.send(method, 2..-10).should eql(L.empty)
-          list.send(method, 2..0).should eql(L.empty)
-          list.send(method, 2..2).should eql(L[3])
-          list.send(method, 2..3).should eql(L[3,4])
-          list.send(method, 2..4).should eql(L[3,4])
-          list.send(method, 3..0).should eql(L.empty)
-          list.send(method, 3..3).should eql(L[4])
-          list.send(method, 3..4).should eql(L[4])
-          list.send(method, 4..0).should eql(L.empty)
-          list.send(method, 4..4).should eql(L.empty)
-          list.send(method, 4..5).should eql(L.empty)
-          list.send(method, 5..0).should be_nil
-          list.send(method, 5..5).should be_nil
-          list.send(method, 5..6).should be_nil
+          expect(list.send(method, 0..-1)).to eql(L[1,2,3,4])
+          expect(list.send(method, 0..-10)).to eql(L.empty)
+          expect(list.send(method, 0..0)).to eql(L[1])
+          expect(list.send(method, 0..1)).to eql(L[1,2])
+          expect(list.send(method, 0..2)).to eql(L[1,2,3])
+          expect(list.send(method, 0..3)).to eql(L[1,2,3,4])
+          expect(list.send(method, 0..4)).to eql(L[1,2,3,4])
+          expect(list.send(method, 0..10)).to eql(L[1,2,3,4])
+          expect(list.send(method, 2..-10)).to eql(L.empty)
+          expect(list.send(method, 2..0)).to eql(L.empty)
+          expect(list.send(method, 2..2)).to eql(L[3])
+          expect(list.send(method, 2..3)).to eql(L[3,4])
+          expect(list.send(method, 2..4)).to eql(L[3,4])
+          expect(list.send(method, 3..0)).to eql(L.empty)
+          expect(list.send(method, 3..3)).to eql(L[4])
+          expect(list.send(method, 3..4)).to eql(L[4])
+          expect(list.send(method, 4..0)).to eql(L.empty)
+          expect(list.send(method, 4..4)).to eql(L.empty)
+          expect(list.send(method, 4..5)).to eql(L.empty)
+          expect(list.send(method, 5..0)).to be_nil
+          expect(list.send(method, 5..5)).to be_nil
+          expect(list.send(method, 5..6)).to be_nil
 
-          big.send(method, 159..162).should eql(L[160,161,162,163])
-          big.send(method, 160..162).should eql(L[161,162,163])
-          big.send(method, 161..162).should eql(L[162,163])
-          big.send(method, 9999..10100).should eql(L[10000])
-          big.send(method, 10000..10100).should eql(L.empty)
-          big.send(method, 10001..10100).should be_nil
+          expect(big.send(method, 159..162)).to eql(L[160,161,162,163])
+          expect(big.send(method, 160..162)).to eql(L[161,162,163])
+          expect(big.send(method, 161..162)).to eql(L[162,163])
+          expect(big.send(method, 9999..10100)).to eql(L[10000])
+          expect(big.send(method, 10000..10100)).to eql(L.empty)
+          expect(big.send(method, 10001..10100)).to be_nil
 
-          list.send(method, 0...-1).should eql(L[1,2,3])
-          list.send(method, 0...-10).should eql(L.empty)
-          list.send(method, 0...0).should eql(L.empty)
-          list.send(method, 0...1).should eql(L[1])
-          list.send(method, 0...2).should eql(L[1,2])
-          list.send(method, 0...3).should eql(L[1,2,3])
-          list.send(method, 0...4).should eql(L[1,2,3,4])
-          list.send(method, 0...10).should eql(L[1,2,3,4])
-          list.send(method, 2...-10).should eql(L.empty)
-          list.send(method, 2...0).should eql(L.empty)
-          list.send(method, 2...2).should eql(L.empty)
-          list.send(method, 2...3).should eql(L[3])
-          list.send(method, 2...4).should eql(L[3,4])
-          list.send(method, 3...0).should eql(L.empty)
-          list.send(method, 3...3).should eql(L.empty)
-          list.send(method, 3...4).should eql(L[4])
-          list.send(method, 4...0).should eql(L.empty)
-          list.send(method, 4...4).should eql(L.empty)
-          list.send(method, 4...5).should eql(L.empty)
-          list.send(method, 5...0).should be_nil
-          list.send(method, 5...5).should be_nil
-          list.send(method, 5...6).should be_nil
+          expect(list.send(method, 0...-1)).to eql(L[1,2,3])
+          expect(list.send(method, 0...-10)).to eql(L.empty)
+          expect(list.send(method, 0...0)).to eql(L.empty)
+          expect(list.send(method, 0...1)).to eql(L[1])
+          expect(list.send(method, 0...2)).to eql(L[1,2])
+          expect(list.send(method, 0...3)).to eql(L[1,2,3])
+          expect(list.send(method, 0...4)).to eql(L[1,2,3,4])
+          expect(list.send(method, 0...10)).to eql(L[1,2,3,4])
+          expect(list.send(method, 2...-10)).to eql(L.empty)
+          expect(list.send(method, 2...0)).to eql(L.empty)
+          expect(list.send(method, 2...2)).to eql(L.empty)
+          expect(list.send(method, 2...3)).to eql(L[3])
+          expect(list.send(method, 2...4)).to eql(L[3,4])
+          expect(list.send(method, 3...0)).to eql(L.empty)
+          expect(list.send(method, 3...3)).to eql(L.empty)
+          expect(list.send(method, 3...4)).to eql(L[4])
+          expect(list.send(method, 4...0)).to eql(L.empty)
+          expect(list.send(method, 4...4)).to eql(L.empty)
+          expect(list.send(method, 4...5)).to eql(L.empty)
+          expect(list.send(method, 5...0)).to be_nil
+          expect(list.send(method, 5...5)).to be_nil
+          expect(list.send(method, 5...6)).to be_nil
 
-          big.send(method, 159...162).should eql(L[160,161,162])
-          big.send(method, 160...162).should eql(L[161,162])
-          big.send(method, 161...162).should eql(L[162])
-          big.send(method, 9999...10100).should eql(L[10000])
-          big.send(method, 10000...10100).should eql(L.empty)
-          big.send(method, 10001...10100).should be_nil
+          expect(big.send(method, 159...162)).to eql(L[160,161,162])
+          expect(big.send(method, 160...162)).to eql(L[161,162])
+          expect(big.send(method, 161...162)).to eql(L[162])
+          expect(big.send(method, 9999...10100)).to eql(L[10000])
+          expect(big.send(method, 10000...10100)).to eql(L.empty)
+          expect(big.send(method, 10001...10100)).to be_nil
 
-          list.send(method, -1..-1).should eql(L[4])
-          list.send(method, -1...-1).should eql(L.empty)
-          list.send(method, -1..3).should eql(L[4])
-          list.send(method, -1...3).should eql(L.empty)
-          list.send(method, -1..4).should eql(L[4])
-          list.send(method, -1...4).should eql(L[4])
-          list.send(method, -1..10).should eql(L[4])
-          list.send(method, -1...10).should eql(L[4])
-          list.send(method, -1..0).should eql(L.empty)
-          list.send(method, -1..-4).should eql(L.empty)
-          list.send(method, -1...-4).should eql(L.empty)
-          list.send(method, -1..-6).should eql(L.empty)
-          list.send(method, -1...-6).should eql(L.empty)
-          list.send(method, -2..-2).should eql(L[3])
-          list.send(method, -2...-2).should eql(L.empty)
-          list.send(method, -2..-1).should eql(L[3,4])
-          list.send(method, -2...-1).should eql(L[3])
-          list.send(method, -2..10).should eql(L[3,4])
-          list.send(method, -2...10).should eql(L[3,4])
+          expect(list.send(method, -1..-1)).to eql(L[4])
+          expect(list.send(method, -1...-1)).to eql(L.empty)
+          expect(list.send(method, -1..3)).to eql(L[4])
+          expect(list.send(method, -1...3)).to eql(L.empty)
+          expect(list.send(method, -1..4)).to eql(L[4])
+          expect(list.send(method, -1...4)).to eql(L[4])
+          expect(list.send(method, -1..10)).to eql(L[4])
+          expect(list.send(method, -1...10)).to eql(L[4])
+          expect(list.send(method, -1..0)).to eql(L.empty)
+          expect(list.send(method, -1..-4)).to eql(L.empty)
+          expect(list.send(method, -1...-4)).to eql(L.empty)
+          expect(list.send(method, -1..-6)).to eql(L.empty)
+          expect(list.send(method, -1...-6)).to eql(L.empty)
+          expect(list.send(method, -2..-2)).to eql(L[3])
+          expect(list.send(method, -2...-2)).to eql(L.empty)
+          expect(list.send(method, -2..-1)).to eql(L[3,4])
+          expect(list.send(method, -2...-1)).to eql(L[3])
+          expect(list.send(method, -2..10)).to eql(L[3,4])
+          expect(list.send(method, -2...10)).to eql(L[3,4])
 
-          big.send(method, -1..-1).should eql(L[10000])
-          big.send(method, -1..9999).should eql(L[10000])
-          big.send(method, -1...9999).should eql(L.empty)
-          big.send(method, -2...9999).should eql(L[9999])
-          big.send(method, -2..-1).should eql(L[9999,10000])
+          expect(big.send(method, -1..-1)).to eql(L[10000])
+          expect(big.send(method, -1..9999)).to eql(L[10000])
+          expect(big.send(method, -1...9999)).to eql(L.empty)
+          expect(big.send(method, -2...9999)).to eql(L[9999])
+          expect(big.send(method, -2..-1)).to eql(L[9999,10000])
 
-          list.send(method, -4..-4).should eql(L[1])
-          list.send(method, -4..-2).should eql(L[1,2,3])
-          list.send(method, -4...-2).should eql(L[1,2])
-          list.send(method, -4..-1).should eql(L[1,2,3,4])
-          list.send(method, -4...-1).should eql(L[1,2,3])
-          list.send(method, -4..3).should eql(L[1,2,3,4])
-          list.send(method, -4...3).should eql(L[1,2,3])
-          list.send(method, -4..4).should eql(L[1,2,3,4])
-          list.send(method, -4...4).should eql(L[1,2,3,4])
-          list.send(method, -4..0).should eql(L[1])
-          list.send(method, -4...0).should eql(L.empty)
-          list.send(method, -4..1).should eql(L[1,2])
-          list.send(method, -4...1).should eql(L[1])
+          expect(list.send(method, -4..-4)).to eql(L[1])
+          expect(list.send(method, -4..-2)).to eql(L[1,2,3])
+          expect(list.send(method, -4...-2)).to eql(L[1,2])
+          expect(list.send(method, -4..-1)).to eql(L[1,2,3,4])
+          expect(list.send(method, -4...-1)).to eql(L[1,2,3])
+          expect(list.send(method, -4..3)).to eql(L[1,2,3,4])
+          expect(list.send(method, -4...3)).to eql(L[1,2,3])
+          expect(list.send(method, -4..4)).to eql(L[1,2,3,4])
+          expect(list.send(method, -4...4)).to eql(L[1,2,3,4])
+          expect(list.send(method, -4..0)).to eql(L[1])
+          expect(list.send(method, -4...0)).to eql(L.empty)
+          expect(list.send(method, -4..1)).to eql(L[1,2])
+          expect(list.send(method, -4...1)).to eql(L[1])
 
-          list.send(method, -5..-5).should be_nil
-          list.send(method, -5...-5).should be_nil
-          list.send(method, -5..-4).should be_nil
-          list.send(method, -5..-1).should be_nil
-          list.send(method, -5..10).should be_nil
+          expect(list.send(method, -5..-5)).to be_nil
+          expect(list.send(method, -5...-5)).to be_nil
+          expect(list.send(method, -5..-4)).to be_nil
+          expect(list.send(method, -5..-1)).to be_nil
+          expect(list.send(method, -5..10)).to be_nil
 
-          big.send(method, -10001..-1).should be_nil
+          expect(big.send(method, -10001..-1)).to be_nil
         end
 
         it "leaves the original unchanged" do
-          list.should eql(L[1,2,3,4])
+          expect(list).to eql(L[1,2,3,4])
         end
       end
     end
@@ -222,8 +222,8 @@ describe Hamster::List do
     context "when passed a subclass of Range" do
       it "works the same as with a Range" do
         subclass = Class.new(Range)
-        list.send(method, subclass.new(1,2)).should eql(L[2,3])
-        list.send(method, subclass.new(-3,-1,true)).should eql(L[2,3])
+        expect(list.send(method, subclass.new(1,2))).to eql(L[2,3])
+        expect(list.send(method, subclass.new(-3,-1,true))).to eql(L[2,3])
       end
     end
   end

--- a/spec/lib/hamster/list/sorting_spec.rb
+++ b/spec/lib/hamster/list/sorting_spec.rb
@@ -8,7 +8,7 @@ describe Hamster::List do
   ].each do |method, comparator|
     describe "##{method}" do
       it "is lazy" do
-        -> { Hamster.stream { fail }.send(method, &comparator) }.should_not raise_error
+        expect { Hamster.stream { fail }.send(method, &comparator) }.not_to raise_error
       end
 
       [
@@ -22,22 +22,22 @@ describe Hamster::List do
           context "with a block" do
             it "preserves the original" do
               list.send(method, &comparator)
-              list.should == L[*values]
+              expect(list).to eq(L[*values])
             end
 
             it "returns #{expected.inspect}" do
-              list.send(method, &comparator).should == L[*expected]
+              expect(list.send(method, &comparator)).to eq(L[*expected])
             end
           end
 
           context "without a block" do
             it "preserves the original" do
               list.send(method)
-              list.should eql(L[*values])
+              expect(list).to eql(L[*values])
             end
 
             it "returns #{expected.sort.inspect}" do
-              list.send(method).should == L[*expected.sort]
+              expect(list.send(method)).to eq(L[*expected.sort])
             end
           end
         end

--- a/spec/lib/hamster/list/span_spec.rb
+++ b/spec/lib/hamster/list/span_spec.rb
@@ -3,7 +3,7 @@ require "hamster/list"
 
 describe "Hamster::list#span" do
   it "is lazy" do
-    -> { Hamster.stream { |item| fail }.span { true } }.should_not raise_error
+    expect { Hamster.stream { |item| fail }.span { true } }.not_to raise_error
   end
 
   describe <<-DESC do
@@ -34,41 +34,41 @@ DESC
 
           it "preserves the original" do
             result
-            list.should eql(L[*values])
+            expect(list).to eql(L[*values])
           end
 
           it "returns the prefix as #{expected_prefix.inspect}" do
-            prefix.should eql(L[*expected_prefix])
+            expect(prefix).to eql(L[*expected_prefix])
           end
 
           it "returns the remainder as #{expected_remainder.inspect}" do
-            remainder.should eql(L[*expected_remainder])
+            expect(remainder).to eql(L[*expected_remainder])
           end
 
           it "calls the block only once for each element" do
             count = 0
             result = list.span { |item| count += 1; item <= 2 }
             # force realization of lazy lists
-            result.first.size.should == expected_prefix.size
-            result.last.size.should == expected_remainder.size
+            expect(result.first.size).to eq(expected_prefix.size)
+            expect(result.last.size).to eq(expected_remainder.size)
             # it may not need to call the block on every element, just up to the
             # point where the block first returns a false value
-            count.should <= values.size
+            expect(count).to be <= values.size
           end
         end
 
         context "without a predicate" do
           it "returns a frozen array" do
-            list.span.class.should be(Array)
-            list.span.should be_frozen
+            expect(list.span.class).to be(Array)
+            expect(list.span).to be_frozen
           end
 
           it "returns self as the prefix" do
-            list.span.first.should equal(list)
+            expect(list.span.first).to equal(list)
           end
 
           it "returns an empty list as the remainder" do
-            list.span.last.should be_empty
+            expect(list.span.last).to be_empty
           end
         end
       end

--- a/spec/lib/hamster/list/split_at_spec.rb
+++ b/spec/lib/hamster/list/split_at_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#split_at" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.split_at(1) }.should_not raise_error
+      expect { Hamster.stream { fail }.split_at(1) }.not_to raise_error
     end
 
     [
@@ -22,21 +22,21 @@ describe Hamster::List do
 
         it "preserves the original" do
           result
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns a frozen array with two items" do
-          result.class.should be(Array)
-          result.should be_frozen
-          result.size.should be(2)
+          expect(result.class).to be(Array)
+          expect(result).to be_frozen
+          expect(result.size).to be(2)
         end
 
         it "correctly identifies the matches" do
-          prefix.should eql(L[*expected_prefix])
+          expect(prefix).to eql(L[*expected_prefix])
         end
 
         it "correctly identifies the remainder" do
-          remainder.should eql(L[*expected_remainder])
+          expect(remainder).to eql(L[*expected_remainder])
         end
       end
     end

--- a/spec/lib/hamster/list/subsequences_spec.rb
+++ b/spec/lib/hamster/list/subsequences_spec.rb
@@ -8,16 +8,16 @@ describe Hamster::List do
     it "yields all sublists with 1 or more consecutive items" do
       result = []
       list.subsequences { |l| result << l }
-      result.size.should == (5 + 4 + 3 + 2 + 1)
-      result.sort.should == [[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5],
-        [2], [2,3], [2,3,4], [2,3,4,5], [3], [3,4], [3,4,5], [4], [4,5], [5]]
+      expect(result.size).to eq(5 + 4 + 3 + 2 + 1)
+      expect(result.sort).to eq([[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5],
+        [2], [2,3], [2,3,4], [2,3,4,5], [3], [3,4], [3,4,5], [4], [4,5], [5]])
     end
 
     context "with no block" do
       it "returns an Enumerator" do
-        list.subsequences.class.should be(Enumerator)
-        list.subsequences.to_a.sort.should == [[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5],
-        [2], [2,3], [2,3,4], [2,3,4,5], [3], [3,4], [3,4,5], [4], [4,5], [5]]
+        expect(list.subsequences.class).to be(Enumerator)
+        expect(list.subsequences.to_a.sort).to eq([[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5],
+        [2], [2,3], [2,3,4], [2,3,4,5], [3], [3,4], [3,4,5], [4], [4,5], [5]])
       end
     end
   end

--- a/spec/lib/hamster/list/sum_spec.rb
+++ b/spec/lib/hamster/list/sum_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#sum" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).sum }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).sum }.not_to raise_error
       end
     end
 
@@ -16,7 +16,7 @@ describe Hamster::List do
     ].each do |values, expected|
       context "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          L[*values].sum.should == expected
+          expect(L[*values].sum).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/list/tail_spec.rb
+++ b/spec/lib/hamster/list/tail_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   describe "#tail" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).select(&:nil?).tail }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).select(&:nil?).tail }.not_to raise_error
       end
     end
 
@@ -19,11 +19,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.tail
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.tail.should eql(L[*expected])
+          expect(list.tail).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/tails_spec.rb
+++ b/spec/lib/hamster/list/tails_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#tails" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.tails }.should_not raise_error
+      expect { Hamster.stream { fail }.tails }.not_to raise_error
     end
 
     [
@@ -17,11 +17,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.tails
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.tails.should eql(L[*expected])
+          expect(list.tails).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/take_spec.rb
+++ b/spec/lib/hamster/list/take_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#take" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.take(1) }.should_not raise_error
+      expect { Hamster.stream { fail }.take(1) }.not_to raise_error
     end
 
     [
@@ -19,11 +19,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.take(number)
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.take(number).should eql(L[*expected])
+          expect(list.take(number)).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/take_while_spec.rb
+++ b/spec/lib/hamster/list/take_while_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#take_while" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.take_while { false } }.should_not raise_error
+      expect { Hamster.stream { fail }.take_while { false } }.not_to raise_error
     end
 
     [
@@ -17,12 +17,12 @@ describe Hamster::List do
 
         context "with a block" do
           it "returns #{expected.inspect}" do
-            list.take_while { |item| item < "C" }.should eql(L[*expected])
+            expect(list.take_while { |item| item < "C" }).to eql(L[*expected])
           end
 
           it "preserves the original" do
             list.take_while { |item| item < "C" }
-            list.should eql(L[*values])
+            expect(list).to eql(L[*values])
           end
 
           it "is lazy" do
@@ -31,14 +31,14 @@ describe Hamster::List do
               count += 1
               true
             end
-            count.should <= 1
+            expect(count).to be <= 1
           end
         end
 
         context "without a block" do
           it "returns an Enumerator" do
-            list.take_while.class.should be(Enumerator)
-            list.take_while.each { |item| item < "C" }.should eql(L[*expected])
+            expect(list.take_while.class).to be(Enumerator)
+            expect(list.take_while.each { |item| item < "C" }).to eql(L[*expected])
           end
         end
       end

--- a/spec/lib/hamster/list/to_a_spec.rb
+++ b/spec/lib/hamster/list/to_a_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::List do
     describe "##{method}" do
       context "on a really big list" do
         it "doesn't run out of stack" do
-          -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).to_a }.should_not raise_error
+          expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).to_a }.not_to raise_error
         end
       end
 
@@ -19,19 +19,19 @@ describe Hamster::List do
           let(:list) { L[*values] }
 
           it "returns #{values.inspect}" do
-            list.send(method).should == values
+            expect(list.send(method)).to eq(values)
           end
 
           it "leaves the original unchanged" do
             list.send(method)
-            list.should eql(L[*values])
+            expect(list).to eql(L[*values])
           end
 
           it "returns a mutable array" do
             result = list.send(method)
             expect(result.last).to_not eq("The End")
             result << "The End"
-            result.last.should == "The End"
+            expect(result.last).to eq("The End")
           end
         end
       end

--- a/spec/lib/hamster/list/to_ary_spec.rb
+++ b/spec/lib/hamster/list/to_ary_spec.rb
@@ -7,7 +7,7 @@ describe Hamster::List do
   describe "#to_ary" do
     context "on a really big list" do
       it "doesn't run out of stack" do
-        -> { Hamster.interval(0, STACK_OVERFLOW_DEPTH).to_ary }.should_not raise_error
+        expect { Hamster.interval(0, STACK_OVERFLOW_DEPTH).to_ary }.not_to raise_error
       end
     end
 

--- a/spec/lib/hamster/list/to_list_spec.rb
+++ b/spec/lib/hamster/list/to_list_spec.rb
@@ -12,7 +12,7 @@ describe Hamster::List do
         let(:list) { L[*values] }
 
         it "returns self" do
-          list.to_list.should equal(list)
+          expect(list.to_list).to equal(list)
         end
       end
     end

--- a/spec/lib/hamster/list/to_set_spec.rb
+++ b/spec/lib/hamster/list/to_set_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::List do
     ].each do |values|
       context "on #{values.inspect}" do
         it "returns a set with the same values" do
-          L[*values].to_set.should eql(S[*values])
+          expect(L[*values].to_set).to eql(S[*values])
         end
       end
     end

--- a/spec/lib/hamster/list/transpose_spec.rb
+++ b/spec/lib/hamster/list/transpose_spec.rb
@@ -4,17 +4,17 @@ require "hamster/list"
 describe Hamster::List do
   describe "#transpose" do
     it "takes a list of lists and returns a list of all the first elements, all the 2nd elements, and so on" do
-      L[L[1, 'a'], L[2, 'b'], L[3, 'c']].transpose.should eql(L[L[1, 2, 3], L["a", "b", "c"]])
-      L[L[1, 2, 3], L["a", "b", "c"]].transpose.should eql(L[L[1, 'a'], L[2, 'b'], L[3, 'c']])
-      L[].transpose.should eql(L[])
-      L[L[]].transpose.should eql(L[])
-      L[L[], L[]].transpose.should eql(L[])
-      L[L[0]].transpose.should eql(L[L[0]])
-      L[L[0], L[1]].transpose.should eql(L[L[0, 1]])
+      expect(L[L[1, 'a'], L[2, 'b'], L[3, 'c']].transpose).to eql(L[L[1, 2, 3], L["a", "b", "c"]])
+      expect(L[L[1, 2, 3], L["a", "b", "c"]].transpose).to eql(L[L[1, 'a'], L[2, 'b'], L[3, 'c']])
+      expect(L[].transpose).to eql(L[])
+      expect(L[L[]].transpose).to eql(L[])
+      expect(L[L[], L[]].transpose).to eql(L[])
+      expect(L[L[0]].transpose).to eql(L[L[0]])
+      expect(L[L[0], L[1]].transpose).to eql(L[L[0, 1]])
     end
 
     it "only goes as far as the shortest list" do
-      L[L[1,2,3], L[2]].transpose.should eql(L[L[1,2]])
+      expect(L[L[1,2,3], L[2]].transpose).to eql(L[L[1,2]])
     end
   end
 end

--- a/spec/lib/hamster/list/union_spec.rb
+++ b/spec/lib/hamster/list/union_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::List do
   [:union, :|].each do |method|
     describe "##{method}" do
       it "is lazy" do
-        -> { Hamster.stream { fail }.union(Hamster.stream { fail }) }.should_not raise_error
+        expect { Hamster.stream { fail }.union(Hamster.stream { fail }) }.not_to raise_error
       end
 
       [
@@ -19,11 +19,11 @@ describe Hamster::List do
           let(:list_b) { L[*b] }
 
           it "for #{a.inspect} and #{b.inspect}"  do
-            list_a.send(method, list_b).should eql(L[*expected])
+            expect(list_a.send(method, list_b)).to eql(L[*expected])
           end
 
           it "for #{b.inspect} and #{a.inspect}"  do
-            list_b.send(method, list_a).should eql(L[*expected])
+            expect(list_b.send(method, list_a)).to eql(L[*expected])
           end
         end
       end

--- a/spec/lib/hamster/list/uniq_spec.rb
+++ b/spec/lib/hamster/list/uniq_spec.rb
@@ -4,12 +4,12 @@ require "hamster/list"
 describe Hamster::List do
   describe "#uniq" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.uniq }.should_not raise_error
+      expect { Hamster.stream { fail }.uniq }.not_to raise_error
     end
 
     context "when passed a block" do
       it "uses the block to identify duplicates" do
-        L["a", "A", "b"].uniq(&:upcase).should eql(Hamster::List["a", "b"])
+        expect(L["a", "A", "b"].uniq(&:upcase)).to eql(Hamster::List["a", "b"])
       end
     end
 
@@ -24,11 +24,11 @@ describe Hamster::List do
 
         it "preserves the original" do
           list.uniq
-          list.should eql(L[*values])
+          expect(list).to eql(L[*values])
         end
 
         it "returns #{expected.inspect}" do
-          list.uniq.should eql(L[*expected])
+          expect(list.uniq).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/list/zip_spec.rb
+++ b/spec/lib/hamster/list/zip_spec.rb
@@ -4,7 +4,7 @@ require "hamster/list"
 describe Hamster::List do
   describe "#zip" do
     it "is lazy" do
-      -> { Hamster.stream { fail }.zip(Hamster.stream { fail }) }.should_not raise_error
+      expect { Hamster.stream { fail }.zip(Hamster.stream { fail }) }.not_to raise_error
     end
 
     [
@@ -16,7 +16,7 @@ describe Hamster::List do
     ].each do |left, right, expected|
       context "on #{left.inspect} and #{right.inspect}" do
         it "returns #{expected.inspect}" do
-          L[*left].zip(L[*right]).should eql(L[*expected])
+          expect(L[*left].zip(L[*right])).to eql(L[*expected])
         end
       end
     end

--- a/spec/lib/hamster/nested/construction_spec.rb
+++ b/spec/lib/hamster/nested/construction_spec.rb
@@ -39,7 +39,7 @@ describe Hamster do
     expectations.each do |input, expected_result|
       context "with #{input.inspect} as input" do
         it "should return #{expected_result.inspect}" do
-          Hamster.from(input).should eql(expected_result)
+          expect(Hamster.from(input)).to eql(expected_result)
         end
       end
     end
@@ -56,7 +56,7 @@ describe Hamster do
           "c" => Hamster::Hash["d" => "e"],
           "f" => Hamster::Vector["g", "h", Hamster::EmptyVector],
           "i" => Hamster::Hash["j" => Hamster::EmptyHash, "k" => Hamster::Set[Hamster::EmptyVector, Hamster::EmptyHash]] ]
-        Hamster.from(input).should eql(expected_result)
+        expect(Hamster.from(input)).to eql(expected_result)
       end
     end
   end
@@ -66,7 +66,7 @@ describe Hamster do
       unless one_way
         context "with #{input.inspect} as input" do
           it "should return #{expected_result.inspect}" do
-            Hamster.to_ruby(input).should eql(expected_result)
+            expect(Hamster.to_ruby(input)).to eql(expected_result)
           end
         end
       end
@@ -74,13 +74,13 @@ describe Hamster do
 
     context "with Hamster::Deque[] as input" do
       it "should return []" do
-        Hamster.to_ruby(Hamster::Deque[]).should eql([])
+        expect(Hamster.to_ruby(Hamster::Deque[])).to eql([])
       end
     end
 
     context "with Hamster::Deque[Hamster::Hash[\"a\" => 1]] as input" do
       it "should return [{\"a\" => 1}]" do
-        Hamster.to_ruby(Hamster::Deque[Hamster::Hash["a" => 1]]).should eql([{"a" => 1}])
+        expect(Hamster.to_ruby(Hamster::Deque[Hamster::Hash["a" => 1]])).to eql([{"a" => 1}])
       end
     end
 
@@ -96,7 +96,7 @@ describe Hamster do
           "c" => {"d" => "e"},
           "f" => ["g", "h"],
           "i" => {"j" => {}, "k" => Set.new([[], {}])} }
-        Hamster.to_ruby(input).should eql(expected_result)
+        expect(Hamster.to_ruby(input)).to eql(expected_result)
       end
     end
   end

--- a/spec/lib/hamster/set/add_spec.rb
+++ b/spec/lib/hamster/set/add_spec.rb
@@ -11,11 +11,11 @@ describe Hamster::Set do
 
         it "preserves the original" do
           result
-          original.should eql(S["A", "B", "C"])
+          expect(original).to eql(S["A", "B", "C"])
         end
 
         it "returns a copy with the superset of values" do
-          result.should eql(S["A", "B", "C", "D"])
+          expect(result).to eql(S["A", "B", "C", "D"])
         end
       end
 
@@ -24,16 +24,16 @@ describe Hamster::Set do
 
         it "preserves the original values" do
           result
-          original.should eql(S["A", "B", "C"])
+          expect(original).to eql(S["A", "B", "C"])
         end
 
         it "returns self" do
-          result.should equal(original)
+          expect(result).to equal(original)
         end
       end
 
       it "can add nil to a set" do
-        original.add(nil).should eql(S["A", "B", "C", nil])
+        expect(original.add(nil)).to eql(S["A", "B", "C", nil])
       end
 
       it "works on large sets, with many combinations of input" do
@@ -43,8 +43,8 @@ describe Hamster::Set do
           array = (1..500).to_a.sample(100).uniq
           set   = S.new(array)
           to_add = 1000 + rand(1000)
-          set.add(to_add).size.should == array.size + 1
-          set.add(to_add).include?(to_add).should == true
+          expect(set.add(to_add).size).to eq(array.size + 1)
+          expect(set.add(to_add).include?(to_add)).to eq(true)
         end
       end
     end
@@ -55,11 +55,11 @@ describe Hamster::Set do
       let(:result) { original.add?("D") }
 
       it "preserves the original" do
-        original.should eql(S["A", "B", "C"])
+        expect(original).to eql(S["A", "B", "C"])
       end
 
       it "returns a copy with the superset of values" do
-        result.should eql(S["A", "B", "C", "D"])
+        expect(result).to eql(S["A", "B", "C", "D"])
       end
     end
 
@@ -67,11 +67,11 @@ describe Hamster::Set do
       let(:result) { original.add?("C") }
 
       it "preserves the original values" do
-        original.should eql(S["A", "B", "C"])
+        expect(original).to eql(S["A", "B", "C"])
       end
 
       it "returns false" do
-        result.should equal(false)
+        expect(result).to equal(false)
       end
     end
   end

--- a/spec/lib/hamster/set/all_spec.rb
+++ b/spec/lib/hamster/set/all_spec.rb
@@ -5,11 +5,11 @@ describe Hamster::Set do
   describe "#all?" do
     context "when empty" do
       it "with a block returns true" do
-        S.empty.all? {}.should == true
+        expect(S.empty.all? {}).to eq(true)
       end
 
       it "with no block returns true" do
-        S.empty.all?.should == true
+        expect(S.empty.all?).to eq(true)
       end
     end
 
@@ -18,32 +18,32 @@ describe Hamster::Set do
         let(:set) { S["A", "B", "C"] }
 
         it "returns true if the block always returns true" do
-          set.all? { |item| true }.should == true
+          expect(set.all? { |item| true }).to eq(true)
         end
 
         it "returns false if the block ever returns false" do
-          set.all? { |item| item == "D" }.should == false
+          expect(set.all? { |item| item == "D" }).to eq(false)
         end
 
         it "propagates an exception from the block" do
-          -> { set.all? { |k,v| raise "help" } }.should raise_error(RuntimeError)
+          expect { set.all? { |k,v| raise "help" } }.to raise_error(RuntimeError)
         end
 
         it "stops iterating as soon as the block returns false" do
           yielded = []
           set.all? { |k,v| yielded << k; false }
-          yielded.size.should == 1
+          expect(yielded.size).to eq(1)
         end
       end
 
       describe "with no block" do
         it "returns true if all values are truthy" do
-          S[true, "A"].all?.should == true
+          expect(S[true, "A"].all?).to eq(true)
         end
 
         [nil, false].each do |value|
           it "returns false if any value is #{value.inspect}" do
-            S[value, true, "A"].all?.should == false
+            expect(S[value, true, "A"].all?).to eq(false)
           end
         end
       end

--- a/spec/lib/hamster/set/any_spec.rb
+++ b/spec/lib/hamster/set/any_spec.rb
@@ -5,11 +5,11 @@ describe Hamster::Set do
   describe "#any?" do
     context "when empty" do
       it "with a block returns false" do
-        S.empty.any? {}.should == false
+        expect(S.empty.any? {}).to eq(false)
       end
 
       it "with no block returns false" do
-        S.empty.any?.should == false
+        expect(S.empty.any?).to eq(false)
       end
     end
 
@@ -19,32 +19,32 @@ describe Hamster::Set do
 
         ["A", "B", "C", nil].each do |value|
           it "returns true if the block ever returns true (#{value.inspect})" do
-            set.any? { |item| item == value }.should == true
+            expect(set.any? { |item| item == value }).to eq(true)
           end
         end
 
         it "returns false if the block always returns false" do
-          set.any? { |item| item == "D" }.should == false
+          expect(set.any? { |item| item == "D" }).to eq(false)
         end
 
         it "propagates exceptions raised in the block" do
-          -> { set.any? { |k,v| raise "help" } }.should raise_error(RuntimeError)
+          expect { set.any? { |k,v| raise "help" } }.to raise_error(RuntimeError)
         end
 
         it "stops iterating as soon as the block returns true" do
           yielded = []
           set.any? { |k,v| yielded << k; true }
-          yielded.size.should == 1
+          expect(yielded.size).to eq(1)
         end
       end
 
       context "with no block" do
         it "returns true if any value is truthy" do
-          S[nil, false, true, "A"].any?.should == true
+          expect(S[nil, false, true, "A"].any?).to eq(true)
         end
 
         it "returns false if all values are falsey" do
-          S[nil, false].any?.should == false
+          expect(S[nil, false].any?).to eq(false)
         end
       end
     end

--- a/spec/lib/hamster/set/clear_spec.rb
+++ b/spec/lib/hamster/set/clear_spec.rb
@@ -13,11 +13,11 @@ describe Hamster::Set do
 
         it "preserves the original" do
           set.clear
-          set.should eql(S[*values])
+          expect(set).to eql(S[*values])
         end
 
         it "returns an empty set" do
-          set.clear.should equal(S.empty)
+          expect(set.clear).to equal(S.empty)
         end
       end
     end
@@ -26,8 +26,8 @@ describe Hamster::Set do
       it "returns an empty instance of the subclass" do
         subclass = Class.new(Hamster::Set)
         instance = subclass.new([:a, :b, :c, :d])
-        instance.clear.class.should be(subclass)
-        instance.clear.should be_empty
+        expect(instance.clear.class).to be(subclass)
+        expect(instance.clear).to be_empty
       end
     end
   end

--- a/spec/lib/hamster/set/compact_spec.rb
+++ b/spec/lib/hamster/set/compact_spec.rb
@@ -19,11 +19,11 @@ describe Hamster::Set do
 
         it "preserves the original" do
           set.compact
-          set.should eql(S[*values])
+          expect(set).to eql(S[*values])
         end
 
         it "returns #{expected.inspect}" do
-          set.compact.should eql(S[*expected])
+          expect(set.compact).to eql(S[*expected])
         end
       end
     end

--- a/spec/lib/hamster/set/construction_spec.rb
+++ b/spec/lib/hamster/set/construction_spec.rb
@@ -5,14 +5,14 @@ describe Hamster::Set do
   describe ".set" do
     context "with no values" do
       it "returns the empty set" do
-        S.empty.should be_empty
-        S.empty.should equal(Hamster::EmptySet)
+        expect(S.empty).to be_empty
+        expect(S.empty).to equal(Hamster::EmptySet)
       end
     end
 
     context "with a list of values" do
       it "is equivalent to repeatedly using #add" do
-        S["A", "B", "C"].should eql(S.empty.add("A").add("B").add("C"))
+        expect(S["A", "B", "C"]).to eql(S.empty.add("A").add("B").add("C"))
       end
     end
   end

--- a/spec/lib/hamster/set/copying_spec.rb
+++ b/spec/lib/hamster/set/copying_spec.rb
@@ -7,7 +7,7 @@ describe Hamster::Set do
 
     describe "##{method}" do
       it "returns self" do
-        set.send(method).should equal(set)
+        expect(set.send(method)).to equal(set)
       end
     end
   end

--- a/spec/lib/hamster/set/count_spec.rb
+++ b/spec/lib/hamster/set/count_spec.rb
@@ -16,13 +16,13 @@ describe Hamster::Set do
 
         context "with a block" do
           it "returns #{expected.inspect}" do
-            set.count(&:odd?).should == expected
+            expect(set.count(&:odd?)).to eq(expected)
           end
         end
 
         context "without a block" do
           it "returns length" do
-            set.count.should == set.length
+            expect(set.count).to eq(set.length)
           end
         end
       end
@@ -30,8 +30,8 @@ describe Hamster::Set do
 
     it "works on large sets" do
       set = Hamster::Set.new(1..2000)
-      set.count.should == 2000
-      set.count(&:odd?).should == 1000
+      expect(set.count).to eq(2000)
+      expect(set.count(&:odd?)).to eq(1000)
     end
   end
 end

--- a/spec/lib/hamster/set/delete_spec.rb
+++ b/spec/lib/hamster/set/delete_spec.rb
@@ -8,28 +8,28 @@ describe Hamster::Set do
     context "with an existing value" do
       it "preserves the original" do
         set.delete("B")
-        set.should eql(S["A", "B", "C"])
+        expect(set).to eql(S["A", "B", "C"])
       end
 
       it "returns a copy with the remaining values" do
-        set.delete("B").should eql(S["A", "C"])
+        expect(set.delete("B")).to eql(S["A", "C"])
       end
     end
 
     context "with a non-existing value" do
       it "preserves the original values" do
         set.delete("D")
-        set.should eql(S["A", "B", "C"])
+        expect(set).to eql(S["A", "B", "C"])
       end
 
       it "returns self" do
-        set.delete("D").should equal(set)
+        expect(set.delete("D")).to equal(set)
       end
     end
 
     context "when removing the last value in a set" do
       it "returns the canonical empty set" do
-        set.delete("B").delete("C").delete("A").should be(Hamster::EmptySet)
+        expect(set.delete("B").delete("C").delete("A")).to be(Hamster::EmptySet)
       end
     end
 
@@ -38,10 +38,10 @@ describe Hamster::Set do
       set = S.new(array)
       array.each do |key|
         result = set.delete(key)
-        result.size.should == set.size - 1
-        result.include?(key).should == false
+        expect(result.size).to eq(set.size - 1)
+        expect(result.include?(key)).to eq(false)
         other = array.sample
-        (result.include?(other).should == true) if other != key
+        (expect(result.include?(other)).to eq(true)) if other != key
       end
     end
   end
@@ -50,22 +50,22 @@ describe Hamster::Set do
     context "with an existing value" do
       it "preserves the original" do
         set.delete?("B")
-        set.should eql(S["A", "B", "C"])
+        expect(set).to eql(S["A", "B", "C"])
       end
 
       it "returns a copy with the remaining values" do
-        set.delete?("B").should eql(S["A", "C"])
+        expect(set.delete?("B")).to eql(S["A", "C"])
       end
     end
 
     context "with a non-existing value" do
       it "preserves the original values" do
         set.delete?("D")
-        set.should eql(S["A", "B", "C"])
+        expect(set).to eql(S["A", "B", "C"])
       end
 
       it "returns false" do
-        set.delete?("D").should be(false)
+        expect(set.delete?("D")).to be(false)
       end
     end
   end

--- a/spec/lib/hamster/set/difference_spec.rb
+++ b/spec/lib/hamster/set/difference_spec.rb
@@ -20,18 +20,18 @@ describe Hamster::Set do
 
           it "doesn't modify the original Sets" do
             result
-            set_a.should eql(S.new(a))
-            set_b.should eql(S.new(b))
+            expect(set_a).to eql(S.new(a))
+            expect(set_b).to eql(S.new(b))
           end
 
           it "returns #{expected.inspect}"  do
-            result.should eql(S[*expected])
+            expect(result).to eql(S[*expected])
           end
         end
 
         context "when passed a Ruby Array" do
           it "returns the expected Set" do
-            S[*a].difference(b.freeze).should eql(S[*expected])
+            expect(S[*a].difference(b.freeze)).to eql(S[*expected])
           end
         end
       end
@@ -42,7 +42,7 @@ describe Hamster::Set do
           array1 = items.sample(200)
           array2 = items.sample(200)
           result = S.new(array1).send(method, S.new(array2))
-          result.to_a.sort.should eql((array1 - array2).sort)
+          expect(result.to_a.sort).to eql((array1 - array2).sort)
         end
       end
     end

--- a/spec/lib/hamster/set/disjoint_spec.rb
+++ b/spec/lib/hamster/set/disjoint_spec.rb
@@ -18,7 +18,7 @@ describe Hamster::Set do
     ].each do |a, b, expected|
       describe "for #{a.inspect} and #{b.inspect}" do
         it "returns #{expected}" do
-          S[*a].disjoint?(S[*b]).should be(expected)
+          expect(S[*a].disjoint?(S[*b])).to be(expected)
         end
       end
     end

--- a/spec/lib/hamster/set/each_spec.rb
+++ b/spec/lib/hamster/set/each_spec.rb
@@ -40,7 +40,7 @@ describe Hamster::Set do
       set = S[DeterministicHash.new('a', 1010), DeterministicHash.new('b', 1010)]
       yielded = []
       set.each { |obj| yielded << obj }
-      yielded.map(&:value).sort.should == ['a', 'b']
+      expect(yielded.map(&:value).sort).to eq(['a', 'b'])
     end
   end
 end

--- a/spec/lib/hamster/set/empty_spec.rb
+++ b/spec/lib/hamster/set/empty_spec.rb
@@ -12,7 +12,7 @@ describe Hamster::Set do
     ].each do |values, expected|
       describe "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          S[*values].empty?.should == expected
+          expect(S[*values].empty?).to eq(expected)
         end
       end
     end
@@ -20,16 +20,16 @@ describe Hamster::Set do
 
   describe ".empty" do
     it "returns the canonical empty set" do
-      S.empty.should be_empty
-      S.empty.object_id.should be(S[].object_id)
-      S.empty.should be(Hamster::EmptySet)
+      expect(S.empty).to be_empty
+      expect(S.empty.object_id).to be(S[].object_id)
+      expect(S.empty).to be(Hamster::EmptySet)
     end
 
     context "from a subclass" do
       it "returns an empty instance of the subclass" do
         subclass = Class.new(Hamster::Set)
-        subclass.empty.class.should be(subclass)
-        subclass.empty.should be_empty
+        expect(subclass.empty.class).to be(subclass)
+        expect(subclass.empty).to be_empty
       end
 
       it "calls overridden #initialize when creating empty Set" do
@@ -38,7 +38,7 @@ describe Hamster::Set do
             @variable = 'value'
           end
         end
-        subclass.empty.instance_variable_get(:@variable).should == 'value'
+        expect(subclass.empty.instance_variable_get(:@variable)).to eq('value')
       end
     end
   end

--- a/spec/lib/hamster/set/exclusion_spec.rb
+++ b/spec/lib/hamster/set/exclusion_spec.rb
@@ -19,18 +19,18 @@ describe Hamster::Set do
 
           it "doesn't modify the original Sets" do
             result
-            set_a.should eql(S.new(a))
-            set_b.should eql(S.new(b))
+            expect(set_a).to eql(S.new(a))
+            expect(set_b).to eql(S.new(b))
           end
 
           it "returns #{expected.inspect}"  do
-            result.should eql(S[*expected])
+            expect(result).to eql(S[*expected])
           end
         end
 
         context "when passed a Ruby Array" do
           it "returns the expected Set" do
-            S[*a].exclusion(b.freeze).should eql(S[*expected])
+            expect(S[*a].exclusion(b.freeze)).to eql(S[*expected])
           end
         end
       end
@@ -40,7 +40,7 @@ describe Hamster::Set do
           array1 = (1..400).to_a.sample(100)
           array2 = (1..400).to_a.sample(100)
           result = S.new(array1) ^ S.new(array2)
-          result.to_a.sort.should eql(((array1 | array2) - (array1 & array2)).sort)
+          expect(result.to_a.sort).to eql(((array1 | array2) - (array1 & array2)).sort)
         end
       end
     end

--- a/spec/lib/hamster/set/find_spec.rb
+++ b/spec/lib/hamster/set/find_spec.rb
@@ -18,15 +18,15 @@ describe Hamster::Set do
         describe "on #{values.inspect}" do
           context "with a block" do
             it "returns #{expected.inspect}" do
-              S[*values].send(method) { |x| x == item }.should == expected
+              expect(S[*values].send(method) { |x| x == item }).to eq(expected)
             end
           end
 
           context "without a block" do
             it "returns an Enumerator" do
               result = S[*values].send(method)
-              result.class.should be(Enumerator)
-              result.each { |x| x == item}.should == expected
+              expect(result.class).to be(Enumerator)
+              expect(result.each { |x| x == item}).to eq(expected)
             end
           end
         end

--- a/spec/lib/hamster/set/first_spec.rb
+++ b/spec/lib/hamster/set/first_spec.rb
@@ -5,24 +5,24 @@ describe Hamster::Set do
   describe "#first" do
     context "on an empty set" do
       it "returns nil" do
-        S.empty.first.should be_nil
+        expect(S.empty.first).to be_nil
       end
     end
 
     context "on a non-empty set" do
       it "returns an arbitrary value from the set" do
-        %w[A B C].include?(S["A", "B", "C"].first).should == true
+        expect(%w[A B C].include?(S["A", "B", "C"].first)).to eq(true)
       end
     end
 
     it "returns nil if only member of set is nil" do
-      S[nil].first.should be(nil)
+      expect(S[nil].first).to be(nil)
     end
 
     it "returns the first item yielded by #each" do
       10.times do
         set = S.new((rand(10)+1).times.collect { rand(10000 )})
-        set.each { |item| break item }.should be(set.first)
+        expect(set.each { |item| break item }).to be(set.first)
       end
     end
   end

--- a/spec/lib/hamster/set/flatten_spec.rb
+++ b/spec/lib/hamster/set/flatten_spec.rb
@@ -14,33 +14,33 @@ describe Hamster do
 
         it "preserves the original" do
           set.flatten
-          set.should eql(S[*values])
+          expect(set).to eql(S[*values])
         end
 
         it "returns the inlined values" do
-          set.flatten.should eql(S[*expected])
+          expect(set.flatten).to eql(S[*expected])
         end
       end
     end
 
     context "on an empty set" do
       it "returns an empty set" do
-        S.empty.flatten.should equal(S.empty)
+        expect(S.empty.flatten).to equal(S.empty)
       end
     end
 
     context "on a set with multiple levels of nesting" do
       it "inlines lower levels of nesting" do
         set = S[S[S[1]], S[S[2]]]
-        set.flatten.should eql(S[1, 2])
+        expect(set.flatten).to eql(S[1, 2])
       end
     end
 
     context "from a subclass" do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Set)
-        subclass.new.flatten.class.should be(subclass)
-        subclass.new([S[1], S[2]]).flatten.class.should be(subclass)
+        expect(subclass.new.flatten.class).to be(subclass)
+        expect(subclass.new([S[1], S[2]]).flatten.class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/set/group_by_spec.rb
+++ b/spec/lib/hamster/set/group_by_spec.rb
@@ -14,8 +14,8 @@ describe Hamster::Set do
             let(:set) { S[*values] }
 
             it "returns #{expected.inspect}" do
-              set.send(method, &:odd?).should eql(H[*expected])
-              set.should eql(S.new(values)) # make sure it hasn't changed
+              expect(set.send(method, &:odd?)).to eql(H[*expected])
+              expect(set).to eql(S.new(values)) # make sure it hasn't changed
             end
           end
         end
@@ -31,8 +31,8 @@ describe Hamster::Set do
             let(:set) { S[*values] }
 
             it "returns #{expected.inspect}" do
-              set.group_by.should eql(H[*expected])
-              set.should eql(S.new(values)) # make sure it hasn't changed
+              expect(set.group_by).to eql(H[*expected])
+              expect(set).to eql(S.new(values)) # make sure it hasn't changed
             end
           end
         end
@@ -40,19 +40,19 @@ describe Hamster::Set do
 
       context "on an empty set" do
         it "returns an empty hash" do
-          S.empty.group_by { |x| x }.should eql(H.empty)
+          expect(S.empty.group_by { |x| x }).to eql(H.empty)
         end
       end
 
       it "returns a hash without default proc" do
-        S[1,2,3].group_by { |x| x }.default_proc.should be_nil
+        expect(S[1,2,3].group_by { |x| x }.default_proc).to be_nil
       end
 
       context "from a subclass" do
         it "returns an Hash whose values are instances of the subclass" do
           subclass = Class.new(Hamster::Set)
           instance = subclass.new([1, 'string', :symbol])
-          instance.group_by { |x| x.class }.values.each { |v| v.class.should be(subclass) }
+          instance.group_by { |x| x.class }.values.each { |v| expect(v.class).to be(subclass) }
         end
       end
     end

--- a/spec/lib/hamster/set/hash_spec.rb
+++ b/spec/lib/hamster/set/hash_spec.rb
@@ -5,7 +5,7 @@ describe Hamster::Set do
   describe "#hash" do
     context "on an empty set" do
       it "returns 0" do
-        S.empty.hash.should == 0
+        expect(S.empty.hash).to eq(0)
       end
     end
 
@@ -13,11 +13,11 @@ describe Hamster::Set do
       item1 = DeterministicHash.new('a', 121)
       item2 = DeterministicHash.new('b', 474)
       item3 = DeterministicHash.new('c', 121)
-      S.empty.add(item1).add(item2).add(item3).hash.should == S.empty.add(item3).add(item2).add(item1).hash
+      expect(S.empty.add(item1).add(item2).add(item3).hash).to eq(S.empty.add(item3).add(item2).add(item1).hash)
     end
 
     it "values are sufficiently distributed" do
-      (1..4000).each_slice(4).map { |a, b, c, d| S[a, b, c, d].hash }.uniq.size.should == 1000
+      expect((1..4000).each_slice(4).map { |a, b, c, d| S[a, b, c, d].hash }.uniq.size).to eq(1000)
     end
   end
 end

--- a/spec/lib/hamster/set/immutable_spec.rb
+++ b/spec/lib/hamster/set/immutable_spec.rb
@@ -4,6 +4,6 @@ require "hamster/set"
 
 describe Hamster::Set do
   it "includes Immutable" do
-    Hamster::Set.should include(Hamster::Immutable)
+    expect(Hamster::Set).to include(Hamster::Immutable)
   end
 end

--- a/spec/lib/hamster/set/include_spec.rb
+++ b/spec/lib/hamster/set/include_spec.rb
@@ -9,20 +9,20 @@ describe Hamster::Set do
 
       ["A", "B", "C", 2.0, nil].each do |value|
         it "returns true for an existing value (#{value.inspect})" do
-          set.send(method, value).should == true
+          expect(set.send(method, value)).to eq(true)
         end
       end
 
       it "returns false for a non-existing value" do
-        set.send(method, "D").should == false
+        expect(set.send(method, "D")).to eq(false)
       end
 
       it "returns true even if existing value is nil" do
-        S[nil].include?(nil).should == true
+        expect(S[nil].include?(nil)).to eq(true)
       end
 
       it "returns true even if existing value is false" do
-        S[false].include?(false).should == true
+        expect(S[false].include?(false)).to eq(true)
       end
 
       it "returns false for a mutable item which is mutated after adding" do
@@ -30,11 +30,11 @@ describe Hamster::Set do
         item = [rand(1000000)] while (item.hash.abs & 31 == [item[0], 'HOSED!'].hash.abs & 31)
         set  = S[item]
         item.push('HOSED!')
-        set.include?(item).should == false
+        expect(set.include?(item)).to eq(false)
       end
 
       it "uses #eql? for equality" do
-        set.send(method, 2).should == false
+        expect(set.send(method, 2)).to eq(false)
       end
 
       it "returns the right answers after a lot of addings and removings" do
@@ -45,16 +45,16 @@ describe Hamster::Set do
             array << (item = rand(10000))
             rb_set.add(item)
             set = set.add(item)
-            set.include?(item).should == true
+            expect(set.include?(item)).to eq(true)
           else
             item = array.sample
             rb_set.delete(item)
             set = set.delete(item)
-            set.include?(item).should == false
+            expect(set.include?(item)).to eq(false)
           end
         end
 
-        array.each { |item| set.include?(item).should == rb_set.include?(item) }
+        array.each { |item| expect(set.include?(item)).to eq(rb_set.include?(item)) }
       end
     end
   end

--- a/spec/lib/hamster/set/inspect_spec.rb
+++ b/spec/lib/hamster/set/inspect_spec.rb
@@ -11,11 +11,11 @@ describe Hamster::Set do
         let(:set) { S[*values] }
 
         it "returns #{expected.inspect}" do
-          set.inspect.should == expected
+          expect(set.inspect).to eq(expected)
         end
 
         it "returns a string which can be eval'd to get an equivalent set" do
-          eval(set.inspect).should eql(set)
+          expect(eval(set.inspect)).to eql(set)
         end
       end
     end
@@ -24,11 +24,11 @@ describe Hamster::Set do
       let(:set) { S["A", "B", "C"] }
 
       it "returns a programmer-readable representation of the set contents" do
-        set.inspect.should match(/^Hamster::Set\["[A-C]", "[A-C]", "[A-C]"\]$/)
+        expect(set.inspect).to match(/^Hamster::Set\["[A-C]", "[A-C]", "[A-C]"\]$/)
       end
 
       it "returns a string which can be eval'd to get an equivalent set" do
-        eval(set.inspect).should eql(set)
+        expect(eval(set.inspect)).to eql(set)
       end
     end
 
@@ -37,11 +37,11 @@ describe Hamster::Set do
       let(:set) { MySet[1, 2] }
 
       it "returns a programmer-readable representation of the set contents" do
-        set.inspect.should match(/^MySet\[[1-2], [1-2]\]$/)
+        expect(set.inspect).to match(/^MySet\[[1-2], [1-2]\]$/)
       end
 
       it "returns a string which can be eval'd to get an equivalent set" do
-        eval(set.inspect).should eql(set)
+        expect(eval(set.inspect)).to eql(set)
       end
     end
   end

--- a/spec/lib/hamster/set/intersect_spec.rb
+++ b/spec/lib/hamster/set/intersect_spec.rb
@@ -18,7 +18,7 @@ describe Hamster::Set do
     ].each do |a, b, expected|
       describe "for #{a.inspect} and #{b.inspect}" do
         it "returns #{expected}" do
-          S[*a].intersect?(S[*b]).should be(expected)
+          expect(S[*a].intersect?(S[*b])).to be(expected)
         end
       end
     end

--- a/spec/lib/hamster/set/intersection_spec.rb
+++ b/spec/lib/hamster/set/intersection_spec.rb
@@ -16,9 +16,9 @@ describe Hamster::Set do
           let(:set_b) { S[*b] }
 
           it "returns #{expected.inspect}, without changing the original Sets" do
-            set_a.send(method, set_b).should eql(S[*expected])
-            set_a.should eql(S.new(a))
-            set_b.should eql(S.new(b))
+            expect(set_a.send(method, set_b)).to eql(S[*expected])
+            expect(set_a).to eql(S.new(a))
+            expect(set_b).to eql(S.new(b))
           end
         end
 
@@ -27,15 +27,15 @@ describe Hamster::Set do
           let(:set_b) { S[*b] }
 
           it "returns #{expected.inspect}, without changing the original Sets" do
-            set_b.send(method, set_a).should eql(S[*expected])
-            set_a.should eql(S.new(a))
-            set_b.should eql(S.new(b))
+            expect(set_b.send(method, set_a)).to eql(S[*expected])
+            expect(set_a).to eql(S.new(a))
+            expect(set_b).to eql(S.new(b))
           end
         end
 
         context "when passed a Ruby Array" do
           it "returns the expected Set" do
-            S[*a].send(method, b.freeze).should eql(S[*expected])
+            expect(S[*a].send(method, b.freeze)).to eql(S[*expected])
           end
         end
       end
@@ -45,7 +45,7 @@ describe Hamster::Set do
           array1 = rand(100).times.map { rand(1000000).to_s(16) }
           array2 = rand(100).times.map { rand(1000000).to_s(16) }
           result = S.new(array1).send(method, S.new(array2))
-          result.to_a.sort.should eql((array1 & array2).sort)
+          expect(result.to_a.sort).to eql((array1 & array2).sort)
         end
       end
     end

--- a/spec/lib/hamster/set/join_spec.rb
+++ b/spec/lib/hamster/set/join_spec.rb
@@ -14,11 +14,11 @@ describe Hamster::Set do
 
           it "preserves the original" do
             set.join("|")
-            set.should eql(S[*values])
+            expect(set).to eql(S[*values])
           end
 
           it "returns #{expected.inspect}" do
-            set.join("|").should eql(expected)
+            expect(set.join("|")).to eql(expected)
           end
         end
       end
@@ -35,11 +35,11 @@ describe Hamster::Set do
 
           it "preserves the original" do
             set.join
-            set.should eql(S[*values])
+            expect(set).to eql(S[*values])
           end
 
           it "returns #{expected.inspect}" do
-            set.join.should eql(expected)
+            expect(set.join).to eql(expected)
           end
         end
       end
@@ -53,11 +53,11 @@ describe Hamster::Set do
       context "on ['A', 'B', 'C']" do
         it "preserves the original" do
           set.join
-          set.should eql(S[DeterministicHash.new("A", 1), DeterministicHash.new("B", 2), DeterministicHash.new("C", 3)])
+          expect(set).to eql(S[DeterministicHash.new("A", 1), DeterministicHash.new("B", 2), DeterministicHash.new("C", 3)])
         end
 
         it "returns #{@expected.inspect}" do
-          set.join.should == "A**B**C"
+          expect(set.join).to eq("A**B**C")
         end
       end
     end

--- a/spec/lib/hamster/set/map_spec.rb
+++ b/spec/lib/hamster/set/map_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::Set do
     describe "##{method}" do
       context "when empty" do
         it "returns self" do
-          S.empty.send(method) {}.should equal(S.empty)
+          expect(S.empty.send(method) {}).to equal(S.empty)
         end
       end
 
@@ -16,18 +16,18 @@ describe Hamster::Set do
         context "with a block" do
           it "preserves the original values" do
             set.send(method, &:downcase)
-            set.should eql(S["A", "B", "C"])
+            expect(set).to eql(S["A", "B", "C"])
           end
 
           it "returns a new set with the mapped values" do
-            set.send(method, &:downcase).should eql(S["a", "b", "c"])
+            expect(set.send(method, &:downcase)).to eql(S["a", "b", "c"])
           end
         end
 
         context "with no block" do
           it "returns an Enumerator" do
-            set.send(method).class.should be(Enumerator)
-            set.send(method).each(&:downcase).should == S['a', 'b', 'c']
+            expect(set.send(method).class).to be(Enumerator)
+            expect(set.send(method).each(&:downcase)).to eq(S['a', 'b', 'c'])
           end
         end
       end
@@ -36,7 +36,7 @@ describe Hamster::Set do
         it "returns an instance of the subclass" do
           subclass = Class.new(Hamster::Set)
           instance = subclass['a', 'b']
-          instance.map { |item| item.upcase }.class.should be(subclass)
+          expect(instance.map { |item| item.upcase }.class).to be(subclass)
         end
       end
 
@@ -44,16 +44,16 @@ describe Hamster::Set do
         it "filters out the duplicates" do
           set = S.new('aa'..'zz')
           result = set.map { |s| s[0] }
-          result.should eql(Hamster::Set.new('a'..'z'))
-          result.size.should == 26
+          expect(result).to eql(Hamster::Set.new('a'..'z'))
+          expect(result.size).to eq(26)
         end
       end
 
       it "works on large sets" do
         set = S.new(1..1000)
         result = set.map { |x| x * 10 }
-        result.size.should == 1000
-        1.upto(1000) { |n| result.include?(n * 10).should == true }
+        expect(result.size).to eq(1000)
+        1.upto(1000) { |n| expect(result.include?(n * 10)).to eq(true) }
       end
     end
   end

--- a/spec/lib/hamster/set/marshal_spec.rb
+++ b/spec/lib/hamster/set/marshal_spec.rb
@@ -18,12 +18,12 @@ describe Hamster::Set do
     end
 
     it "can survive dumping and loading into a new process" do
-      reloaded_hash.should eql(S[:one, :two])
+      expect(reloaded_hash).to eql(S[:one, :two])
     end
 
     it "is still possible to test items by key after loading" do
-      reloaded_hash.should include :one
-      reloaded_hash.should include :two
+      expect(reloaded_hash).to include :one
+      expect(reloaded_hash).to include :two
     end
   end
 end

--- a/spec/lib/hamster/set/maximum_spec.rb
+++ b/spec/lib/hamster/set/maximum_spec.rb
@@ -14,7 +14,7 @@ describe Hamster::Set do
           let(:result) { set.max { |maximum, item| maximum.length <=> item.length }}
 
           it "returns #{expected.inspect}" do
-            result.should == expected
+            expect(result).to eq(expected)
           end
         end
       end
@@ -28,7 +28,7 @@ describe Hamster::Set do
       ].each do |values, expected|
         describe "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            S[*values].max.should == expected
+            expect(S[*values].max).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/set/minimum_spec.rb
+++ b/spec/lib/hamster/set/minimum_spec.rb
@@ -14,7 +14,7 @@ describe Hamster::Set do
           let(:result) { set.min { |minimum, item| minimum.length <=> item.length }}
 
           it "returns #{expected.inspect}" do
-            result.should == expected
+            expect(result).to eq(expected)
           end
         end
       end
@@ -28,7 +28,7 @@ describe Hamster::Set do
       ].each do |values, expected|
         describe "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            S[*values].min.should == expected
+            expect(S[*values].min).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/set/new_spec.rb
+++ b/spec/lib/hamster/set/new_spec.rb
@@ -5,29 +5,29 @@ describe Hamster::Set do
   describe ".new" do
     it "initializes a new set" do
       set = S.new([1,2,3])
-      set.size.should be(3)
-      [1,2,3].each { |n| set.include?(n).should == true }
+      expect(set.size).to be(3)
+      [1,2,3].each { |n| expect(set.include?(n)).to eq(true) }
     end
 
     it "accepts a Range" do
       set = S.new(1..3)
-      set.size.should be(3)
-      [1,2,3].each { |n| set.include?(n).should == true }
+      expect(set.size).to be(3)
+      [1,2,3].each { |n| expect(set.include?(n)).to eq(true) }
     end
 
     it "returns a Set which doesn't change even if the initializer is mutated" do
       array = [1,2,3]
       set = S.new([1,2,3])
       array.push('BAD')
-      set.should eql(S[1,2,3])
+      expect(set).to eql(S[1,2,3])
     end
 
     context "from a subclass" do
       it "returns a frozen instance of the subclass" do
         subclass = Class.new(Hamster::Set)
         instance = subclass.new(["some", "values"])
-        instance.class.should be subclass
-        instance.should be_frozen
+        expect(instance.class).to be subclass
+        expect(instance).to be_frozen
       end
     end
 
@@ -39,16 +39,16 @@ describe Hamster::Set do
       end
 
       set = SnazzySet.new
-      set.size.should be(1)
-      set.include?('SNAZZY!!!').should == true
+      expect(set.size).to be(1)
+      expect(set.include?('SNAZZY!!!')).to eq(true)
     end
   end
 
   describe "[]" do
     it "accepts any number of arguments and initializes a new set" do
       set = S[1,2,3,4]
-      set.size.should be(4)
-      [1,2,3,4].each { |n| set.include?(n).should == true }
+      expect(set.size).to be(4)
+      [1,2,3,4].each { |n| expect(set.include?(n)).to eq(true) }
     end
   end
 end

--- a/spec/lib/hamster/set/none_spec.rb
+++ b/spec/lib/hamster/set/none_spec.rb
@@ -5,11 +5,11 @@ describe Hamster::Set do
   describe "#none?" do
     context "when empty" do
       it "with a block returns true" do
-        S.empty.none? {}.should == true
+        expect(S.empty.none? {}).to eq(true)
       end
 
       it "with no block returns true" do
-        S.empty.none?.should == true
+        expect(S.empty.none?).to eq(true)
       end
     end
 
@@ -19,28 +19,28 @@ describe Hamster::Set do
 
         ["A", "B", "C", nil].each do |value|
           it "returns false if the block ever returns true (#{value.inspect})" do
-            set.none? { |item| item == value }.should == false
+            expect(set.none? { |item| item == value }).to eq(false)
           end
         end
 
         it "returns true if the block always returns false" do
-          set.none? { |item| item == "D" }.should == true
+          expect(set.none? { |item| item == "D" }).to eq(true)
         end
 
         it "stops iterating as soon as the block returns true" do
           yielded = []
           set.none? { |item| yielded << item; true }
-          yielded.size.should == 1
+          expect(yielded.size).to eq(1)
         end
       end
 
       context "with no block" do
         it "returns false if any value is truthy" do
-          S[nil, false, true, "A"].none?.should == false
+          expect(S[nil, false, true, "A"].none?).to eq(false)
         end
 
         it "returns true if all values are falsey" do
-          S[nil, false].none?.should == true
+          expect(S[nil, false].none?).to eq(true)
         end
       end
     end

--- a/spec/lib/hamster/set/one_spec.rb
+++ b/spec/lib/hamster/set/one_spec.rb
@@ -5,11 +5,11 @@ describe Hamster::Set do
   describe "#one?" do
     context "when empty" do
       it "with a block returns false" do
-        S.empty.one? {}.should == false
+        expect(S.empty.one? {}).to eq(false)
       end
 
       it "with no block returns false" do
-        S.empty.one?.should == false
+        expect(S.empty.one?).to eq(false)
       end
     end
 
@@ -18,29 +18,29 @@ describe Hamster::Set do
         let(:set) { S["A", "B", "C"] }
 
         it "returns false if the block returns true more than once" do
-          set.one? { |item| true }.should == false
+          expect(set.one? { |item| true }).to eq(false)
         end
 
         it "returns false if the block never returns true" do
-          set.one? { |item| false }.should == false
+          expect(set.one? { |item| false }).to eq(false)
         end
 
         it "returns true if the block only returns true once" do
-          set.one? { |item| item == "A" }.should == true
+          expect(set.one? { |item| item == "A" }).to eq(true)
         end
       end
 
       context "with no block" do
         it "returns false if more than one value is truthy" do
-          S[nil, true, "A"].one?.should == false
+          expect(S[nil, true, "A"].one?).to eq(false)
         end
 
         it "returns true if only one value is truthy" do
-          S[nil, true, false].one?.should == true
+          expect(S[nil, true, false].one?).to eq(true)
         end
 
         it "returns false if no values are truthy" do
-          S[nil, false].one?.should == false
+          expect(S[nil, false].one?).to eq(false)
         end
       end
     end

--- a/spec/lib/hamster/set/partition_spec.rb
+++ b/spec/lib/hamster/set/partition_spec.rb
@@ -23,28 +23,28 @@ describe Hamster::Set do
 
           it "preserves the original" do
             result
-            set.should eql(S[*values])
+            expect(set).to eql(S[*values])
           end
 
           it "returns a frozen array with two items" do
-            result.class.should be(Array)
-            result.should be_frozen
-            result.size.should be(2)
+            expect(result.class).to be(Array)
+            expect(result).to be_frozen
+            expect(result.size).to be(2)
           end
 
           it "correctly identifies the matches" do
-            matches.should eql(S[*expected_matches])
+            expect(matches).to eql(S[*expected_matches])
           end
 
           it "correctly identifies the remainder" do
-            remainder.should eql(S[*expected_remainder])
+            expect(remainder).to eql(S[*expected_remainder])
           end
         end
 
         describe "without a block" do
           it "returns an Enumerator" do
-            set.partition.class.should be(Enumerator)
-            set.partition.each(&:odd?).should eql([S.new(expected_matches), S.new(expected_remainder)])
+            expect(set.partition.class).to be(Enumerator)
+            expect(set.partition.each(&:odd?)).to eql([S.new(expected_matches), S.new(expected_remainder)])
           end
         end
       end

--- a/spec/lib/hamster/set/product_spec.rb
+++ b/spec/lib/hamster/set/product_spec.rb
@@ -12,11 +12,11 @@ describe Hamster::Set do
         let(:set) { S[*values] }
 
         it "returns #{expected.inspect}" do
-          set.product.should == expected
+          expect(set.product).to eq(expected)
         end
 
         it "doesn't change the original Set" do
-          set.should eql(S.new(values))
+          expect(set).to eql(S.new(values))
         end
       end
     end

--- a/spec/lib/hamster/set/reduce_spec.rb
+++ b/spec/lib/hamster/set/reduce_spec.rb
@@ -15,7 +15,7 @@ describe Hamster::Set do
           context "with an initial value of #{initial}" do
             context "and a block" do
               it "returns #{expected.inspect}" do
-                set.send(method, initial) { |memo, item| memo - item }.should == expected
+                expect(set.send(method, initial) { |memo, item| memo - item }).to eq(expected)
               end
             end
           end
@@ -33,7 +33,7 @@ describe Hamster::Set do
           context "with no initial value" do
             context "and a block" do
               it "returns #{expected.inspect}" do
-                set.send(method) { |memo, item| memo + item }.should == expected
+                expect(set.send(method) { |memo, item| memo + item }).to eq(expected)
               end
             end
           end
@@ -42,13 +42,13 @@ describe Hamster::Set do
 
       describe "with no block and a symbol argument" do
         it "uses the symbol as the name of a method to reduce with" do
-          S[1, 2, 3].reduce(:+).should == 6
+          expect(S[1, 2, 3].reduce(:+)).to eq(6)
         end
       end
 
       describe "with no block and a string argument" do
         it "uses the string as the name of a method to reduce with" do
-          S[1, 2, 3].reduce('+').should == 6
+          expect(S[1, 2, 3].reduce('+')).to eq(6)
         end
       end
     end

--- a/spec/lib/hamster/set/reject_spec.rb
+++ b/spec/lib/hamster/set/reject_spec.rb
@@ -8,7 +8,7 @@ describe Hamster::Set do
 
       context "when nothing matches" do
         it "returns self" do
-          set.send(method) { |item| false }.should equal(set)
+          expect(set.send(method) { |item| false }).to equal(set)
         end
       end
 
@@ -18,18 +18,18 @@ describe Hamster::Set do
 
           it "preserves the original" do
             result
-            set.should eql(S["A", "B", "C"])
+            expect(set).to eql(S["A", "B", "C"])
           end
 
           it "returns a set with the matching values" do
-            result.should eql(S["B", "C"])
+            expect(result).to eql(S["B", "C"])
           end
         end
 
         context "with no block" do
           it "returns self" do
-            set.send(method).class.should be(Enumerator)
-            set.send(method).each { |item| item == "A" }.should == S["B", "C"]
+            expect(set.send(method).class).to be(Enumerator)
+            expect(set.send(method).each { |item| item == "A" }).to eq(S["B", "C"])
           end
         end
       end
@@ -40,9 +40,9 @@ describe Hamster::Set do
           set   = S.new(array)
           [0, 10, 100, 200, 500, 800, 900, 999, 1000].each do |threshold|
             result = set.send(method) { |item| item > threshold }
-            result.size.should == threshold
-            1.upto(threshold)  { |n| result.include?(n).should == true }
-            (threshold+1).upto(1000) { |n| result.include?(n).should == false }
+            expect(result.size).to eq(threshold)
+            1.upto(threshold)  { |n| expect(result.include?(n)).to eq(true) }
+            (threshold+1).upto(1000) { |n| expect(result.include?(n)).to eq(false) }
           end
         end
       end

--- a/spec/lib/hamster/set/sample_spec.rb
+++ b/spec/lib/hamster/set/sample_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::Set do
 
     it "returns a randomly chosen item" do
       chosen = 100.times.map { set.sample }
-      chosen.each { |item| set.include?(item).should == true }
-      set.each { |item| chosen.include?(item).should == true }
+      chosen.each { |item| expect(set.include?(item)).to eq(true) }
+      set.each { |item| expect(chosen.include?(item)).to eq(true) }
     end
   end
 end

--- a/spec/lib/hamster/set/select_spec.rb
+++ b/spec/lib/hamster/set/select_spec.rb
@@ -8,7 +8,7 @@ describe Hamster::Set do
 
       context "when everything matches" do
         it "returns self" do
-          set.send(method) { |item| true }.should equal(set)
+          expect(set.send(method) { |item| true }).to equal(set)
         end
       end
 
@@ -18,18 +18,18 @@ describe Hamster::Set do
 
           it "preserves the original" do
             result
-            set.should eql(S["A", "B", "C"])
+            expect(set).to eql(S["A", "B", "C"])
           end
 
           it "returns a set with the matching values" do
-            result.should eql(S["A"])
+            expect(result).to eql(S["A"])
           end
         end
 
         context "with no block" do
           it "returns an Enumerator" do
-            set.send(method).class.should be(Enumerator)
-            set.send(method).each { |item| item == "A" }.should eql(S["A"])
+            expect(set.send(method).class).to be(Enumerator)
+            expect(set.send(method).each { |item| item == "A" }).to eql(S["A"])
           end
         end
       end
@@ -39,11 +39,11 @@ describe Hamster::Set do
 
         it "preserves the original" do
           result
-          set.should eql(S["A", "B", "C"])
+          expect(set).to eql(S["A", "B", "C"])
         end
 
         it "returns the canonical empty set" do
-          result.should equal(Hamster::EmptySet)
+          expect(result).to equal(Hamster::EmptySet)
         end
       end
 
@@ -51,9 +51,9 @@ describe Hamster::Set do
         it "returns an instance of the same class" do
           subclass = Class.new(Hamster::Set)
           instance = subclass.new(['A', 'B', 'C'])
-          instance.send(method) { true }.class.should be(subclass)
-          instance.send(method) { false }.class.should be(subclass)
-          instance.send(method) { rand(2) == 0 }.class.should be(subclass)
+          expect(instance.send(method) { true }.class).to be(subclass)
+          expect(instance.send(method) { false }.class).to be(subclass)
+          expect(instance.send(method) { rand(2) == 0 }.class).to be(subclass)
         end
       end
 
@@ -63,11 +63,11 @@ describe Hamster::Set do
         30.times do
           threshold = rand(1000)
           result    = original.send(method) { |item| item <= threshold }
-          result.size.should == threshold
-          result.each { |item| item.should <= threshold }
-          (threshold+1).upto(1000) { |item| result.include?(item).should == false }
+          expect(result.size).to eq(threshold)
+          result.each { |item| expect(item).to be <= threshold }
+          (threshold+1).upto(1000) { |item| expect(result.include?(item)).to eq(false) }
         end
-        original.should eql(S.new(items))
+        expect(original).to eql(S.new(items))
       end
     end
   end

--- a/spec/lib/hamster/set/size_spec.rb
+++ b/spec/lib/hamster/set/size_spec.rb
@@ -10,7 +10,7 @@ describe Hamster::Set do
         [%w[A B C], 3],
       ].each do |values, result|
         it "returns #{result} for #{values.inspect}" do
-          S[*values].send(method).should == result
+          expect(S[*values].send(method)).to eq(result)
         end
       end
     end

--- a/spec/lib/hamster/set/sorting_spec.rb
+++ b/spec/lib/hamster/set/sorting_spec.rb
@@ -19,13 +19,13 @@ describe Hamster::Set do
             let(:result) { set.send(method, &comparator) }
 
             it "returns #{expected.inspect}" do
-              result.should eql(SS.new(expected, &comparator))
-              result.to_a.should == expected
+              expect(result).to eql(SS.new(expected, &comparator))
+              expect(result.to_a).to eq(expected)
             end
 
             it "doesn't change the original Set" do
               result
-              set.should eql(S.new(values))
+              expect(set).to eql(S.new(values))
             end
           end
 
@@ -33,13 +33,13 @@ describe Hamster::Set do
             let(:result) { set.send(method) }
 
             it "returns #{expected.sort.inspect}" do
-              result.should eql(SS[*expected])
-              result.to_a.should == expected.sort
+              expect(result).to eql(SS[*expected])
+              expect(result.to_a).to eq(expected.sort)
             end
 
             it "doesn't change the original Set" do
               result
-              set.should eql(S.new(values))
+              expect(set).to eql(S.new(values))
             end
           end
         end
@@ -53,8 +53,8 @@ describe Hamster::Set do
       fn    = lambda { |x| count += 1; -x }
       items = 100.times.collect { rand(10000) }.uniq
 
-      S[*items].sort_by(&fn).to_a.should == items.sort.reverse
-      count.should == items.length
+      expect(S[*items].sort_by(&fn).to_a).to eq(items.sort.reverse)
+      expect(count).to eq(items.length)
     end
   end
 end

--- a/spec/lib/hamster/set/subset_spec.rb
+++ b/spec/lib/hamster/set/subset_spec.rb
@@ -19,7 +19,7 @@ describe Hamster::Set do
       ].each do |a, b, expected|
         describe "for #{a.inspect} and #{b.inspect}" do
           it "returns #{expected}"  do
-            S[*a].send(method, S[*b]).should == expected
+            expect(S[*a].send(method, S[*b])).to eq(expected)
           end
         end
       end
@@ -43,7 +43,7 @@ describe Hamster::Set do
       ].each do |a, b, expected|
         describe "for #{a.inspect} and #{b.inspect}" do
           it "returns #{expected}"  do
-            S[*a].send(method, S[*b]).should == expected
+            expect(S[*a].send(method, S[*b])).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/set/sum_spec.rb
+++ b/spec/lib/hamster/set/sum_spec.rb
@@ -12,11 +12,11 @@ describe Hamster::Set do
         let(:set) { S[*values] }
 
         it "returns #{expected.inspect}" do
-          set.sum.should == expected
+          expect(set.sum).to eq(expected)
         end
 
         it "doesn't change the original Set" do
-          set.should eql(S.new(values))
+          expect(set).to eql(S.new(values))
         end
       end
     end

--- a/spec/lib/hamster/set/superset_spec.rb
+++ b/spec/lib/hamster/set/superset_spec.rb
@@ -19,7 +19,7 @@ describe Hamster::Set do
       ].each do |a, b, expected|
         describe "for #{a.inspect} and #{b.inspect}" do
           it "returns #{expected}"  do
-            S[*a].send(method, S[*b]).should == expected
+            expect(S[*a].send(method, S[*b])).to eq(expected)
           end
         end
       end
@@ -43,7 +43,7 @@ describe Hamster::Set do
       ].each do |a, b, expected|
         describe "for #{a.inspect} and #{b.inspect}" do
           it "returns #{expected}"  do
-            S[*a].send(method, S[*b]).should == expected
+            expect(S[*a].send(method, S[*b])).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/set/to_a_spec.rb
+++ b/spec/lib/hamster/set/to_a_spec.rb
@@ -11,18 +11,18 @@ describe Hamster::Set do
 
         context "on 'a'..'#{letter}'" do
           it "returns an equivalent array" do
-            result.sort.should == values.sort
+            expect(result.sort).to eq(values.sort)
           end
 
           it "doesn't change the original Set" do
             result
-            set.should eql(S[*values])
+            expect(set).to eql(S[*values])
           end
 
           it "returns a mutable array" do
             expect(result.last).to_not eq("The End")
             result << "The End"
-            result.last.should == "The End"
+            expect(result.last).to eq("The End")
           end
         end
       end

--- a/spec/lib/hamster/set/to_list_spec.rb
+++ b/spec/lib/hamster/set/to_list_spec.rb
@@ -14,21 +14,21 @@ describe Hamster::Set do
         let(:list) { set.to_list }
 
         it "returns a list" do
-          list.is_a?(Hamster::List).should == true
+          expect(list.is_a?(Hamster::List)).to eq(true)
         end
 
         it "doesn't change the original Set" do
           list
-          set.should eql(S.new(values))
+          expect(set).to eql(S.new(values))
         end
 
         describe "the returned list" do
           it "has the correct length" do
-            list.size.should == values.size
+            expect(list.size).to eq(values.size)
           end
 
           it "contains all values" do
-            list.to_a.sort.should == values.sort
+            expect(list.to_a.sort).to eq(values.sort)
           end
         end
       end

--- a/spec/lib/hamster/set/to_set_spec.rb
+++ b/spec/lib/hamster/set/to_set_spec.rb
@@ -12,7 +12,7 @@ describe Hamster::Set do
         let(:set) { S[*values] }
 
         it "returns self" do
-          set.to_set.should equal(set)
+          expect(set.to_set).to equal(set)
         end
       end
     end

--- a/spec/lib/hamster/set/union_spec.rb
+++ b/spec/lib/hamster/set/union_spec.rb
@@ -18,9 +18,9 @@ describe Hamster::Set do
           let(:set_b) { S[*b] }
 
           it "returns #{expected.inspect}, without changing the original Sets" do
-            set_a.send(method, set_b).should eql(S[*expected])
-            set_a.should eql(S.new(a))
-            set_b.should eql(S.new(b))
+            expect(set_a.send(method, set_b)).to eql(S[*expected])
+            expect(set_a).to eql(S.new(a))
+            expect(set_b).to eql(S.new(b))
           end
         end
 
@@ -29,24 +29,24 @@ describe Hamster::Set do
           let(:set_b) { S[*b] }
 
           it "returns #{expected.inspect}, without changing the original Sets" do
-            set_b.send(method, set_a).should eql(S[*expected])
-            set_a.should eql(S.new(a))
-            set_b.should eql(S.new(b))
+            expect(set_b.send(method, set_a)).to eql(S[*expected])
+            expect(set_a).to eql(S.new(a))
+            expect(set_b).to eql(S.new(b))
           end
         end
 
         context "when passed a Ruby Array" do
           it "returns the expected Set" do
-            S[*a].send(method, b.freeze).should eql(S[*expected])
-            S[*b].send(method, a.freeze).should eql(S[*expected])
+            expect(S[*a].send(method, b.freeze)).to eql(S[*expected])
+            expect(S[*b].send(method, a.freeze)).to eql(S[*expected])
           end
         end
 
         context "from a subclass" do
           it "returns an instance of the subclass" do
             subclass = Class.new(Hamster::Set)
-            subclass.new(a).send(method, S.new(b)).class.should be(subclass)
-            subclass.new(b).send(method, S.new(a)).class.should be(subclass)
+            expect(subclass.new(a).send(method, S.new(b)).class).to be(subclass)
+            expect(subclass.new(b).send(method, S.new(a)).class).to be(subclass)
           end
         end
       end
@@ -56,7 +56,7 @@ describe Hamster::Set do
         let(:set_b) { S.new(1..200) }
 
         it "returns self" do
-          set_a.send(method, set_b).should be(set_a)
+          expect(set_a.send(method, set_b)).to be(set_a)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/above_spec.rb
+++ b/spec/lib/hamster/sorted_set/above_spec.rb
@@ -11,9 +11,9 @@ describe Hamster::SortedSet do
           threshold = rand(1000)
           result    = set.above(threshold)
           array     = items.select { |x| x > threshold }.sort
-          result.class.should be(Hamster::SortedSet)
-          result.size.should == array.size
-          result.to_a.should == array
+          expect(result.class).to be(Hamster::SortedSet)
+          expect(result.size).to eq(array.size)
+          expect(result.to_a).to eq(array)
         end
       end
     end
@@ -27,25 +27,25 @@ describe Hamster::SortedSet do
           result    = []
           set.above(threshold) { |x| result << x }
           array  = items.select { |x| x > threshold }.sort
-          result.size.should == array.size
-          result.should == array
+          expect(result.size).to eq(array.size)
+          expect(result).to eq(array)
         end
       end
     end
 
     context "on an empty set" do
       it "returns an empty set" do
-        SS.empty.above(1).should be_empty
-        SS.empty.above('abc').should be_empty
-        SS.empty.above(:symbol).should be_empty
+        expect(SS.empty.above(1)).to be_empty
+        expect(SS.empty.above('abc')).to be_empty
+        expect(SS.empty.above(:symbol)).to be_empty
       end
     end
 
     context "with an argument higher than all the values in the set" do
       it "returns an empty set" do
         result = SS.new(1..100).above(100)
-        result.class.should be(Hamster::SortedSet)
-        result.should be_empty
+        expect(result.class).to be(Hamster::SortedSet)
+        expect(result).to be_empty
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/add_spec.rb
+++ b/spec/lib/hamster/sorted_set/add_spec.rb
@@ -9,29 +9,29 @@ describe Hamster::SortedSet do
       context "with a unique value" do
         it "preserves the original" do
           sorted_set.send(method, "A")
-          sorted_set.should eql(SS["B", "C", "D"])
+          expect(sorted_set).to eql(SS["B", "C", "D"])
         end
 
         it "returns a copy with the superset of values (in order)" do
-          sorted_set.send(method, "A").should eql(SS["A", "B", "C", "D"])
+          expect(sorted_set.send(method, "A")).to eql(SS["A", "B", "C", "D"])
         end
       end
 
       context "with a duplicate value" do
         it "preserves the original values" do
           sorted_set.send(method, "C")
-          sorted_set.should eql(SS["B", "C", "D"])
+          expect(sorted_set).to eql(SS["B", "C", "D"])
         end
 
         it "returns self" do
-          sorted_set.send(method, "C").should equal(sorted_set)
+          expect(sorted_set.send(method, "C")).to equal(sorted_set)
         end
       end
 
       context "on a set ordered by a comparator" do
         it "inserts the new item in the correct place" do
           s = SS.new(['tick', 'pig', 'hippopotamus']) { |str| str.length }
-          s.add('giraffe').to_a.should == ['pig', 'tick', 'giraffe', 'hippopotamus']
+          expect(s.add('giraffe').to_a).to eq(['pig', 'tick', 'giraffe', 'hippopotamus'])
         end
       end
     end
@@ -41,22 +41,22 @@ describe Hamster::SortedSet do
     context "with a unique value" do
       it "preserves the original" do
         sorted_set.add?("A")
-        sorted_set.should eql(SS["B", "C", "D"])
+        expect(sorted_set).to eql(SS["B", "C", "D"])
       end
 
       it "returns a copy with the superset of values" do
-        sorted_set.add?("A").should eql(SS["A", "B", "C", "D"])
+        expect(sorted_set.add?("A")).to eql(SS["A", "B", "C", "D"])
       end
     end
 
     context "with a duplicate value" do
       it "preserves the original values" do
         sorted_set.add?("C")
-        sorted_set.should eql(SS["B", "C", "D"])
+        expect(sorted_set).to eql(SS["B", "C", "D"])
       end
 
       it "returns false" do
-        sorted_set.add?("C").should equal(false)
+        expect(sorted_set.add?("C")).to equal(false)
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/at_spec.rb
+++ b/spec/lib/hamster/sorted_set/at_spec.rb
@@ -17,7 +17,7 @@ describe Hamster::SortedSet do
     ].each do |values, number, expected|
       describe "#{values.inspect} with #{number}" do
         it "returns #{expected.inspect}" do
-          SS[*values].at(number).should == expected
+          expect(SS[*values].at(number)).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/below_spec.rb
+++ b/spec/lib/hamster/sorted_set/below_spec.rb
@@ -11,9 +11,9 @@ describe Hamster::SortedSet do
           threshold = rand(1000)
           result    = set.below(threshold)
           array     = items.select { |x| x < threshold }.sort
-          result.class.should be(Hamster::SortedSet)
-          result.size.should == array.size
-          result.to_a.should == array
+          expect(result.class).to be(Hamster::SortedSet)
+          expect(result.size).to eq(array.size)
+          expect(result.to_a).to eq(array)
         end
       end
     end
@@ -27,25 +27,25 @@ describe Hamster::SortedSet do
           result    = []
           set.below(threshold) { |x| result << x }
           array  = items.select { |x| x < threshold }.sort
-          result.size.should == array.size
-          result.should == array
+          expect(result.size).to eq(array.size)
+          expect(result).to eq(array)
         end
       end
     end
 
     context "on an empty set" do
       it "returns an empty set" do
-        SS.empty.below(1).should be_empty
-        SS.empty.below('abc').should be_empty
-        SS.empty.below(:symbol).should be_empty
+        expect(SS.empty.below(1)).to be_empty
+        expect(SS.empty.below('abc')).to be_empty
+        expect(SS.empty.below(:symbol)).to be_empty
       end
     end
 
     context "with an argument lower than all the values in the set" do
       it "returns an empty set" do
         result = SS.new(1..100).below(1)
-        result.class.should be(Hamster::SortedSet)
-        result.should be_empty
+        expect(result.class).to be(Hamster::SortedSet)
+        expect(result).to be_empty
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/between_spec.rb
+++ b/spec/lib/hamster/sorted_set/between_spec.rb
@@ -11,9 +11,9 @@ describe Hamster::SortedSet do
           from,to = [rand(1000),rand(1000)].sort
           result  = set.between(from, to)
           array   = items.select { |x| x >= from && x <= to }.sort
-          result.class.should be(Hamster::SortedSet)
-          result.size.should == array.size
-          result.to_a.should == array
+          expect(result.class).to be(Hamster::SortedSet)
+          expect(result.size).to eq(array.size)
+          expect(result.to_a).to eq(array)
         end
       end
     end
@@ -27,25 +27,25 @@ describe Hamster::SortedSet do
           result  = []
           set.between(from, to) { |x| result << x }
           array  = items.select { |x| x >= from && x <= to }.sort
-          result.size.should == array.size
-          result.should == array
+          expect(result.size).to eq(array.size)
+          expect(result).to eq(array)
         end
       end
     end
 
     context "on an empty set" do
       it "returns an empty set" do
-        SS.empty.between(1, 2).should be_empty
-        SS.empty.between('abc', 'def').should be_empty
-        SS.empty.between(:symbol, :another).should be_empty
+        expect(SS.empty.between(1, 2)).to be_empty
+        expect(SS.empty.between('abc', 'def')).to be_empty
+        expect(SS.empty.between(:symbol, :another)).to be_empty
       end
     end
 
     context "with a 'to' argument lower than the 'from' argument" do
       it "returns an empty set" do
         result = SS.new(1..100).between(6, 5)
-        result.class.should be(Hamster::SortedSet)
-        result.should be_empty
+        expect(result.class).to be(Hamster::SortedSet)
+        expect(result).to be_empty
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/clear_spec.rb
+++ b/spec/lib/hamster/sorted_set/clear_spec.rb
@@ -13,12 +13,12 @@ describe Hamster::SortedSet do
 
         it "preserves the original" do
           sorted_set.clear
-          sorted_set.should eql(SS[*values])
+          expect(sorted_set).to eql(SS[*values])
         end
 
         it "returns an empty set" do
-          sorted_set.clear.should equal(Hamster::EmptySortedSet)
-          sorted_set.clear.should be_empty
+          expect(sorted_set.clear).to equal(Hamster::EmptySortedSet)
+          expect(sorted_set.clear).to be_empty
         end
       end
     end
@@ -27,8 +27,8 @@ describe Hamster::SortedSet do
       it "returns an empty instance of the subclass" do
         subclass = Class.new(Hamster::SortedSet)
         instance = subclass.new([:a, :b, :c, :d])
-        instance.clear.class.should be(subclass)
-        instance.clear.should be_empty
+        expect(instance.clear.class).to be(subclass)
+        expect(instance.clear).to be_empty
       end
     end
 
@@ -36,8 +36,8 @@ describe Hamster::SortedSet do
       let(:sorted_set) { SS.new([1, 2, 3]) { |x| -x } }
       it "returns an empty instance with same comparator" do
         e = sorted_set.clear
-        e.should be_empty
-        e.add(4).add(5).add(6).to_a.should == [6, 5, 4]
+        expect(e).to be_empty
+        expect(e.add(4).add(5).add(6).to_a).to eq([6, 5, 4])
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/copying_spec.rb
+++ b/spec/lib/hamster/sorted_set/copying_spec.rb
@@ -13,7 +13,7 @@ describe Hamster::SortedSet do
         let(:sorted_set) { SS[*values] }
 
         it "returns self" do
-          sorted_set.send(method).should equal(sorted_set)
+          expect(sorted_set.send(method)).to equal(sorted_set)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/delete_at_spec.rb
+++ b/spec/lib/hamster/sorted_set/delete_at_spec.rb
@@ -6,14 +6,14 @@ describe Hamster::SortedSet do
     let(:sorted_set) { SS[1,2,3,4,5] }
 
     it "removes the element at the specified index" do
-      sorted_set.delete_at(0).should  eql(SS[2,3,4,5])
-      sorted_set.delete_at(2).should  eql(SS[1,2,4,5])
-      sorted_set.delete_at(-1).should eql(SS[1,2,3,4])
+      expect(sorted_set.delete_at(0)).to  eql(SS[2,3,4,5])
+      expect(sorted_set.delete_at(2)).to  eql(SS[1,2,4,5])
+      expect(sorted_set.delete_at(-1)).to eql(SS[1,2,3,4])
     end
 
     it "makes no modification if the index is out of range" do
-      sorted_set.delete_at(5).should eql(sorted_set)
-      sorted_set.delete_at(-6).should eql(sorted_set)
+      expect(sorted_set.delete_at(5)).to eql(sorted_set)
+      expect(sorted_set.delete_at(-6)).to eql(sorted_set)
     end
   end
 end

--- a/spec/lib/hamster/sorted_set/delete_spec.rb
+++ b/spec/lib/hamster/sorted_set/delete_spec.rb
@@ -7,29 +7,29 @@ describe Hamster::SortedSet do
   describe "#delete" do
     context "on an empty set" do
       it "returns an empty set" do
-        SS.empty.delete(0).should be(SS.empty)
+        expect(SS.empty.delete(0)).to be(SS.empty)
       end
     end
 
     context "with an existing value" do
       it "preserves the original" do
         sorted_set.delete("B")
-        sorted_set.should eql(SS["A", "B", "C"])
+        expect(sorted_set).to eql(SS["A", "B", "C"])
       end
 
       it "returns a copy with the remaining of values" do
-        sorted_set.delete("B").should eql(SS["A", "C"])
+        expect(sorted_set.delete("B")).to eql(SS["A", "C"])
       end
     end
 
     context "with a non-existing value" do
       it "preserves the original values" do
         sorted_set.delete("D")
-        sorted_set.should eql(SS["A", "B", "C"])
+        expect(sorted_set).to eql(SS["A", "B", "C"])
       end
 
       it "returns self" do
-        sorted_set.delete("D").should equal(sorted_set)
+        expect(sorted_set.delete("D")).to equal(sorted_set)
       end
     end
 
@@ -38,12 +38,12 @@ describe Hamster::SortedSet do
         ss = SS.new(["peanuts", "jam", "milk"]) { |word| word.length }
         ss = ss.delete("jam").delete("peanuts").delete("milk")
         ss = ss.add("banana").add("sugar").add("spam")
-        ss.to_a.should == ['spam', 'sugar', 'banana']
+        expect(ss.to_a).to eq(['spam', 'sugar', 'banana'])
       end
 
       context "when the set is in natural order" do
         it "returns the canonical empty set" do
-          sorted_set.delete("B").delete("C").delete("A").should be(Hamster::EmptySortedSet)
+          expect(sorted_set.delete("B").delete("C").delete("A")).to be(Hamster::EmptySortedSet)
         end
       end
     end
@@ -56,8 +56,8 @@ describe Hamster::SortedSet do
           it "returns #{expected.inspect}" do
             set    = SS.new(values)
             result = to_delete.reduce(set) { |s,val| s.delete(val) }
-            result.should eql(SS.new(expected))
-            result.to_a.should eql(expected)
+            expect(result).to eql(SS.new(expected))
+            expect(result.to_a).to eql(expected)
           end
         end
       end
@@ -68,22 +68,22 @@ describe Hamster::SortedSet do
     context "with an existing value" do
       it "preserves the original" do
         sorted_set.delete?("B")
-        sorted_set.should eql(SS["A", "B", "C"])
+        expect(sorted_set).to eql(SS["A", "B", "C"])
       end
 
       it "returns a copy with the remaining values" do
-        sorted_set.delete?("B").should eql(SS["A", "C"])
+        expect(sorted_set.delete?("B")).to eql(SS["A", "C"])
       end
     end
 
     context "with a non-existing value" do
       it "preserves the original values" do
         sorted_set.delete?("D")
-        sorted_set.should eql(SS["A", "B", "C"])
+        expect(sorted_set).to eql(SS["A", "B", "C"])
       end
 
       it "returns false" do
-        sorted_set.delete?("D").should be(false)
+        expect(sorted_set.delete?("D")).to be(false)
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/difference_spec.rb
+++ b/spec/lib/hamster/sorted_set/difference_spec.rb
@@ -14,7 +14,7 @@ describe Hamster::SortedSet do
       ].each do |a, b, expected|
         context "for #{a.inspect} and #{b.inspect}" do
           it "returns #{expected.inspect}"  do
-            SS[*a].send(method, SS[*b]).should eql(SS[*expected])
+            expect(SS[*a].send(method, SS[*b])).to eql(SS[*expected])
           end
         end
       end

--- a/spec/lib/hamster/sorted_set/disjoint_spec.rb
+++ b/spec/lib/hamster/sorted_set/disjoint_spec.rb
@@ -18,7 +18,7 @@ describe Hamster::SortedSet do
     ].each do |a, b, expected|
       context "for #{a.inspect} and #{b.inspect}" do
         it "returns #{expected}" do
-          SS[*a].disjoint?(SS[*b]).should be(expected)
+          expect(SS[*a].disjoint?(SS[*b])).to be(expected)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/drop_spec.rb
+++ b/spec/lib/hamster/sorted_set/drop_spec.rb
@@ -17,11 +17,11 @@ describe Hamster::SortedSet do
 
         it "preserves the original" do
           sorted_set.drop(number)
-          sorted_set.should eql(SS[*values])
+          expect(sorted_set).to eql(SS[*values])
         end
 
         it "returns #{expected.inspect}" do
-          sorted_set.drop(number).should eql(SS[*expected])
+          expect(sorted_set.drop(number)).to eql(SS[*expected])
         end
       end
     end
@@ -29,27 +29,27 @@ describe Hamster::SortedSet do
     context "when argument is zero" do
       let(:sorted_set) { SS[6, 7, 8, 9] }
       it "returns self" do
-        sorted_set.drop(0).should be(sorted_set)
+        expect(sorted_set.drop(0)).to be(sorted_set)
       end
     end
 
     context "when the set has a custom order" do
       let(:sorted_set) { SS.new([1, 2, 3]) { |x| -x }}
       it "maintains the custom order" do
-        sorted_set.drop(1).to_a.should == [2, 1]
-        sorted_set.drop(2).to_a.should == [1]
+        expect(sorted_set.drop(1).to_a).to eq([2, 1])
+        expect(sorted_set.drop(2).to_a).to eq([1])
       end
 
       it "keeps the comparator even when set is cleared" do
         s = sorted_set.drop(3)
-        s.add(4).add(5).add(6).to_a.should == [6, 5, 4]
+        expect(s.add(4).add(5).add(6).to_a).to eq([6, 5, 4])
       end
     end
 
     context "when called on a subclass" do
       it "should return an instance of the subclass" do
         subclass = Class.new(Hamster::SortedSet)
-        subclass.new([1,2,3]).drop(1).class.should be(subclass)
+        expect(subclass.new([1,2,3]).drop(1).class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/drop_while_spec.rb
+++ b/spec/lib/hamster/sorted_set/drop_while_spec.rb
@@ -15,18 +15,18 @@ describe Hamster::SortedSet do
         context "with a block" do
           it "preserves the original" do
             sorted_set.drop_while { |item| item < "C" }
-            sorted_set.should eql(SS[*values])
+            expect(sorted_set).to eql(SS[*values])
           end
 
           it "returns #{expected.inspect}" do
-            sorted_set.drop_while { |item| item < "C" }.should eql(SS[*expected])
+            expect(sorted_set.drop_while { |item| item < "C" }).to eql(SS[*expected])
           end
         end
 
         context "without a block" do
           it "returns an Enumerator" do
-            sorted_set.drop_while.class.should be(Enumerator)
-            sorted_set.drop_while.each { |item| item < "C" }.should eql(SS[*expected])
+            expect(sorted_set.drop_while.class).to be(Enumerator)
+            expect(sorted_set.drop_while.each { |item| item < "C" }).to eql(SS[*expected])
           end
         end
       end

--- a/spec/lib/hamster/sorted_set/each_spec.rb
+++ b/spec/lib/hamster/sorted_set/each_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::SortedSet do
       let(:sorted_set) { SS["A", "B", "C"] }
 
       it "returns an Enumerator" do
-        sorted_set.each.class.should be(Enumerator)
-        sorted_set.each.to_a.should eql(sorted_set.to_a)
+        expect(sorted_set.each.class).to be(Enumerator)
+        expect(sorted_set.each.to_a).to eql(sorted_set.to_a)
       end
     end
 
@@ -16,13 +16,13 @@ describe Hamster::SortedSet do
       let(:sorted_set) { SS.new((1..1025).to_a.reverse) }
 
       it "returns self" do
-        sorted_set.each {}.should be(sorted_set)
+        expect(sorted_set.each {}).to be(sorted_set)
       end
 
       it "iterates over the items in order" do
         items = []
         sorted_set.each { |item| items << item }
-        items.should == (1..1025).to_a
+        expect(items).to eq((1..1025).to_a)
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/empty_spec.rb
+++ b/spec/lib/hamster/sorted_set/empty_spec.rb
@@ -12,7 +12,7 @@ describe Hamster::SortedSet do
         let(:sorted_set) { SS[*values] }
 
         it "returns #{expected.inspect}" do
-          sorted_set.empty?.should == expected
+          expect(sorted_set.empty?).to eq(expected)
         end
       end
     end
@@ -20,15 +20,15 @@ describe Hamster::SortedSet do
 
   describe ".empty" do
     it "returns the canonical empty set" do
-      SS.empty.size.should be(0)
-      SS.empty.object_id.should be(SS.empty.object_id)
+      expect(SS.empty.size).to be(0)
+      expect(SS.empty.object_id).to be(SS.empty.object_id)
     end
 
     context "from a subclass" do
       it "returns an empty instance of the subclass" do
         subclass = Class.new(Hamster::SortedSet)
-        subclass.empty.class.should be(subclass)
-        subclass.empty.should be_empty
+        expect(subclass.empty.class).to be(subclass)
+        expect(subclass.empty).to be_empty
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/exclusion_spec.rb
+++ b/spec/lib/hamster/sorted_set/exclusion_spec.rb
@@ -14,7 +14,7 @@ describe Hamster::SortedSet do
       ].each do |a, b, expected|
         context "for #{a.inspect} and #{b.inspect}" do
           it "returns #{expected.inspect}"  do
-            SS[*a].send(method, SS[*b]).should eql(SS[*expected])
+            expect(SS[*a].send(method, SS[*b])).to eql(SS[*expected])
           end
         end
       end

--- a/spec/lib/hamster/sorted_set/fetch_spec.rb
+++ b/spec/lib/hamster/sorted_set/fetch_spec.rb
@@ -8,16 +8,16 @@ describe Hamster::SortedSet do
     context "with no default provided" do
       context "when the index exists" do
         it "returns the value at the index" do
-          sorted_set.fetch(0).should == "a"
-          sorted_set.fetch(1).should == "b"
-          sorted_set.fetch(2).should == "c"
+          expect(sorted_set.fetch(0)).to eq("a")
+          expect(sorted_set.fetch(1)).to eq("b")
+          expect(sorted_set.fetch(2)).to eq("c")
         end
       end
 
       context "when the key does not exist" do
         it "raises an IndexError" do
-          -> { sorted_set.fetch(3) }.should raise_error(IndexError)
-          -> { sorted_set.fetch(-4) }.should raise_error(IndexError)
+          expect { sorted_set.fetch(3) }.to raise_error(IndexError)
+          expect { sorted_set.fetch(-4) }.to raise_error(IndexError)
         end
       end
     end
@@ -25,16 +25,16 @@ describe Hamster::SortedSet do
     context "with a default value" do
       context "when the index exists" do
         it "returns the value at the index" do
-          sorted_set.fetch(0, "default").should == "a"
-          sorted_set.fetch(1, "default").should == "b"
-          sorted_set.fetch(2, "default").should == "c"
+          expect(sorted_set.fetch(0, "default")).to eq("a")
+          expect(sorted_set.fetch(1, "default")).to eq("b")
+          expect(sorted_set.fetch(2, "default")).to eq("c")
         end
       end
 
       context "when the index does not exist" do
         it "returns the default value" do
-          sorted_set.fetch(3, "default").should == "default"
-          sorted_set.fetch(-4, "default").should == "default"
+          expect(sorted_set.fetch(3, "default")).to eq("default")
+          expect(sorted_set.fetch(-4, "default")).to eq("default")
         end
       end
     end
@@ -42,24 +42,24 @@ describe Hamster::SortedSet do
     context "with a default block" do
       context "when the index exists" do
         it "returns the value at the index" do
-          sorted_set.fetch(0) { "default".upcase }.should == "a"
-          sorted_set.fetch(1) { "default".upcase }.should == "b"
-          sorted_set.fetch(2) { "default".upcase }.should == "c"
+          expect(sorted_set.fetch(0) { "default".upcase }).to eq("a")
+          expect(sorted_set.fetch(1) { "default".upcase }).to eq("b")
+          expect(sorted_set.fetch(2) { "default".upcase }).to eq("c")
         end
       end
 
       context "when the index does not exist" do
         it "invokes the block with the missing index as parameter" do
-          sorted_set.fetch(3) { |index| index.should == 3 }
-          sorted_set.fetch(-4) { |index| index.should == -4 }
-          sorted_set.fetch(3) { "default".upcase }.should == "DEFAULT"
-          sorted_set.fetch(-4) { "default".upcase }.should == "DEFAULT"
+          sorted_set.fetch(3) { |index| expect(index).to eq(3) }
+          sorted_set.fetch(-4) { |index| expect(index).to eq(-4) }
+          expect(sorted_set.fetch(3) { "default".upcase }).to eq("DEFAULT")
+          expect(sorted_set.fetch(-4) { "default".upcase }).to eq("DEFAULT")
         end
       end
     end
 
     it "gives precedence to default block over default argument if passed both" do
-      sorted_set.fetch(3, 'one') { 'two' }.should == 'two'
+      expect(sorted_set.fetch(3, 'one') { 'two' }).to eq('two')
     end
   end
 end

--- a/spec/lib/hamster/sorted_set/find_index_spec.rb
+++ b/spec/lib/hamster/sorted_set/find_index_spec.rb
@@ -25,14 +25,14 @@ describe Hamster::SortedSet do
         unless item.nil? # test breaks otherwise
           context "looking for #{item.inspect} in #{values.inspect} without block" do
             it "returns #{expected.inspect}" do
-              SS[*values].send(method, item).should == expected
+              expect(SS[*values].send(method, item)).to eq(expected)
             end
           end
         end
 
         context "looking for #{item.inspect} in #{values.inspect} with block" do
           it "returns #{expected.inspect}" do
-            SS[*values].send(method) { |x| x == item }.should == expected
+            expect(SS[*values].send(method) { |x| x == item }).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/sorted_set/first_spec.rb
+++ b/spec/lib/hamster/sorted_set/first_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::SortedSet do
     ].each do |values, expected|
       context "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          SS[*values].first.should eql(expected)
+          expect(SS[*values].first).to eql(expected)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/from_spec.rb
+++ b/spec/lib/hamster/sorted_set/from_spec.rb
@@ -11,9 +11,9 @@ describe Hamster::SortedSet do
           threshold = rand(1000)
           result    = set.from(threshold)
           array     = items.select { |x| x >= threshold }.sort
-          result.class.should be(Hamster::SortedSet)
-          result.size.should == array.size
-          result.to_a.should == array
+          expect(result.class).to be(Hamster::SortedSet)
+          expect(result.size).to eq(array.size)
+          expect(result.to_a).to eq(array)
         end
       end
     end
@@ -27,25 +27,25 @@ describe Hamster::SortedSet do
           result    = []
           set.from(threshold) { |x| result << x }
           array  = items.select { |x| x >= threshold }.sort
-          result.size.should == array.size
-          result.should == array
+          expect(result.size).to eq(array.size)
+          expect(result).to eq(array)
         end
       end
     end
 
     context "on an empty set" do
       it "returns an empty set" do
-        SS.empty.from(1).should be_empty
-        SS.empty.from('abc').should be_empty
-        SS.empty.from(:symbol).should be_empty
+        expect(SS.empty.from(1)).to be_empty
+        expect(SS.empty.from('abc')).to be_empty
+        expect(SS.empty.from(:symbol)).to be_empty
       end
     end
 
     context "with an argument higher than all the values in the set" do
       it "returns an empty set" do
         result = SS.new(1..100).from(101)
-        result.class.should be(Hamster::SortedSet)
-        result.should be_empty
+        expect(result.class).to be(Hamster::SortedSet)
+        expect(result).to be_empty
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/group_by_spec.rb
+++ b/spec/lib/hamster/sorted_set/group_by_spec.rb
@@ -15,11 +15,11 @@ describe Hamster::SortedSet do
 
             it "preserves the original" do
               sorted_set.send(method, &:odd?)
-              sorted_set.should eql(SS[*values])
+              expect(sorted_set).to eql(SS[*values])
             end
 
             it "returns #{expected.inspect}" do
-              sorted_set.send(method, &:odd?).should eql(H[*expected])
+              expect(sorted_set.send(method, &:odd?)).to eql(H[*expected])
             end
           end
         end
@@ -36,11 +36,11 @@ describe Hamster::SortedSet do
 
             it "preserves the original" do
               sorted_set.group_by
-              sorted_set.should eql(SS[*values])
+              expect(sorted_set).to eql(SS[*values])
             end
 
             it "returns #{expected.inspect}" do
-              sorted_set.group_by.should eql(H[*expected])
+              expect(sorted_set.group_by).to eql(H[*expected])
             end
           end
         end
@@ -50,7 +50,7 @@ describe Hamster::SortedSet do
         it "returns an Hash whose values are instances of the subclass" do
           subclass = Class.new(Hamster::SortedSet)
           instance = subclass.new(['some', 'strings', 'here'])
-          instance.group_by { |x| x }.values.each { |v| v.class.should be(subclass) }
+          instance.group_by { |x| x }.values.each { |v| expect(v.class).to be(subclass) }
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/include_spec.rb
+++ b/spec/lib/hamster/sorted_set/include_spec.rb
@@ -8,16 +8,16 @@ describe Hamster::SortedSet do
 
       [1, 2, 3, 4.0].each do |value|
         it "returns true for an existing value (#{value.inspect})" do
-          sorted_set.send(method, value).should == true
+          expect(sorted_set.send(method, value)).to eq(true)
         end
       end
 
       it "returns false for a non-existing value" do
-        sorted_set.send(method, 5).should == false
+        expect(sorted_set.send(method, 5)).to eq(false)
       end
 
       it "uses #<=> for equality" do
-        sorted_set.send(method, 4).should == true
+        expect(sorted_set.send(method, 4)).to eq(true)
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/inspect_spec.rb
+++ b/spec/lib/hamster/sorted_set/inspect_spec.rb
@@ -12,11 +12,11 @@ describe Hamster::SortedSet do
         let(:sorted_set) { SS[*values] }
 
         it "returns #{expected.inspect}" do
-          sorted_set.inspect.should == expected
+          expect(sorted_set.inspect).to eq(expected)
         end
 
         it "returns a string which can be eval'd to get an equivalent set" do
-          eval(sorted_set.inspect).should eql(sorted_set)
+          expect(eval(sorted_set.inspect)).to eql(sorted_set)
         end
       end
     end
@@ -27,11 +27,11 @@ describe Hamster::SortedSet do
       let(:sorted_set) { MySortedSet[1, 2] }
 
       it "returns a programmer-readable representation of the set contents" do
-        sorted_set.inspect.should == 'MySortedSet[1, 2]'
+        expect(sorted_set.inspect).to eq('MySortedSet[1, 2]')
       end
 
       it "returns a string which can be eval'd to get an equivalent set" do
-        eval(sorted_set.inspect).should eql(sorted_set)
+        expect(eval(sorted_set.inspect)).to eql(sorted_set)
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/intersect_spec.rb
+++ b/spec/lib/hamster/sorted_set/intersect_spec.rb
@@ -18,7 +18,7 @@ describe Hamster::SortedSet do
     ].each do |a, b, expected|
       context "for #{a.inspect} and #{b.inspect}" do
         it "returns #{expected}" do
-          SS[*a].intersect?(SS[*b]).should be(expected)
+          expect(SS[*a].intersect?(SS[*b])).to be(expected)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/intersection_spec.rb
+++ b/spec/lib/hamster/sorted_set/intersection_spec.rb
@@ -14,13 +14,13 @@ describe Hamster::SortedSet do
       ].each do |a, b, expected|
         context "for #{a.inspect} and #{b.inspect}" do
           it "returns #{expected.inspect}" do
-            SS[*a].send(method, SS[*b]).should eql(SS[*expected])
+            expect(SS[*a].send(method, SS[*b])).to eql(SS[*expected])
           end
         end
 
         context "for #{b.inspect} and #{a.inspect}" do
           it "returns #{expected.inspect}" do
-            SS[*b].send(method, SS[*a]).should eql(SS[*expected])
+            expect(SS[*b].send(method, SS[*a])).to eql(SS[*expected])
           end
         end
       end

--- a/spec/lib/hamster/sorted_set/map_spec.rb
+++ b/spec/lib/hamster/sorted_set/map_spec.rb
@@ -6,7 +6,7 @@ describe Hamster::SortedSet do
     describe "##{method}" do
       context "when empty" do
         it "returns self" do
-          SS.empty.send(method) {}.should equal(SS.empty)
+          expect(SS.empty.send(method) {}).to equal(SS.empty)
         end
       end
 
@@ -16,18 +16,18 @@ describe Hamster::SortedSet do
         context "with a block" do
           it "preserves the original values" do
             sorted_set.send(method, &:downcase)
-            sorted_set.should eql(SS["A", "B", "C"])
+            expect(sorted_set).to eql(SS["A", "B", "C"])
           end
 
           it "returns a new set with the mapped values" do
-            sorted_set.send(method, &:downcase).should eql(SS["a", "b", "c"])
+            expect(sorted_set.send(method, &:downcase)).to eql(SS["a", "b", "c"])
           end
         end
 
         context "with no block" do
           it "returns an Enumerator" do
-            sorted_set.send(method).class.should be(Enumerator)
-            sorted_set.send(method).each(&:downcase).should == SS['a', 'b', 'c']
+            expect(sorted_set.send(method).class).to be(Enumerator)
+            expect(sorted_set.send(method).each(&:downcase)).to eq(SS['a', 'b', 'c'])
           end
         end
       end
@@ -36,7 +36,7 @@ describe Hamster::SortedSet do
         let(:sorted_set) { SS.new(["A", "B", "C"]) { |a,b| b <=> a }}
 
         it "returns a new set with the mapped values" do
-          sorted_set.send(method, &:downcase).should == ['c', 'b', 'a']
+          expect(sorted_set.send(method, &:downcase)).to eq(['c', 'b', 'a'])
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/marshal_spec.rb
+++ b/spec/lib/hamster/sorted_set/marshal_spec.rb
@@ -31,7 +31,7 @@ describe Hamster::SortedSet do
 
     it "raises a TypeError if set has a custom sort order" do
       # this is because comparator block can't be serialized
-      -> { Marshal.dump(SS.new([1, 2, 3]) { |x| -x }) }.should raise_error(TypeError)
+      expect { Marshal.dump(SS.new([1, 2, 3]) { |x| -x }) }.to raise_error(TypeError)
     end
   end
 end

--- a/spec/lib/hamster/sorted_set/maximum_spec.rb
+++ b/spec/lib/hamster/sorted_set/maximum_spec.rb
@@ -14,7 +14,7 @@ describe Hamster::SortedSet do
           let(:result) { set.max { |maximum, item| maximum.length <=> item.length }}
 
           it "returns #{expected.inspect}" do
-            result.should == expected
+            expect(result).to eq(expected)
           end
         end
       end
@@ -28,7 +28,7 @@ describe Hamster::SortedSet do
       ].each do |values, expected|
         describe "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            SS[*values].max.should == expected
+            expect(SS[*values].max).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/sorted_set/minimum_spec.rb
+++ b/spec/lib/hamster/sorted_set/minimum_spec.rb
@@ -12,7 +12,7 @@ describe Hamster::SortedSet do
     ].each do |values, expected|
       context "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          SS[*values].min.should == expected
+          expect(SS[*values].min).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/new_spec.rb
+++ b/spec/lib/hamster/sorted_set/new_spec.rb
@@ -5,18 +5,18 @@ describe Hamster::SortedSet do
   describe ".new" do
     it "accepts a single enumerable argument and creates a new sorted set" do
       sorted_set = SS.new([1,2,3])
-      sorted_set.size.should be(3)
-      sorted_set[0].should be(1)
-      sorted_set[1].should be(2)
-      sorted_set[2].should be(3)
+      expect(sorted_set.size).to be(3)
+      expect(sorted_set[0]).to be(1)
+      expect(sorted_set[1]).to be(2)
+      expect(sorted_set[2]).to be(3)
     end
 
     it "also works with a Range" do
       sorted_set = SS.new(1..3)
-      sorted_set.size.should be(3)
-      sorted_set[0].should be(1)
-      sorted_set[1].should be(2)
-      sorted_set[2].should be(3)
+      expect(sorted_set.size).to be(3)
+      expect(sorted_set[0]).to be(1)
+      expect(sorted_set[1]).to be(2)
+      expect(sorted_set[2]).to be(3)
     end
 
     it "is amenable to overriding of #initialize" do
@@ -27,36 +27,36 @@ describe Hamster::SortedSet do
       end
 
       sorted_set = SnazzySortedSet.new
-      sorted_set.size.should be(1)
-      sorted_set.to_a.should == ['SNAZZY!!!']
+      expect(sorted_set.size).to be(1)
+      expect(sorted_set.to_a).to eq(['SNAZZY!!!'])
     end
 
     it "accepts a block with arity 1" do
       sorted_set = SS.new(1..3) { |a| -a }
-      sorted_set[0].should be(3)
-      sorted_set[1].should be(2)
-      sorted_set[2].should be(1)
+      expect(sorted_set[0]).to be(3)
+      expect(sorted_set[1]).to be(2)
+      expect(sorted_set[2]).to be(1)
     end
 
     it "accepts a block with arity 2" do
       sorted_set = SS.new(1..3) { |a,b| b <=> a }
-      sorted_set[0].should be(3)
-      sorted_set[1].should be(2)
-      sorted_set[2].should be(1)
+      expect(sorted_set[0]).to be(3)
+      expect(sorted_set[1]).to be(2)
+      expect(sorted_set[2]).to be(1)
     end
 
     it "can use a block produced by Symbol#to_proc" do
       sorted_set = SS.new([Object, BasicObject], &:name.to_proc)
-      sorted_set[0].should be(BasicObject)
-      sorted_set[1].should be(Object)
+      expect(sorted_set[0]).to be(BasicObject)
+      expect(sorted_set[1]).to be(Object)
     end
 
     context "from a subclass" do
       it "returns a frozen instance of the subclass" do
         subclass = Class.new(Hamster::SortedSet)
         instance = subclass.new(["some", "values"])
-        instance.class.should be subclass
-        instance.frozen?.should be true
+        expect(instance.class).to be subclass
+        expect(instance.frozen?).to be true
       end
     end
   end
@@ -64,9 +64,9 @@ describe Hamster::SortedSet do
   describe ".[]" do
     it "accepts a variable number of items and creates a new sorted set" do
       sorted_set = SS['a', 'b']
-      sorted_set.size.should be(2)
-      sorted_set[0].should == 'a'
-      sorted_set[1].should == 'b'
+      expect(sorted_set.size).to be(2)
+      expect(sorted_set[0]).to eq('a')
+      expect(sorted_set[1]).to eq('b')
     end
   end
 end

--- a/spec/lib/hamster/sorted_set/reverse_each_spec.rb
+++ b/spec/lib/hamster/sorted_set/reverse_each_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::SortedSet do
       let(:sorted_set) { SS["A", "B", "C"] }
 
       it "returns an Enumerator" do
-        sorted_set.reverse_each.class.should be(Enumerator)
-        sorted_set.reverse_each.to_a.should eql(sorted_set.to_a.reverse)
+        expect(sorted_set.reverse_each.class).to be(Enumerator)
+        expect(sorted_set.reverse_each.to_a).to eql(sorted_set.to_a.reverse)
       end
     end
 
@@ -16,13 +16,13 @@ describe Hamster::SortedSet do
       let(:sorted_set) { SS.new(1..1025) }
 
       it "returns self" do
-        sorted_set.reverse_each {}.should be(sorted_set)
+        expect(sorted_set.reverse_each {}).to be(sorted_set)
       end
 
       it "iterates over the items in order" do
         items = []
         sorted_set.reverse_each { |item| items << item }
-        items.should == (1..1025).to_a.reverse
+        expect(items).to eq((1..1025).to_a.reverse)
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/sample_spec.rb
+++ b/spec/lib/hamster/sorted_set/sample_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::SortedSet do
 
     it "returns a randomly chosen item" do
       chosen = 100.times.map { sorted_set.sample }
-      chosen.each { |item| sorted_set.include?(item).should == true }
-      sorted_set.each { |item| chosen.include?(item).should == true }
+      chosen.each { |item| expect(sorted_set.include?(item)).to eq(true) }
+      sorted_set.each { |item| expect(chosen.include?(item)).to eq(true) }
     end
   end
 end

--- a/spec/lib/hamster/sorted_set/select_spec.rb
+++ b/spec/lib/hamster/sorted_set/select_spec.rb
@@ -9,11 +9,11 @@ describe Hamster::SortedSet do
       context "when everything matches" do
         it "preserves the original" do
           sorted_set.send(method) { true }
-          sorted_set.should eql(SS["A", "B", "C"])
+          expect(sorted_set).to eql(SS["A", "B", "C"])
         end
 
         it "returns self" do
-          sorted_set.send(method) { |item| true }.should equal(sorted_set)
+          expect(sorted_set.send(method) { |item| true }).to equal(sorted_set)
         end
       end
 
@@ -21,18 +21,18 @@ describe Hamster::SortedSet do
         context "with a block" do
           it "preserves the original" do
             sorted_set.send(method) { |item| item == "A" }
-            sorted_set.should eql(SS["A", "B", "C"])
+            expect(sorted_set).to eql(SS["A", "B", "C"])
           end
 
           it "returns a set with the matching values" do
-            sorted_set.send(method) { |item| item == "A" }.should eql(SS["A"])
+            expect(sorted_set.send(method) { |item| item == "A" }).to eql(SS["A"])
           end
         end
 
         context "with no block" do
           it "returns an Enumerator" do
-            sorted_set.send(method).class.should be(Enumerator)
-            sorted_set.send(method).each { |item| item == "A" }.should eql(SS["A"])
+            expect(sorted_set.send(method).class).to be(Enumerator)
+            expect(sorted_set.send(method).each { |item| item == "A" }).to eql(SS["A"])
           end
         end
       end
@@ -40,11 +40,11 @@ describe Hamster::SortedSet do
       context "when nothing matches" do
         it "preserves the original" do
           sorted_set.send(method) { |item| false }
-          sorted_set.should eql(SS["A", "B", "C"])
+          expect(sorted_set).to eql(SS["A", "B", "C"])
         end
 
         it "returns the canonical empty set" do
-          sorted_set.send(method) { |item| false }.should equal(Hamster::EmptySortedSet)
+          expect(sorted_set.send(method) { |item| false }).to equal(Hamster::EmptySortedSet)
         end
       end
 
@@ -52,9 +52,9 @@ describe Hamster::SortedSet do
         it "returns an instance of the same class" do
           subclass = Class.new(Hamster::SortedSet)
           instance = subclass.new(['A', 'B', 'C'])
-          instance.send(method) { true }.class.should be(subclass)
-          instance.send(method) { false }.class.should be(subclass)
-          instance.send(method) { rand(2) == 0 }.class.should be(subclass)
+          expect(instance.send(method) { true }.class).to be(subclass)
+          expect(instance.send(method) { false }.class).to be(subclass)
+          expect(instance.send(method) { rand(2) == 0 }.class).to be(subclass)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/size_spec.rb
+++ b/spec/lib/hamster/sorted_set/size_spec.rb
@@ -10,7 +10,7 @@ describe Hamster::SortedSet do
         [%w[A B C], 3],
       ].each do |values, result|
         it "returns #{result} for #{values.inspect}" do
-          SS[*values].send(method).should == result
+          expect(SS[*values].send(method)).to eq(result)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/slice_spec.rb
+++ b/spec/lib/hamster/sorted_set/slice_spec.rb
@@ -9,212 +9,212 @@ describe Hamster::SortedSet do
     describe "##{method}" do
       context "when passed a positive integral index" do
         it "returns the element at that index" do
-          sorted_set.send(method, 0).should be(1)
-          sorted_set.send(method, 1).should be(2)
-          sorted_set.send(method, 2).should be(3)
-          sorted_set.send(method, 3).should be(4)
-          sorted_set.send(method, 4).should be(nil)
-          sorted_set.send(method, 10).should be(nil)
+          expect(sorted_set.send(method, 0)).to be(1)
+          expect(sorted_set.send(method, 1)).to be(2)
+          expect(sorted_set.send(method, 2)).to be(3)
+          expect(sorted_set.send(method, 3)).to be(4)
+          expect(sorted_set.send(method, 4)).to be(nil)
+          expect(sorted_set.send(method, 10)).to be(nil)
 
-          big.send(method, 0).should be(1)
-          big.send(method, 9999).should be(10000)
+          expect(big.send(method, 0)).to be(1)
+          expect(big.send(method, 9999)).to be(10000)
         end
 
         it "leaves the original unchanged" do
-          sorted_set.should eql(SS[1,2,3,4])
+          expect(sorted_set).to eql(SS[1,2,3,4])
         end
       end
 
       context "when passed a negative integral index" do
         it "returns the element which is number (index.abs) counting from the end of the sorted_set" do
-          sorted_set.send(method, -1).should be(4)
-          sorted_set.send(method, -2).should be(3)
-          sorted_set.send(method, -3).should be(2)
-          sorted_set.send(method, -4).should be(1)
-          sorted_set.send(method, -5).should be(nil)
-          sorted_set.send(method, -10).should be(nil)
+          expect(sorted_set.send(method, -1)).to be(4)
+          expect(sorted_set.send(method, -2)).to be(3)
+          expect(sorted_set.send(method, -3)).to be(2)
+          expect(sorted_set.send(method, -4)).to be(1)
+          expect(sorted_set.send(method, -5)).to be(nil)
+          expect(sorted_set.send(method, -10)).to be(nil)
 
-          big.send(method, -1).should be(10000)
-          big.send(method, -10000).should be(1)
+          expect(big.send(method, -1)).to be(10000)
+          expect(big.send(method, -10000)).to be(1)
         end
       end
 
       context "when passed a positive integral index and count" do
         it "returns 'count' elements starting from 'index'" do
-          sorted_set.send(method, 0, 0).should  eql(SS.empty)
-          sorted_set.send(method, 0, 1).should  eql(SS[1])
-          sorted_set.send(method, 0, 2).should  eql(SS[1,2])
-          sorted_set.send(method, 0, 4).should  eql(SS[1,2,3,4])
-          sorted_set.send(method, 0, 6).should  eql(SS[1,2,3,4])
-          sorted_set.send(method, 0, -1).should be_nil
-          sorted_set.send(method, 0, -2).should be_nil
-          sorted_set.send(method, 0, -4).should be_nil
-          sorted_set.send(method, 2, 0).should  eql(SS.empty)
-          sorted_set.send(method, 2, 1).should  eql(SS[3])
-          sorted_set.send(method, 2, 2).should  eql(SS[3,4])
-          sorted_set.send(method, 2, 4).should  eql(SS[3,4])
-          sorted_set.send(method, 2, -1).should be_nil
-          sorted_set.send(method, 4, 0).should  eql(SS.empty)
-          sorted_set.send(method, 4, 2).should  eql(SS.empty)
-          sorted_set.send(method, 4, -1).should be_nil
-          sorted_set.send(method, 5, 0).should  be_nil
-          sorted_set.send(method, 5, 2).should  be_nil
-          sorted_set.send(method, 5, -1).should be_nil
-          sorted_set.send(method, 6, 0).should  be_nil
-          sorted_set.send(method, 6, 2).should  be_nil
-          sorted_set.send(method, 6, -1).should be_nil
+          expect(sorted_set.send(method, 0, 0)).to  eql(SS.empty)
+          expect(sorted_set.send(method, 0, 1)).to  eql(SS[1])
+          expect(sorted_set.send(method, 0, 2)).to  eql(SS[1,2])
+          expect(sorted_set.send(method, 0, 4)).to  eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, 0, 6)).to  eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, 0, -1)).to be_nil
+          expect(sorted_set.send(method, 0, -2)).to be_nil
+          expect(sorted_set.send(method, 0, -4)).to be_nil
+          expect(sorted_set.send(method, 2, 0)).to  eql(SS.empty)
+          expect(sorted_set.send(method, 2, 1)).to  eql(SS[3])
+          expect(sorted_set.send(method, 2, 2)).to  eql(SS[3,4])
+          expect(sorted_set.send(method, 2, 4)).to  eql(SS[3,4])
+          expect(sorted_set.send(method, 2, -1)).to be_nil
+          expect(sorted_set.send(method, 4, 0)).to  eql(SS.empty)
+          expect(sorted_set.send(method, 4, 2)).to  eql(SS.empty)
+          expect(sorted_set.send(method, 4, -1)).to be_nil
+          expect(sorted_set.send(method, 5, 0)).to  be_nil
+          expect(sorted_set.send(method, 5, 2)).to  be_nil
+          expect(sorted_set.send(method, 5, -1)).to be_nil
+          expect(sorted_set.send(method, 6, 0)).to  be_nil
+          expect(sorted_set.send(method, 6, 2)).to  be_nil
+          expect(sorted_set.send(method, 6, -1)).to be_nil
 
-          big.send(method, 0, 3).should    eql(SS[1,2,3])
-          big.send(method, 1023, 4).should eql(SS[1024,1025,1026,1027])
-          big.send(method, 1024, 4).should eql(SS[1025,1026,1027,1028])
+          expect(big.send(method, 0, 3)).to    eql(SS[1,2,3])
+          expect(big.send(method, 1023, 4)).to eql(SS[1024,1025,1026,1027])
+          expect(big.send(method, 1024, 4)).to eql(SS[1025,1026,1027,1028])
         end
 
         it "leaves the original unchanged" do
-          sorted_set.should eql(SS[1,2,3,4])
+          expect(sorted_set).to eql(SS[1,2,3,4])
         end
       end
 
       context "when passed a negative integral index and count" do
         it "returns 'count' elements, starting from index which is number 'index.abs' counting from the end of the array" do
-          sorted_set.send(method, -1, 0).should  eql(SS.empty)
-          sorted_set.send(method, -1, 1).should  eql(SS[4])
-          sorted_set.send(method, -1, 2).should  eql(SS[4])
-          sorted_set.send(method, -1, -1).should be_nil
-          sorted_set.send(method, -2, 0).should  eql(SS.empty)
-          sorted_set.send(method, -2, 1).should  eql(SS[3])
-          sorted_set.send(method, -2, 2).should  eql(SS[3,4])
-          sorted_set.send(method, -2, 4).should  eql(SS[3,4])
-          sorted_set.send(method, -2, -1).should be_nil
-          sorted_set.send(method, -4, 0).should  eql(SS.empty)
-          sorted_set.send(method, -4, 1).should  eql(SS[1])
-          sorted_set.send(method, -4, 2).should  eql(SS[1,2])
-          sorted_set.send(method, -4, 4).should  eql(SS[1,2,3,4])
-          sorted_set.send(method, -4, 6).should  eql(SS[1,2,3,4])
-          sorted_set.send(method, -4, -1).should be_nil
-          sorted_set.send(method, -5, 0).should  be_nil
-          sorted_set.send(method, -5, 1).should  be_nil
-          sorted_set.send(method, -5, 10).should be_nil
-          sorted_set.send(method, -5, -1).should be_nil
+          expect(sorted_set.send(method, -1, 0)).to  eql(SS.empty)
+          expect(sorted_set.send(method, -1, 1)).to  eql(SS[4])
+          expect(sorted_set.send(method, -1, 2)).to  eql(SS[4])
+          expect(sorted_set.send(method, -1, -1)).to be_nil
+          expect(sorted_set.send(method, -2, 0)).to  eql(SS.empty)
+          expect(sorted_set.send(method, -2, 1)).to  eql(SS[3])
+          expect(sorted_set.send(method, -2, 2)).to  eql(SS[3,4])
+          expect(sorted_set.send(method, -2, 4)).to  eql(SS[3,4])
+          expect(sorted_set.send(method, -2, -1)).to be_nil
+          expect(sorted_set.send(method, -4, 0)).to  eql(SS.empty)
+          expect(sorted_set.send(method, -4, 1)).to  eql(SS[1])
+          expect(sorted_set.send(method, -4, 2)).to  eql(SS[1,2])
+          expect(sorted_set.send(method, -4, 4)).to  eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, -4, 6)).to  eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, -4, -1)).to be_nil
+          expect(sorted_set.send(method, -5, 0)).to  be_nil
+          expect(sorted_set.send(method, -5, 1)).to  be_nil
+          expect(sorted_set.send(method, -5, 10)).to be_nil
+          expect(sorted_set.send(method, -5, -1)).to be_nil
 
-          big.send(method, -1, 1).should eql(SS[10000])
-          big.send(method, -1, 2).should eql(SS[10000])
-          big.send(method, -6, 2).should eql(SS[9995,9996])
+          expect(big.send(method, -1, 1)).to eql(SS[10000])
+          expect(big.send(method, -1, 2)).to eql(SS[10000])
+          expect(big.send(method, -6, 2)).to eql(SS[9995,9996])
         end
       end
 
       context "when passed a Range" do
         it "returns the elements whose indexes are within the given Range" do
-          sorted_set.send(method, 0..-1).should  eql(SS[1,2,3,4])
-          sorted_set.send(method, 0..-10).should eql(SS.empty)
-          sorted_set.send(method, 0..0).should   eql(SS[1])
-          sorted_set.send(method, 0..1).should   eql(SS[1,2])
-          sorted_set.send(method, 0..2).should   eql(SS[1,2,3])
-          sorted_set.send(method, 0..3).should   eql(SS[1,2,3,4])
-          sorted_set.send(method, 0..4).should   eql(SS[1,2,3,4])
-          sorted_set.send(method, 0..10).should  eql(SS[1,2,3,4])
-          sorted_set.send(method, 2..-10).should eql(SS.empty)
-          sorted_set.send(method, 2..0).should   eql(SS.empty)
-          sorted_set.send(method, 2..2).should   eql(SS[3])
-          sorted_set.send(method, 2..3).should   eql(SS[3,4])
-          sorted_set.send(method, 2..4).should   eql(SS[3,4])
-          sorted_set.send(method, 3..0).should   eql(SS.empty)
-          sorted_set.send(method, 3..3).should   eql(SS[4])
-          sorted_set.send(method, 3..4).should   eql(SS[4])
-          sorted_set.send(method, 4..0).should   eql(SS.empty)
-          sorted_set.send(method, 4..4).should   eql(SS.empty)
-          sorted_set.send(method, 4..5).should   eql(SS.empty)
-          sorted_set.send(method, 5..0).should   be_nil
-          sorted_set.send(method, 5..5).should   be_nil
-          sorted_set.send(method, 5..6).should   be_nil
+          expect(sorted_set.send(method, 0..-1)).to  eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, 0..-10)).to eql(SS.empty)
+          expect(sorted_set.send(method, 0..0)).to   eql(SS[1])
+          expect(sorted_set.send(method, 0..1)).to   eql(SS[1,2])
+          expect(sorted_set.send(method, 0..2)).to   eql(SS[1,2,3])
+          expect(sorted_set.send(method, 0..3)).to   eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, 0..4)).to   eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, 0..10)).to  eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, 2..-10)).to eql(SS.empty)
+          expect(sorted_set.send(method, 2..0)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 2..2)).to   eql(SS[3])
+          expect(sorted_set.send(method, 2..3)).to   eql(SS[3,4])
+          expect(sorted_set.send(method, 2..4)).to   eql(SS[3,4])
+          expect(sorted_set.send(method, 3..0)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 3..3)).to   eql(SS[4])
+          expect(sorted_set.send(method, 3..4)).to   eql(SS[4])
+          expect(sorted_set.send(method, 4..0)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 4..4)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 4..5)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 5..0)).to   be_nil
+          expect(sorted_set.send(method, 5..5)).to   be_nil
+          expect(sorted_set.send(method, 5..6)).to   be_nil
 
-          big.send(method, 159..162).should     eql(SS[160,161,162,163])
-          big.send(method, 160..162).should     eql(SS[161,162,163])
-          big.send(method, 161..162).should     eql(SS[162,163])
-          big.send(method, 9999..10100).should  eql(SS[10000])
-          big.send(method, 10000..10100).should eql(SS.empty)
-          big.send(method, 10001..10100).should be_nil
+          expect(big.send(method, 159..162)).to     eql(SS[160,161,162,163])
+          expect(big.send(method, 160..162)).to     eql(SS[161,162,163])
+          expect(big.send(method, 161..162)).to     eql(SS[162,163])
+          expect(big.send(method, 9999..10100)).to  eql(SS[10000])
+          expect(big.send(method, 10000..10100)).to eql(SS.empty)
+          expect(big.send(method, 10001..10100)).to be_nil
 
-          sorted_set.send(method, 0...-1).should  eql(SS[1,2,3])
-          sorted_set.send(method, 0...-10).should eql(SS.empty)
-          sorted_set.send(method, 0...0).should   eql(SS.empty)
-          sorted_set.send(method, 0...1).should   eql(SS[1])
-          sorted_set.send(method, 0...2).should   eql(SS[1,2])
-          sorted_set.send(method, 0...3).should   eql(SS[1,2,3])
-          sorted_set.send(method, 0...4).should   eql(SS[1,2,3,4])
-          sorted_set.send(method, 0...10).should  eql(SS[1,2,3,4])
-          sorted_set.send(method, 2...-10).should eql(SS.empty)
-          sorted_set.send(method, 2...0).should   eql(SS.empty)
-          sorted_set.send(method, 2...2).should   eql(SS.empty)
-          sorted_set.send(method, 2...3).should   eql(SS[3])
-          sorted_set.send(method, 2...4).should   eql(SS[3,4])
-          sorted_set.send(method, 3...0).should   eql(SS.empty)
-          sorted_set.send(method, 3...3).should   eql(SS.empty)
-          sorted_set.send(method, 3...4).should   eql(SS[4])
-          sorted_set.send(method, 4...0).should   eql(SS.empty)
-          sorted_set.send(method, 4...4).should   eql(SS.empty)
-          sorted_set.send(method, 4...5).should   eql(SS.empty)
-          sorted_set.send(method, 5...0).should   be_nil
-          sorted_set.send(method, 5...5).should   be_nil
-          sorted_set.send(method, 5...6).should   be_nil
+          expect(sorted_set.send(method, 0...-1)).to  eql(SS[1,2,3])
+          expect(sorted_set.send(method, 0...-10)).to eql(SS.empty)
+          expect(sorted_set.send(method, 0...0)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 0...1)).to   eql(SS[1])
+          expect(sorted_set.send(method, 0...2)).to   eql(SS[1,2])
+          expect(sorted_set.send(method, 0...3)).to   eql(SS[1,2,3])
+          expect(sorted_set.send(method, 0...4)).to   eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, 0...10)).to  eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, 2...-10)).to eql(SS.empty)
+          expect(sorted_set.send(method, 2...0)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 2...2)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 2...3)).to   eql(SS[3])
+          expect(sorted_set.send(method, 2...4)).to   eql(SS[3,4])
+          expect(sorted_set.send(method, 3...0)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 3...3)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 3...4)).to   eql(SS[4])
+          expect(sorted_set.send(method, 4...0)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 4...4)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 4...5)).to   eql(SS.empty)
+          expect(sorted_set.send(method, 5...0)).to   be_nil
+          expect(sorted_set.send(method, 5...5)).to   be_nil
+          expect(sorted_set.send(method, 5...6)).to   be_nil
 
-          big.send(method, 159...162).should     eql(SS[160,161,162])
-          big.send(method, 160...162).should     eql(SS[161,162])
-          big.send(method, 161...162).should     eql(SS[162])
-          big.send(method, 9999...10100).should  eql(SS[10000])
-          big.send(method, 10000...10100).should eql(SS.empty)
-          big.send(method, 10001...10100).should be_nil
+          expect(big.send(method, 159...162)).to     eql(SS[160,161,162])
+          expect(big.send(method, 160...162)).to     eql(SS[161,162])
+          expect(big.send(method, 161...162)).to     eql(SS[162])
+          expect(big.send(method, 9999...10100)).to  eql(SS[10000])
+          expect(big.send(method, 10000...10100)).to eql(SS.empty)
+          expect(big.send(method, 10001...10100)).to be_nil
 
-          sorted_set.send(method, -1..-1).should  eql(SS[4])
-          sorted_set.send(method, -1...-1).should eql(SS.empty)
-          sorted_set.send(method, -1..3).should   eql(SS[4])
-          sorted_set.send(method, -1...3).should  eql(SS.empty)
-          sorted_set.send(method, -1..4).should   eql(SS[4])
-          sorted_set.send(method, -1...4).should  eql(SS[4])
-          sorted_set.send(method, -1..10).should  eql(SS[4])
-          sorted_set.send(method, -1...10).should eql(SS[4])
-          sorted_set.send(method, -1..0).should   eql(SS.empty)
-          sorted_set.send(method, -1..-4).should  eql(SS.empty)
-          sorted_set.send(method, -1...-4).should eql(SS.empty)
-          sorted_set.send(method, -1..-6).should  eql(SS.empty)
-          sorted_set.send(method, -1...-6).should eql(SS.empty)
-          sorted_set.send(method, -2..-2).should  eql(SS[3])
-          sorted_set.send(method, -2...-2).should eql(SS.empty)
-          sorted_set.send(method, -2..-1).should  eql(SS[3,4])
-          sorted_set.send(method, -2...-1).should eql(SS[3])
-          sorted_set.send(method, -2..10).should  eql(SS[3,4])
-          sorted_set.send(method, -2...10).should eql(SS[3,4])
+          expect(sorted_set.send(method, -1..-1)).to  eql(SS[4])
+          expect(sorted_set.send(method, -1...-1)).to eql(SS.empty)
+          expect(sorted_set.send(method, -1..3)).to   eql(SS[4])
+          expect(sorted_set.send(method, -1...3)).to  eql(SS.empty)
+          expect(sorted_set.send(method, -1..4)).to   eql(SS[4])
+          expect(sorted_set.send(method, -1...4)).to  eql(SS[4])
+          expect(sorted_set.send(method, -1..10)).to  eql(SS[4])
+          expect(sorted_set.send(method, -1...10)).to eql(SS[4])
+          expect(sorted_set.send(method, -1..0)).to   eql(SS.empty)
+          expect(sorted_set.send(method, -1..-4)).to  eql(SS.empty)
+          expect(sorted_set.send(method, -1...-4)).to eql(SS.empty)
+          expect(sorted_set.send(method, -1..-6)).to  eql(SS.empty)
+          expect(sorted_set.send(method, -1...-6)).to eql(SS.empty)
+          expect(sorted_set.send(method, -2..-2)).to  eql(SS[3])
+          expect(sorted_set.send(method, -2...-2)).to eql(SS.empty)
+          expect(sorted_set.send(method, -2..-1)).to  eql(SS[3,4])
+          expect(sorted_set.send(method, -2...-1)).to eql(SS[3])
+          expect(sorted_set.send(method, -2..10)).to  eql(SS[3,4])
+          expect(sorted_set.send(method, -2...10)).to eql(SS[3,4])
 
-          big.send(method, -1..-1).should    eql(SS[10000])
-          big.send(method, -1..9999).should  eql(SS[10000])
-          big.send(method, -1...9999).should eql(SS.empty)
-          big.send(method, -2...9999).should eql(SS[9999])
-          big.send(method, -2..-1).should    eql(SS[9999,10000])
+          expect(big.send(method, -1..-1)).to    eql(SS[10000])
+          expect(big.send(method, -1..9999)).to  eql(SS[10000])
+          expect(big.send(method, -1...9999)).to eql(SS.empty)
+          expect(big.send(method, -2...9999)).to eql(SS[9999])
+          expect(big.send(method, -2..-1)).to    eql(SS[9999,10000])
 
-          sorted_set.send(method, -4..-4).should  eql(SS[1])
-          sorted_set.send(method, -4..-2).should  eql(SS[1,2,3])
-          sorted_set.send(method, -4...-2).should eql(SS[1,2])
-          sorted_set.send(method, -4..-1).should  eql(SS[1,2,3,4])
-          sorted_set.send(method, -4...-1).should eql(SS[1,2,3])
-          sorted_set.send(method, -4..3).should   eql(SS[1,2,3,4])
-          sorted_set.send(method, -4...3).should  eql(SS[1,2,3])
-          sorted_set.send(method, -4..4).should   eql(SS[1,2,3,4])
-          sorted_set.send(method, -4...4).should  eql(SS[1,2,3,4])
-          sorted_set.send(method, -4..0).should   eql(SS[1])
-          sorted_set.send(method, -4...0).should  eql(SS.empty)
-          sorted_set.send(method, -4..1).should   eql(SS[1,2])
-          sorted_set.send(method, -4...1).should  eql(SS[1])
+          expect(sorted_set.send(method, -4..-4)).to  eql(SS[1])
+          expect(sorted_set.send(method, -4..-2)).to  eql(SS[1,2,3])
+          expect(sorted_set.send(method, -4...-2)).to eql(SS[1,2])
+          expect(sorted_set.send(method, -4..-1)).to  eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, -4...-1)).to eql(SS[1,2,3])
+          expect(sorted_set.send(method, -4..3)).to   eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, -4...3)).to  eql(SS[1,2,3])
+          expect(sorted_set.send(method, -4..4)).to   eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, -4...4)).to  eql(SS[1,2,3,4])
+          expect(sorted_set.send(method, -4..0)).to   eql(SS[1])
+          expect(sorted_set.send(method, -4...0)).to  eql(SS.empty)
+          expect(sorted_set.send(method, -4..1)).to   eql(SS[1,2])
+          expect(sorted_set.send(method, -4...1)).to  eql(SS[1])
 
-          sorted_set.send(method, -5..-5).should  be_nil
-          sorted_set.send(method, -5...-5).should be_nil
-          sorted_set.send(method, -5..-4).should  be_nil
-          sorted_set.send(method, -5..-1).should  be_nil
-          sorted_set.send(method, -5..10).should  be_nil
+          expect(sorted_set.send(method, -5..-5)).to  be_nil
+          expect(sorted_set.send(method, -5...-5)).to be_nil
+          expect(sorted_set.send(method, -5..-4)).to  be_nil
+          expect(sorted_set.send(method, -5..-1)).to  be_nil
+          expect(sorted_set.send(method, -5..10)).to  be_nil
 
-          big.send(method, -10001..-1).should be_nil
+          expect(big.send(method, -10001..-1)).to be_nil
         end
 
         it "leaves the original unchanged" do
-          sorted_set.should eql(SS[1,2,3,4])
+          expect(sorted_set).to eql(SS[1,2,3,4])
         end
       end
     end
@@ -223,7 +223,7 @@ describe Hamster::SortedSet do
       it "does not lose custom sort order" do
         ss = SS.new(["yogurt", "cake", "pistachios"]) { |word| word.length }
         ss = ss.send(method, 1...1).add("tea").add("fruitcake").add("toast")
-        ss.to_a.should == ["tea", "toast", "fruitcake"]
+        expect(ss.to_a).to eq(["tea", "toast", "fruitcake"])
       end
     end
 
@@ -231,15 +231,15 @@ describe Hamster::SortedSet do
       it "does not lose custom sort order" do
         ss = SS.new(["yogurt", "cake", "pistachios"]) { |word| word.length }
         ss = ss.send(method, 0, 0).add("tea").add("fruitcake").add("toast")
-        ss.to_a.should == ["tea", "toast", "fruitcake"]
+        expect(ss.to_a).to eq(["tea", "toast", "fruitcake"])
       end
     end
 
     context "when passed a subclass of Range" do
       it "works the same as with a Range" do
         subclass = Class.new(Range)
-        sorted_set.send(method, subclass.new(1,2)).should eql(SS[2,3])
-        sorted_set.send(method, subclass.new(-3,-1,true)).should eql(SS[2,3])
+        expect(sorted_set.send(method, subclass.new(1,2))).to eql(SS[2,3])
+        expect(sorted_set.send(method, subclass.new(-3,-1,true))).to eql(SS[2,3])
       end
     end
 
@@ -247,10 +247,10 @@ describe Hamster::SortedSet do
       it "with index and count or a range, returns an instance of the subclass" do
         subclass = Class.new(Hamster::SortedSet)
         instance = subclass.new([1,2,3])
-        instance.send(method, 0, 0).class.should be(subclass)
-        instance.send(method, 0, 2).class.should be(subclass)
-        instance.send(method, 0..0).class.should be(subclass)
-        instance.send(method, 1..-1).class.should be(subclass)
+        expect(instance.send(method, 0, 0).class).to be(subclass)
+        expect(instance.send(method, 0, 2).class).to be(subclass)
+        expect(instance.send(method, 0..0).class).to be(subclass)
+        expect(instance.send(method, 1..-1).class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/sorting_spec.rb
+++ b/spec/lib/hamster/sorted_set/sorting_spec.rb
@@ -18,24 +18,24 @@ describe Hamster::SortedSet do
           context "with a block" do
             it "preserves the original" do
               sorted_set.send(method, &comparator)
-              sorted_set.to_a.should == SS.new(values) { |item| item.reverse }
+              expect(sorted_set.to_a).to eq(SS.new(values) { |item| item.reverse })
             end
 
             it "returns #{expected.inspect}" do
-              sorted_set.send(method, &comparator).class.should be(Hamster::SortedSet)
-              sorted_set.send(method, &comparator).to_a.should == expected
+              expect(sorted_set.send(method, &comparator).class).to be(Hamster::SortedSet)
+              expect(sorted_set.send(method, &comparator).to_a).to eq(expected)
             end
           end
 
           context "without a block" do
             it "preserves the original" do
               sorted_set.send(method)
-              sorted_set.to_a.should == SS.new(values) { |item| item.reverse }
+              expect(sorted_set.to_a).to eq(SS.new(values) { |item| item.reverse })
             end
 
             it "returns #{expected.sort.inspect}" do
-              sorted_set.send(method).class.should be(Hamster::SortedSet)
-              sorted_set.send(method).to_a.should == expected.sort
+              expect(sorted_set.send(method).class).to be(Hamster::SortedSet)
+              expect(sorted_set.send(method).to_a).to eq(expected.sort)
             end
           end
         end

--- a/spec/lib/hamster/sorted_set/subset_spec.rb
+++ b/spec/lib/hamster/sorted_set/subset_spec.rb
@@ -18,7 +18,7 @@ describe Hamster::SortedSet do
     ].each do |a, b, expected|
       context "for #{a.inspect} and #{b.inspect}" do
         it "returns #{expected}"  do
-          SS[*a].subset?(SS[*b]).should == expected
+          expect(SS[*a].subset?(SS[*b])).to eq(expected)
         end
       end
     end
@@ -40,7 +40,7 @@ describe Hamster::SortedSet do
     ].each do |a, b, expected|
       context "for #{a.inspect} and #{b.inspect}" do
         it "returns #{expected}"  do
-          SS[*a].proper_subset?(SS[*b]).should == expected
+          expect(SS[*a].proper_subset?(SS[*b])).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/superset_spec.rb
+++ b/spec/lib/hamster/sorted_set/superset_spec.rb
@@ -18,7 +18,7 @@ describe Hamster::SortedSet do
     ].each do |a, b, expected|
       context "for #{a.inspect} and #{b.inspect}" do
         it "returns #{expected}"  do
-          SS[*a].superset?(SS[*b]).should == expected
+          expect(SS[*a].superset?(SS[*b])).to eq(expected)
         end
       end
     end
@@ -40,7 +40,7 @@ describe Hamster::SortedSet do
     ].each do |a, b, expected|
       context "for #{a.inspect} and #{b.inspect}" do
         it "returns #{expected}"  do
-          SS[*a].proper_superset?(SS[*b]).should == expected
+          expect(SS[*a].proper_superset?(SS[*b])).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/take_spec.rb
+++ b/spec/lib/hamster/sorted_set/take_spec.rb
@@ -14,11 +14,11 @@ describe Hamster::SortedSet do
 
         it "preserves the original" do
           sorted_set.take(number)
-          sorted_set.should eql(SS[*values])
+          expect(sorted_set).to eql(SS[*values])
         end
 
         it "returns #{expected.inspect}" do
-          sorted_set.take(number).should eql(SS[*expected])
+          expect(sorted_set.take(number)).to eql(SS[*expected])
         end
       end
     end
@@ -26,29 +26,29 @@ describe Hamster::SortedSet do
     context "when argument is at least size of receiver" do
       let(:sorted_set) { SS[6, 7, 8, 9] }
       it "returns self" do
-        sorted_set.take(sorted_set.size).should be(sorted_set)
-        sorted_set.take(sorted_set.size + 1).should be(sorted_set)
+        expect(sorted_set.take(sorted_set.size)).to be(sorted_set)
+        expect(sorted_set.take(sorted_set.size + 1)).to be(sorted_set)
       end
     end
 
     context "when the set has a custom order" do
       let(:sorted_set) { SS.new([1, 2, 3]) { |x| -x }}
       it "maintains the custom order" do
-        sorted_set.take(1).to_a.should == [3]
-        sorted_set.take(2).to_a.should == [3, 2]
-        sorted_set.take(3).to_a.should == [3, 2, 1]
+        expect(sorted_set.take(1).to_a).to eq([3])
+        expect(sorted_set.take(2).to_a).to eq([3, 2])
+        expect(sorted_set.take(3).to_a).to eq([3, 2, 1])
       end
 
       it "keeps the comparator even when set is cleared" do
         s = sorted_set.take(0)
-        s.add(4).add(5).add(6).to_a.should == [6, 5, 4]
+        expect(s.add(4).add(5).add(6).to_a).to eq([6, 5, 4])
       end
     end
 
     context "when called on a subclass" do
       it "should return an instance of the subclass" do
         subclass = Class.new(Hamster::SortedSet)
-        subclass.new([1,2,3]).take(1).class.should be(subclass)
+        expect(subclass.new([1,2,3]).take(1).class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/take_while_spec.rb
+++ b/spec/lib/hamster/sorted_set/take_while_spec.rb
@@ -13,19 +13,19 @@ describe Hamster::SortedSet do
 
         context "with a block" do
           it "returns #{expected.inspect}" do
-            sorted_set.take_while { |item| item < "C" }.should eql(SS[*expected])
+            expect(sorted_set.take_while { |item| item < "C" }).to eql(SS[*expected])
           end
 
           it "preserves the original" do
             sorted_set.take_while { |item| item < "C" }
-            sorted_set.should eql(SS[*values])
+            expect(sorted_set).to eql(SS[*values])
           end
         end
 
         context "without a block" do
           it "returns an Enumerator" do
-            sorted_set.take_while.class.should be(Enumerator)
-            sorted_set.take_while.each { |item| item < "C" }.should eql(SS[*expected])
+            expect(sorted_set.take_while.class).to be(Enumerator)
+            expect(sorted_set.take_while.each { |item| item < "C" }).to eql(SS[*expected])
           end
         end
       end

--- a/spec/lib/hamster/sorted_set/to_set_spec.rb
+++ b/spec/lib/hamster/sorted_set/to_set_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::SortedSet do
     ].each do |values|
       context "on #{values.inspect}" do
         it "returns a set with the same values" do
-          SS[*values].to_set.should eql(S[*values])
+          expect(SS[*values].to_set).to eql(S[*values])
         end
       end
     end

--- a/spec/lib/hamster/sorted_set/union_spec.rb
+++ b/spec/lib/hamster/sorted_set/union_spec.rb
@@ -13,13 +13,13 @@ describe Hamster::SortedSet do
       ].each do |a, b, expected|
         context "for #{a.inspect} and #{b.inspect}" do
           it "returns #{expected.inspect}" do
-            SS[*a].send(method, SS[*b]).should eql(SS[*expected])
+            expect(SS[*a].send(method, SS[*b])).to eql(SS[*expected])
           end
         end
 
         context "for #{b.inspect} and #{a.inspect}" do
           it "returns #{expected.inspect}" do
-            SS[*b].send(method, SS[*a]).should eql(SS[*expected])
+            expect(SS[*b].send(method, SS[*a])).to eql(SS[*expected])
           end
         end
       end

--- a/spec/lib/hamster/sorted_set/up_to_spec.rb
+++ b/spec/lib/hamster/sorted_set/up_to_spec.rb
@@ -11,9 +11,9 @@ describe Hamster::SortedSet do
           threshold = rand(1000)
           result    = set.up_to(threshold)
           array     = items.select { |x| x <= threshold }.sort
-          result.class.should be(Hamster::SortedSet)
-          result.size.should == array.size
-          result.to_a.should == array
+          expect(result.class).to be(Hamster::SortedSet)
+          expect(result.size).to eq(array.size)
+          expect(result.to_a).to eq(array)
         end
       end
     end
@@ -27,26 +27,26 @@ describe Hamster::SortedSet do
           result    = []
           set.up_to(threshold) { |x| result << x }
           array  = items.select { |x| x <= threshold }.sort
-          result.size.should == array.size
-          result.should == array
+          expect(result.size).to eq(array.size)
+          expect(result).to eq(array)
         end
       end
     end
 
     context "on an empty set" do
       it "returns an empty set" do
-        SS.empty.up_to(1).should be_empty
-        SS.empty.up_to('abc').should be_empty
-        SS.empty.up_to(:symbol).should be_empty
-        SS.empty.up_to(nil).should be_empty
+        expect(SS.empty.up_to(1)).to be_empty
+        expect(SS.empty.up_to('abc')).to be_empty
+        expect(SS.empty.up_to(:symbol)).to be_empty
+        expect(SS.empty.up_to(nil)).to be_empty
       end
     end
 
     context "with an argument less than all the values in the set" do
       it "returns an empty set" do
         result = SS.new(1..100).up_to(0)
-        result.class.should be(Hamster::SortedSet)
-        result.should be_empty
+        expect(result.class).to be(Hamster::SortedSet)
+        expect(result).to be_empty
       end
     end
   end

--- a/spec/lib/hamster/sorted_set/values_at_spec.rb
+++ b/spec/lib/hamster/sorted_set/values_at_spec.rb
@@ -6,20 +6,20 @@ describe Hamster::SortedSet do
     let(:sorted_set) { SS['a', 'b', 'c'] }
 
     it "accepts any number of indices, and returns a sorted_set of items at those indices" do
-      sorted_set.values_at(0).should   eql(SS['a'])
-      sorted_set.values_at(1,2).should eql(SS['b', 'c'])
+      expect(sorted_set.values_at(0)).to   eql(SS['a'])
+      expect(sorted_set.values_at(1,2)).to eql(SS['b', 'c'])
     end
 
     context "when passed invalid indices" do
       it "filters them out" do
-        sorted_set.values_at(1,2,3).should  eql(SS['b', 'c'])
-        sorted_set.values_at(-10,10).should eql(SS.empty)
+        expect(sorted_set.values_at(1,2,3)).to  eql(SS['b', 'c'])
+        expect(sorted_set.values_at(-10,10)).to eql(SS.empty)
       end
     end
 
     context "when passed no arguments" do
       it "returns an empty sorted_set" do
-        sorted_set.values_at.should eql(SS.empty)
+        expect(sorted_set.values_at).to eql(SS.empty)
       end
     end
 
@@ -27,7 +27,7 @@ describe Hamster::SortedSet do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::SortedSet)
         instance = subclass.new([1,2,3])
-        instance.values_at(1,2).class.should be(subclass)
+        expect(instance.values_at(1,2).class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/vector/add_spec.rb
+++ b/spec/lib/hamster/vector/add_spec.rb
@@ -60,7 +60,7 @@ describe Hamster::Vector do
         it "returns an instance of the subclass" do
           subclass = Class.new(Hamster::Vector)
           instance = subclass[1,2,3]
-          instance.add(4).class.should be(subclass)
+          expect(instance.add(4).class).to be(subclass)
         end
       end
     end

--- a/spec/lib/hamster/vector/assoc_spec.rb
+++ b/spec/lib/hamster/vector/assoc_spec.rb
@@ -6,41 +6,41 @@ describe Hamster::Vector do
 
   describe "#assoc" do
     it "searches for a 2-element array with a given 1st item" do
-      vector.assoc(:b).should == [:b, 2]
+      expect(vector.assoc(:b)).to eq([:b, 2])
     end
 
     it "returns nil if a matching 1st item is not found" do
-      vector.assoc(:d).should be_nil
+      expect(vector.assoc(:d)).to be_nil
     end
 
     it "uses #== to compare 1st items with provided object" do
-      vector.assoc(EqualNotEql.new).should_not be_nil
-      vector.assoc(EqlNotEqual.new).should be_nil
+      expect(vector.assoc(EqualNotEql.new)).not_to be_nil
+      expect(vector.assoc(EqlNotEqual.new)).to be_nil
     end
 
     it "skips elements which are not indexable" do
-      V[false, true, nil].assoc(:b).should be_nil
-      V[[1,2], nil].assoc(3).should be_nil
+      expect(V[false, true, nil].assoc(:b)).to be_nil
+      expect(V[[1,2], nil].assoc(3)).to be_nil
     end
   end
 
   describe "#rassoc" do
     it "searches for a 2-element array with a given 2nd item" do
-      vector.rassoc(1).should == [:c, 1]
+      expect(vector.rassoc(1)).to eq([:c, 1])
     end
 
     it "returns nil if a matching 2nd item is not found" do
-      vector.rassoc(4).should be_nil
+      expect(vector.rassoc(4)).to be_nil
     end
 
     it "uses #== to compare 2nd items with provided object" do
-      vector.rassoc(EqualNotEql.new).should_not be_nil
-      vector.rassoc(EqlNotEqual.new).should be_nil
+      expect(vector.rassoc(EqualNotEql.new)).not_to be_nil
+      expect(vector.rassoc(EqlNotEqual.new)).to be_nil
     end
 
     it "skips elements which are not indexable" do
-      V[false, true, nil].rassoc(:b).should be_nil
-      V[[1,2], nil].rassoc(3).should be_nil
+      expect(V[false, true, nil].rassoc(:b)).to be_nil
+      expect(V[[1,2], nil].rassoc(3)).to be_nil
     end
   end
 end

--- a/spec/lib/hamster/vector/bsearch_spec.rb
+++ b/spec/lib/hamster/vector/bsearch_spec.rb
@@ -7,59 +7,59 @@ describe Hamster::Vector do
 
     context "with a block which returns false for elements below desired position, and true for those at/above" do
       it "returns the first element for which the predicate is true" do
-        vector.bsearch { |x| x > 10 }.should be(20)
-        vector.bsearch { |x| x > 1 }.should be(5)
-        vector.bsearch { |x| x > 25 }.should be(30)
+        expect(vector.bsearch { |x| x > 10 }).to be(20)
+        expect(vector.bsearch { |x| x > 1 }).to be(5)
+        expect(vector.bsearch { |x| x > 25 }).to be(30)
       end
 
       context "if the block always returns false" do
         it "returns nil" do
-          vector.bsearch { false }.should be_nil
+          expect(vector.bsearch { false }).to be_nil
         end
       end
 
       context "if the block always returns true" do
         it "returns the first element" do
-          vector.bsearch { true }.should be(5)
+          expect(vector.bsearch { true }).to be(5)
         end
       end
     end
 
     context "with a block which returns a negative number for elements below desired position, zero for the right element, and positive for those above" do
       it "returns the element for which the block returns zero" do
-        vector.bsearch { |x| x <=> 10 }.should be(10)
+        expect(vector.bsearch { |x| x <=> 10 }).to be(10)
       end
 
       context "if the block always returns positive" do
         it "returns nil" do
-          vector.bsearch { 1 }.should be_nil
+          expect(vector.bsearch { 1 }).to be_nil
         end
       end
 
       context "if the block always returns negative" do
         it "returns nil" do
-          vector.bsearch { -1 }.should be_nil
+          expect(vector.bsearch { -1 }).to be_nil
         end
       end
 
       context "if the block returns sometimes positive, sometimes negative, but never zero" do
         it "returns nil" do
-          vector.bsearch { |x| x <=> 11 }.should be_nil
+          expect(vector.bsearch { |x| x <=> 11 }).to be_nil
         end
       end
 
       context "if not passed a block" do
         it "returns an Enumerator" do
           enum = vector.bsearch
-          enum.should be_a(Enumerator)
-          enum.each { |x| x <=> 10 }.should == 10
+          expect(enum).to be_a(Enumerator)
+          expect(enum.each { |x| x <=> 10 }).to eq(10)
         end
       end
     end
 
     context "on an empty vector" do
       it "returns nil" do
-        V.empty.bsearch { |x| x > 5 }.should be_nil
+        expect(V.empty.bsearch { |x| x > 5 }).to be_nil
       end
     end
   end

--- a/spec/lib/hamster/vector/clear_spec.rb
+++ b/spec/lib/hamster/vector/clear_spec.rb
@@ -13,11 +13,11 @@ describe Hamster::Vector do
 
         it "preserves the original" do
           vector.clear
-          vector.should eql(V[*values])
+          expect(vector).to eql(V[*values])
         end
 
         it "returns an empty vector" do
-          vector.clear.should equal(V.empty)
+          expect(vector.clear).to equal(V.empty)
         end
       end
 
@@ -25,8 +25,8 @@ describe Hamster::Vector do
         it "returns an instance of the subclass" do
           subclass = Class.new(Hamster::Vector)
           instance = subclass.new(%w{a b c})
-          instance.clear.class.should be(subclass)
-          instance.clear.should be_empty
+          expect(instance.clear.class).to be(subclass)
+          expect(instance.clear).to be_empty
         end
       end
     end

--- a/spec/lib/hamster/vector/combination_spec.rb
+++ b/spec/lib/hamster/vector/combination_spec.rb
@@ -7,21 +7,21 @@ describe Hamster::Vector do
 
     context "with a block" do
       it "returns self" do
-        vector.combination(2) {}.should be(vector)
+        expect(vector.combination(2) {}).to be(vector)
       end
     end
 
     context "with no block" do
       it "returns an Enumerator" do
-        vector.combination(2).class.should be(Enumerator)
-        vector.combination(2).to_a.should == vector.to_a.combination(2).to_a
+        expect(vector.combination(2).class).to be(Enumerator)
+        expect(vector.combination(2).to_a).to eq(vector.to_a.combination(2).to_a)
       end
     end
 
     context "when passed an argument which is out of bounds" do
       it "yields nothing and returns self" do
-        vector.combination(5) { fail }.should be(vector)
-        vector.combination(-1) { fail }.should be(vector)
+        expect(vector.combination(5) { fail }).to be(vector)
+        expect(vector.combination(-1) { fail }).to be(vector)
       end
     end
 
@@ -29,7 +29,7 @@ describe Hamster::Vector do
       it "yields an empty array" do
         result = []
         vector.combination(0) { |obj| result << obj }
-        result.should eql([[]])
+        expect(result).to eql([[]])
       end
     end
 
@@ -37,7 +37,7 @@ describe Hamster::Vector do
       it "yields self as an array" do
         result = []
         vector.combination(4) { |obj| result << obj }
-        result.should eql([vector.to_a])
+        expect(result).to eql([vector.to_a])
       end
     end
 
@@ -45,7 +45,7 @@ describe Hamster::Vector do
       it "yields each item in the vector, as single-item vectors" do
         result = []
         vector.combination(1) { |obj| result << obj }
-        result.should eql([[1], [2], [3], [4]])
+        expect(result).to eql([[1], [2], [3], [4]])
       end
     end
 
@@ -53,30 +53,30 @@ describe Hamster::Vector do
       it "yields all combinations of the given length" do
         result = []
         vector.combination(3) { |obj| result << obj }
-        result.should eql([[1,2,3], [1,2,4], [1,3,4], [2,3,4]])
+        expect(result).to eql([[1,2,3], [1,2,4], [1,3,4], [2,3,4]])
       end
     end
 
     context "on an empty vector" do
       it "works the same" do
-        V.empty.combination(0).to_a.should == [[]]
-        V.empty.combination(1).to_a.should == []
+        expect(V.empty.combination(0).to_a).to eq([[]])
+        expect(V.empty.combination(1).to_a).to eq([])
       end
     end
 
     it "works on many combinations of input" do
       0.upto(5) do |comb_size|
         array = 12.times.map { rand(1000) }
-        V.new(array).combination(comb_size).to_a.should == array.combination(comb_size).to_a
+        expect(V.new(array).combination(comb_size).to_a).to eq(array.combination(comb_size).to_a)
       end
 
       array = 20.times.map { rand(1000) }
-      V.new(array).combination(2).to_a.should == array.combination(2).to_a
+      expect(V.new(array).combination(2).to_a).to eq(array.combination(2).to_a)
     end
 
     it "leaves the original unmodified" do
       vector.combination(2) {}
-      vector.should eql(V[1,2,3,4])
+      expect(vector).to eql(V[1,2,3,4])
     end
   end
 end

--- a/spec/lib/hamster/vector/compact_spec.rb
+++ b/spec/lib/hamster/vector/compact_spec.rb
@@ -4,26 +4,26 @@ require "hamster/vector"
 describe Hamster::Vector do
   describe "#compact" do
     it "returns a new Vector with all nils removed" do
-      V[1, nil, 2, nil].compact.should eql(V[1, 2])
-      V[1, 2, 3].compact.should eql(V[1, 2, 3])
-      V[nil].compact.should eql(V.empty)
+      expect(V[1, nil, 2, nil].compact).to eql(V[1, 2])
+      expect(V[1, 2, 3].compact).to eql(V[1, 2, 3])
+      expect(V[nil].compact).to eql(V.empty)
     end
 
     context "on an empty vector" do
       it "returns self" do
-        V.empty.compact.should be(V.empty)
+        expect(V.empty.compact).to be(V.empty)
       end
     end
 
     it "doesn't remove false" do
-      V[false].compact.should eql(V[false])
+      expect(V[false].compact).to eql(V[false])
     end
 
     context "from a subclass" do
       it "returns an instance of the subclass" do
         subclass = Class.new(V)
         instance = subclass[1, nil, 2]
-        instance.compact.class.should be(subclass)
+        expect(instance.compact.class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/vector/compare_spec.rb
+++ b/spec/lib/hamster/vector/compare_spec.rb
@@ -12,19 +12,19 @@ describe Hamster::Vector do
     ].each do |items1, items2|
       describe "with #{items1} and #{items2}" do
         it "returns -1" do
-          (V.new(items1) <=> V.new(items2)).should be(-1)
+          expect(V.new(items1) <=> V.new(items2)).to be(-1)
         end
       end
 
       describe "with #{items2} and #{items1}" do
         it "returns 1" do
-          (V.new(items2) <=> V.new(items1)).should be(1)
+          expect(V.new(items2) <=> V.new(items1)).to be(1)
         end
       end
 
       describe "with #{items1} and #{items1}" do
         it "returns 0" do
-          (V.new(items1) <=> V.new(items1)).should be(0)
+          expect(V.new(items1) <=> V.new(items1)).to be(0)
         end
       end
     end

--- a/spec/lib/hamster/vector/concat_spec.rb
+++ b/spec/lib/hamster/vector/concat_spec.rb
@@ -8,16 +8,16 @@ describe Hamster::Vector do
 
       it "preserves the original" do
         vector.concat([1,2,3])
-        vector.should eql(V.new(1..100))
+        expect(vector).to eql(V.new(1..100))
       end
 
       it "appends the elements in the other enumerable" do
-        vector.concat([1,2,3]).should eql(V.new((1..100).to_a + [1,2,3]))
-        vector.concat(1..1000).should eql(V.new((1..100).to_a + (1..1000).to_a))
-        vector.concat(1..200).size.should == 300
-        vector.concat(vector).should eql(V.new((1..100).to_a * 2))
-        vector.concat(V.empty).should eql(vector)
-        V.empty.concat(vector).should eql(vector)
+        expect(vector.concat([1,2,3])).to eql(V.new((1..100).to_a + [1,2,3]))
+        expect(vector.concat(1..1000)).to eql(V.new((1..100).to_a + (1..1000).to_a))
+        expect(vector.concat(1..200).size).to eq(300)
+        expect(vector.concat(vector)).to eql(V.new((1..100).to_a * 2))
+        expect(vector.concat(V.empty)).to eql(vector)
+        expect(V.empty.concat(vector)).to eql(vector)
       end
 
       [1, 31, 32, 33, 1023, 1024, 1025].each do |size|
@@ -25,8 +25,8 @@ describe Hamster::Vector do
           it "works the same" do
             vector = V.new(1..size)
             result = vector.concat((size+1)..size+10)
-            result.size.should == size + 10
-            result.should eql(V.new(1..(size+10)))
+            expect(result.size).to eq(size + 10)
+            expect(result).to eql(V.new(1..(size+10)))
           end
         end
       end

--- a/spec/lib/hamster/vector/copying_spec.rb
+++ b/spec/lib/hamster/vector/copying_spec.rb
@@ -13,7 +13,7 @@ describe Hamster::Vector do
         let(:vector) { V[*values] }
 
         it "returns self" do
-          vector.send(method).should equal(vector)
+          expect(vector.send(method)).to equal(vector)
         end
       end
     end

--- a/spec/lib/hamster/vector/count_spec.rb
+++ b/spec/lib/hamster/vector/count_spec.rb
@@ -4,15 +4,15 @@ require "hamster/vector"
 describe Hamster::Vector do
   describe "#count" do
     it "returns the number of elements" do
-      V[:a, :b, :c].count.should == 3
+      expect(V[:a, :b, :c].count).to eq(3)
     end
 
     it "returns the number of elements that equal the argument" do
-      V[:a, :b, :b, :c].count(:b).should == 2
+      expect(V[:a, :b, :b, :c].count(:b)).to eq(2)
     end
 
     it "returns the number of element for which the block evaluates to true" do
-      V[:a, :b, :c].count { |s| s != :b }.should == 2
+      expect(V[:a, :b, :c].count { |s| s != :b }).to eq(2)
     end
   end
 end

--- a/spec/lib/hamster/vector/delete_at_spec.rb
+++ b/spec/lib/hamster/vector/delete_at_spec.rb
@@ -6,35 +6,35 @@ describe Hamster::Vector do
     let(:vector) { V[1,2,3,4,5] }
 
     it "removes the element at the specified index" do
-      vector.delete_at(0).should eql(V[2,3,4,5])
-      vector.delete_at(2).should eql(V[1,2,4,5])
-      vector.delete_at(-1).should eql(V[1,2,3,4])
+      expect(vector.delete_at(0)).to eql(V[2,3,4,5])
+      expect(vector.delete_at(2)).to eql(V[1,2,4,5])
+      expect(vector.delete_at(-1)).to eql(V[1,2,3,4])
     end
 
     it "makes no modification if the index is out of range" do
-      vector.delete_at(5).should eql(vector)
-      vector.delete_at(-6).should eql(vector)
+      expect(vector.delete_at(5)).to eql(vector)
+      expect(vector.delete_at(-6)).to eql(vector)
     end
 
     it "works when deleting last item at boundary where vector trie needs to get shallower" do
       vector = Hamster::Vector.new(1..33)
-      vector.delete_at(32).size.should == 32
-      vector.delete_at(32).to_a.should eql((1..32).to_a)
+      expect(vector.delete_at(32).size).to eq(32)
+      expect(vector.delete_at(32).to_a).to eql((1..32).to_a)
     end
 
     it "works on an empty vector" do
-      V.empty.delete_at(0).should be(V.empty)
-      V.empty.delete_at(1).should be(V.empty)
+      expect(V.empty.delete_at(0)).to be(V.empty)
+      expect(V.empty.delete_at(1)).to be(V.empty)
     end
 
     it "works on a vector with 1 item" do
-      V[10].delete_at(0).should eql(V.empty)
-      V[10].delete_at(1).should eql(V[10])
+      expect(V[10].delete_at(0)).to eql(V.empty)
+      expect(V[10].delete_at(1)).to eql(V[10])
     end
 
     it "works on a vector with 32 items" do
-      V.new(1..32).delete_at(0).should eql(V.new(2..32))
-      V.new(1..32).delete_at(31).should eql(V.new(1..31))
+      expect(V.new(1..32).delete_at(0)).to eql(V.new(2..32))
+      expect(V.new(1..32).delete_at(31)).to eql(V.new(1..31))
     end
 
     it "has the right size and contents after many deletions" do
@@ -44,10 +44,10 @@ describe Hamster::Vector do
         index = rand(vector.size)
         vector = vector.delete_at(index)
         array.delete_at(index)
-        vector.size.should == array.size
+        expect(vector.size).to eq(array.size)
         ary = vector.to_a
-        ary.size.should == vector.size
-        ary.should eql(array)
+        expect(ary.size).to eq(vector.size)
+        expect(ary).to eql(array)
       end
     end
   end

--- a/spec/lib/hamster/vector/delete_spec.rb
+++ b/spec/lib/hamster/vector/delete_spec.rb
@@ -4,19 +4,19 @@ require "hamster/vector"
 describe Hamster::Vector do
   describe "#delete" do
     it "removes elements that are #== to the argument" do
-      V[1,2,3].delete(1).should eql(V[2,3])
-      V[1,2,3].delete(2).should eql(V[1,3])
-      V[1,2,3].delete(3).should eql(V[1,2])
-      V[1,2,3].delete(0).should eql(V[1,2,3])
-      V['a','b','a','c','a','a','d'].delete('a').should eql(V['b','c','d'])
+      expect(V[1,2,3].delete(1)).to eql(V[2,3])
+      expect(V[1,2,3].delete(2)).to eql(V[1,3])
+      expect(V[1,2,3].delete(3)).to eql(V[1,2])
+      expect(V[1,2,3].delete(0)).to eql(V[1,2,3])
+      expect(V['a','b','a','c','a','a','d'].delete('a')).to eql(V['b','c','d'])
 
-      V[EqualNotEql.new, EqualNotEql.new].delete(:something).should eql(V.empty)
-      V[EqlNotEqual.new, EqlNotEqual.new].delete(:something).should_not be_empty
+      expect(V[EqualNotEql.new, EqualNotEql.new].delete(:something)).to eql(V.empty)
+      expect(V[EqlNotEqual.new, EqlNotEqual.new].delete(:something)).not_to be_empty
     end
 
     context "on an empty vector" do
       it "returns self" do
-        V.empty.delete(1).should be(V.empty)
+        expect(V.empty.delete(1)).to be(V.empty)
       end
     end
 
@@ -24,7 +24,7 @@ describe Hamster::Vector do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1,2,3])
-        instance.delete(1).class.should be(subclass)
+        expect(instance.delete(1).class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/vector/drop_spec.rb
+++ b/spec/lib/hamster/vector/drop_spec.rb
@@ -18,24 +18,24 @@ describe Hamster::Vector do
 
         it "preserves the original" do
           vector.drop(number)
-          vector.should eql(V[*values])
+          expect(vector).to eql(V[*values])
         end
 
         it "returns #{expected.inspect}" do
-          vector.drop(number).should eql(V[*expected])
+          expect(vector.drop(number)).to eql(V[*expected])
         end
       end
     end
 
     it "raises an ArgumentError if number of elements specified is negative" do
-      -> { V[1, 2, 3].drop(-1) }.should raise_error(ArgumentError)
-      -> { V[1, 2, 3].drop(-3) }.should raise_error(ArgumentError)
+      expect { V[1, 2, 3].drop(-1) }.to raise_error(ArgumentError)
+      expect { V[1, 2, 3].drop(-3) }.to raise_error(ArgumentError)
     end
 
     context "when number of elements specified is zero" do
       let(:vector) { V[1, 2, 3, 4, 5, 6] }
       it "returns self" do
-        vector.drop(0).should be(vector)
+        expect(vector.drop(0)).to be(vector)
       end
     end
   end

--- a/spec/lib/hamster/vector/drop_while_spec.rb
+++ b/spec/lib/hamster/vector/drop_while_spec.rb
@@ -16,18 +16,18 @@ describe Hamster::Vector do
 
           it "preserves the original" do
             result
-            vector.should eql(V[*values])
+            expect(vector).to eql(V[*values])
           end
 
           it "returns #{expected.inspect}" do
-            result.should eql(V[*expected])
+            expect(result).to eql(V[*expected])
           end
         end
 
         describe "without a block" do
           it "returns an Enumerator" do
-            vector.drop_while.class.should be(Enumerator)
-            vector.drop_while.each { |item| item < "C" }.should eql(V[*expected])
+            expect(vector.drop_while.class).to be(Enumerator)
+            expect(vector.drop_while.each { |item| item < "C" }).to eql(V[*expected])
           end
         end
       end
@@ -35,21 +35,21 @@ describe Hamster::Vector do
 
     context "on an empty vector" do
       it "returns an empty vector" do
-        V.empty.drop_while { false }.should eql(V.empty)
+        expect(V.empty.drop_while { false }).to eql(V.empty)
       end
     end
 
     it "returns an empty vector if block is always true" do
-      V.new(1..32).drop_while { true }.should eql(V.empty)
-      V.new(1..100).drop_while { true }.should eql(V.empty)
+      expect(V.new(1..32).drop_while { true }).to eql(V.empty)
+      expect(V.new(1..100).drop_while { true }).to eql(V.empty)
     end
 
     it "stops dropping items if block returns nil" do
-      V[1, 2, 3, nil, 4, 5].drop_while { |x| x }.should eql(V[nil, 4, 5])
+      expect(V[1, 2, 3, nil, 4, 5].drop_while { |x| x }).to eql(V[nil, 4, 5])
     end
 
     it "stops dropping items if block returns false" do
-      V[1, 2, 3, false, 4, 5].drop_while { |x| x }.should eql(V[false, 4, 5])
+      expect(V[1, 2, 3, false, 4, 5].drop_while { |x| x }).to eql(V[false, 4, 5])
     end
   end
 end

--- a/spec/lib/hamster/vector/each_index_spec.rb
+++ b/spec/lib/hamster/vector/each_index_spec.rb
@@ -9,18 +9,18 @@ describe Hamster::Vector do
       it "yields all the valid indices into the vector" do
         result = []
         vector.each_index { |i| result << i }
-        result.should eql([0,1,2,3])
+        expect(result).to eql([0,1,2,3])
       end
 
       it "returns self" do
-        vector.each_index {}.should be(vector)
+        expect(vector.each_index {}).to be(vector)
       end
     end
 
     context "without a block" do
       it "returns an Enumerator" do
-        vector.each_index.class.should be(Enumerator)
-        vector.each_index.to_a.should eql([0,1,2,3])
+        expect(vector.each_index.class).to be(Enumerator)
+        expect(vector.each_index.to_a).to eql([0,1,2,3])
       end
     end
 
@@ -33,7 +33,7 @@ describe Hamster::Vector do
     [1, 2, 10, 31, 32, 33, 1000, 1024, 1025].each do |size|
       context "on a #{size}-item vector" do
         it "yields all valid indices" do
-          V.new(1..size).each_index.to_a.should == (0..(size-1)).to_a
+          expect(V.new(1..size).each_index.to_a).to eq((0..(size-1)).to_a)
         end
       end
     end

--- a/spec/lib/hamster/vector/each_spec.rb
+++ b/spec/lib/hamster/vector/each_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::Vector do
       let(:vector) { V["A", "B", "C"] }
 
       it "returns an Enumerator" do
-        vector.each.class.should be(Enumerator)
-        vector.each.to_a.should == vector
+        expect(vector.each.class).to be(Enumerator)
+        expect(vector.each.to_a).to eq(vector)
       end
     end
 
@@ -19,18 +19,18 @@ describe Hamster::Vector do
 
           it "returns self" do
             items = []
-            vector.each { |item| items << item }.should be(vector)
+            expect(vector.each { |item| items << item }).to be(vector)
           end
 
           it "yields all the items" do
             items = []
             vector.each { |item| items << item }
-            items.should == (1..size).to_a
+            expect(items).to eq((1..size).to_a)
           end
 
           it "iterates over the items in order" do
-            vector.each.first.should == 1
-            vector.each.to_a.last.should == size
+            expect(vector.each.first).to eq(1)
+            expect(vector.each.to_a.last).to eq(size)
           end
         end
       end

--- a/spec/lib/hamster/vector/each_with_index_spec.rb
+++ b/spec/lib/hamster/vector/each_with_index_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::Vector do
       let(:vector) { V["A", "B", "C"] }
 
       it "returns an Enumerator" do
-        vector.each_with_index.class.should be(Enumerator)
-        vector.each_with_index.to_a.should == [['A', 0], ['B', 1], ['C', 2]]
+        expect(vector.each_with_index.class).to be(Enumerator)
+        expect(vector.each_with_index.to_a).to eq([['A', 0], ['B', 1], ['C', 2]])
       end
     end
 
@@ -19,13 +19,13 @@ describe Hamster::Vector do
 
           it "returns self" do
             pairs = []
-            vector.each_with_index { |item, index| pairs << [item, index] }.should be(vector)
+            expect(vector.each_with_index { |item, index| pairs << [item, index] }).to be(vector)
           end
 
           it "iterates over the items in order" do
             pairs = []
-            vector.each_with_index { |item, index| pairs << [item, index] }.should be(vector)
-            pairs.should == (1..size).zip(0..size.pred)
+            expect(vector.each_with_index { |item, index| pairs << [item, index] }).to be(vector)
+            expect(pairs).to eq((1..size).zip(0..size.pred))
           end
         end
       end

--- a/spec/lib/hamster/vector/empty_spec.rb
+++ b/spec/lib/hamster/vector/empty_spec.rb
@@ -10,7 +10,7 @@ describe Hamster::Vector do
     ].each do |values, expected|
       describe "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          V[*values].empty?.should == expected
+          expect(V[*values].empty?).to eq(expected)
         end
       end
     end
@@ -18,15 +18,15 @@ describe Hamster::Vector do
 
   describe ".empty" do
     it "returns the canonical empty vector" do
-      V.empty.size.should be(0)
-      V.empty.object_id.should be(V.empty.object_id)
+      expect(V.empty.size).to be(0)
+      expect(V.empty.object_id).to be(V.empty.object_id)
     end
 
     context "from a subclass" do
       it "returns an empty instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
-        subclass.empty.class.should be(subclass)
-        subclass.empty.should be_empty
+        expect(subclass.empty.class).to be(subclass)
+        expect(subclass.empty).to be_empty
       end
 
       it "calls overridden #initialize when creating empty Hash" do
@@ -35,7 +35,7 @@ describe Hamster::Vector do
             @variable = 'value'
           end
         end
-        subclass.empty.instance_variable_get(:@variable).should == 'value'
+        expect(subclass.empty.instance_variable_get(:@variable)).to eq('value')
       end
     end
   end

--- a/spec/lib/hamster/vector/eql_spec.rb
+++ b/spec/lib/hamster/vector/eql_spec.rb
@@ -6,19 +6,19 @@ describe Hamster::Vector do
     let(:vector) { V["A", "B", "C"] }
 
     it "returns false when comparing with an array with the same contents" do
-      vector.eql?(%w[A B C]).should == false
+      expect(vector.eql?(%w[A B C])).to eq(false)
     end
 
     it "returns false when comparing with an arbitrary object" do
-      vector.eql?(Object.new).should == false
+      expect(vector.eql?(Object.new)).to eq(false)
     end
 
     it "returns false when comparing an empty vector with an empty array" do
-      V.empty.eql?([]).should == false
+      expect(V.empty.eql?([])).to eq(false)
     end
 
     it "returns false when comparing with a subclass of Hamster::Vector" do
-      vector.eql?(Class.new(Hamster::Vector).new(%w[A B C])).should == false
+      expect(vector.eql?(Class.new(Hamster::Vector).new(%w[A B C]))).to eq(false)
     end
   end
 
@@ -26,24 +26,24 @@ describe Hamster::Vector do
     let(:vector) { V["A", "B", "C"] }
 
     it "returns true when comparing with an array with the same contents" do
-      (vector == %w[A B C]).should == true
+      expect(vector == %w[A B C]).to eq(true)
     end
 
     it "returns false when comparing with an arbitrary object" do
-      (vector == Object.new).should == false
+      expect(vector == Object.new).to eq(false)
     end
 
     it "returns true when comparing an empty vector with an empty array" do
-      (V.empty == []).should == true
+      expect(V.empty == []).to eq(true)
     end
 
     it "returns true when comparing with a subclass of Hamster::Vector" do
-      (vector == Class.new(Hamster::Vector).new(%w[A B C])).should == true
+      expect(vector == Class.new(Hamster::Vector).new(%w[A B C])).to eq(true)
     end
 
     it "works on larger vectors" do
       array = 2000.times.map { rand(10000) }
-      (V.new(array.dup) == array).should == true
+      expect(V.new(array.dup) == array).to eq(true)
     end
   end
 
@@ -64,11 +64,11 @@ describe Hamster::Vector do
           let(:vector_b) { V[*b] }
 
           it "for vectors #{a.inspect} and #{b.inspect}" do
-            vector_a.send(method, vector_b).should == expected
+            expect(vector_a.send(method, vector_b)).to eq(expected)
           end
 
           it "for vectors #{b.inspect} and #{a.inspect}" do
-            vector_b.send(method, vector_a).should == expected
+            expect(vector_b.send(method, vector_a)).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/vector/fetch_spec.rb
+++ b/spec/lib/hamster/vector/fetch_spec.rb
@@ -8,16 +8,16 @@ describe Hamster::Vector do
     context "with no default provided" do
       context "when the index exists" do
         it "returns the value at the index" do
-          vector.fetch(0).should == "a"
-          vector.fetch(1).should == "b"
-          vector.fetch(2).should == "c"
+          expect(vector.fetch(0)).to eq("a")
+          expect(vector.fetch(1)).to eq("b")
+          expect(vector.fetch(2)).to eq("c")
         end
       end
 
       context "when the key does not exist" do
         it "raises an IndexError" do
-          -> { vector.fetch(3) }.should raise_error(IndexError)
-          -> { vector.fetch(-4) }.should raise_error(IndexError)
+          expect { vector.fetch(3) }.to raise_error(IndexError)
+          expect { vector.fetch(-4) }.to raise_error(IndexError)
         end
       end
     end
@@ -25,16 +25,16 @@ describe Hamster::Vector do
     context "with a default value" do
       context "when the index exists" do
         it "returns the value at the index" do
-          vector.fetch(0, "default").should == "a"
-          vector.fetch(1, "default").should == "b"
-          vector.fetch(2, "default").should == "c"
+          expect(vector.fetch(0, "default")).to eq("a")
+          expect(vector.fetch(1, "default")).to eq("b")
+          expect(vector.fetch(2, "default")).to eq("c")
         end
       end
 
       context "when the index does not exist" do
         it "returns the default value" do
-          vector.fetch(3, "default").should == "default"
-          vector.fetch(-4, "default").should == "default"
+          expect(vector.fetch(3, "default")).to eq("default")
+          expect(vector.fetch(-4, "default")).to eq("default")
         end
       end
     end
@@ -42,24 +42,24 @@ describe Hamster::Vector do
     context "with a default block" do
       context "when the index exists" do
         it "returns the value at the index" do
-          vector.fetch(0) { "default".upcase }.should == "a"
-          vector.fetch(1) { "default".upcase }.should == "b"
-          vector.fetch(2) { "default".upcase }.should == "c"
+          expect(vector.fetch(0) { "default".upcase }).to eq("a")
+          expect(vector.fetch(1) { "default".upcase }).to eq("b")
+          expect(vector.fetch(2) { "default".upcase }).to eq("c")
         end
       end
 
       context "when the index does not exist" do
         it "invokes the block with the missing index as parameter" do
-          vector.fetch(3) { |index| index.should == 3}
-          vector.fetch(-4) { |index| index.should == -4 }
-          vector.fetch(3) { "default".upcase }.should == "DEFAULT"
-          vector.fetch(-4) { "default".upcase }.should == "DEFAULT"
+          vector.fetch(3) { |index| expect(index).to eq(3)}
+          vector.fetch(-4) { |index| expect(index).to eq(-4) }
+          expect(vector.fetch(3) { "default".upcase }).to eq("DEFAULT")
+          expect(vector.fetch(-4) { "default".upcase }).to eq("DEFAULT")
         end
       end
     end
 
     it "gives precedence to default block over default argument if passed both" do
-      vector.fetch(3, 'one') { 'two' }.should == 'two'
+      expect(vector.fetch(3, 'one') { 'two' }).to eq('two')
     end
   end
 end

--- a/spec/lib/hamster/vector/fill_spec.rb
+++ b/spec/lib/hamster/vector/fill_spec.rb
@@ -6,47 +6,47 @@ describe Hamster::Vector do
     let(:vector) { V[1, 2, 3, 4, 5, 6] }
 
     it "can replace a range of items at the beginning of a vector" do
-      vector.fill(:a, 0, 3).should eql(V[:a, :a, :a, 4, 5, 6])
+      expect(vector.fill(:a, 0, 3)).to eql(V[:a, :a, :a, 4, 5, 6])
     end
 
     it "can replace a range of items in the middle of a vector" do
-      vector.fill(:a, 3, 2).should eql(V[1, 2, 3, :a, :a, 6])
+      expect(vector.fill(:a, 3, 2)).to eql(V[1, 2, 3, :a, :a, 6])
     end
 
     it "can replace a range of items at the end of a vector" do
-      vector.fill(:a, 4, 2).should eql(V[1, 2, 3, 4, :a, :a])
+      expect(vector.fill(:a, 4, 2)).to eql(V[1, 2, 3, 4, :a, :a])
     end
 
     it "can replace all the items in a vector" do
-      vector.fill(:a, 0, 6).should eql(V[:a, :a, :a, :a, :a, :a])
+      expect(vector.fill(:a, 0, 6)).to eql(V[:a, :a, :a, :a, :a, :a])
     end
 
     it "can fill past the end of the vector" do
-      vector.fill(:a, 3, 6).should eql(V[1, 2, 3, :a, :a, :a, :a, :a, :a])
+      expect(vector.fill(:a, 3, 6)).to eql(V[1, 2, 3, :a, :a, :a, :a, :a, :a])
     end
 
     context "with 1 argument" do
       it "replaces all the items in the vector by default" do
-        vector.fill(:a).should eql(V[:a, :a, :a, :a, :a, :a])
+        expect(vector.fill(:a)).to eql(V[:a, :a, :a, :a, :a, :a])
       end
     end
 
     context "with 2 arguments" do
       it "replaces up to the end of the vector by default" do
-        vector.fill(:a, 4).should eql(V[1, 2, 3, 4, :a, :a])
+        expect(vector.fill(:a, 4)).to eql(V[1, 2, 3, 4, :a, :a])
       end
     end
 
     context "when index and length are 0" do
       it "leaves the vector unmodified" do
-        vector.fill(:a, 0, 0).should eql(vector)
+        expect(vector.fill(:a, 0, 0)).to eql(vector)
       end
     end
 
     context "when expanding a vector past boundary where vector trie needs to deepen" do
       it "works the same" do
-        vector.fill(:a, 32, 3).size.should == 35
-        vector.fill(:a, 32, 3).to_a.size.should == 35
+        expect(vector.fill(:a, 32, 3).size).to eq(35)
+        expect(vector.fill(:a, 32, 3).to_a.size).to eq(35)
       end
     end
 
@@ -59,10 +59,10 @@ describe Hamster::Vector do
             next if index > size
             vector = vector.fill(obj, index, length)
             array.fill(obj, index, length)
-            vector.size.should == array.size
+            expect(vector.size).to eq(array.size)
             ary = vector.to_a
-            ary.size.should == vector.size
-            ary.should eql(array)
+            expect(ary.size).to eq(vector.size)
+            expect(ary).to eql(array)
           end
         end
       end
@@ -73,16 +73,16 @@ describe Hamster::Vector do
         array = rand(100).times.map { rand(1000) }
         index = rand(array.size)
         length = rand(50)
-        V.new(array).fill(:a, index, length).should == array.fill(:a, index, length)
+        expect(V.new(array).fill(:a, index, length)).to eq(array.fill(:a, index, length))
       end
       10.times do
         array = rand(100).times.map { rand(10000) }
         length = rand(100)
-        V.new(array).fill(:a, array.size, length).should == array.fill(:a, array.size, length)
+        expect(V.new(array).fill(:a, array.size, length)).to eq(array.fill(:a, array.size, length))
       end
       10.times do
         array = rand(100).times.map { rand(10000) }
-        V.new(array).fill(:a).should == array.fill(:a)
+        expect(V.new(array).fill(:a)).to eq(array.fill(:a))
       end
     end
   end

--- a/spec/lib/hamster/vector/first_spec.rb
+++ b/spec/lib/hamster/vector/first_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::Vector do
     ].each do |values, expected|
       describe "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          V[*values].first.should == expected
+          expect(V[*values].first).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/vector/flatten_spec.rb
+++ b/spec/lib/hamster/vector/flatten_spec.rb
@@ -4,26 +4,26 @@ require "hamster/vector"
 describe Hamster::Vector do
   describe "#flatten" do
     it "recursively flattens nested vectors into containing vector" do
-      V[V[1], V[2]].flatten.should eql(V[1,2])
-      V[V[V[V[V[V[1,2,3]]]]]].flatten.should eql(V[1,2,3])
-      V[V[V[1]], V[V[V[2]]]].flatten.should eql(V[1,2])
+      expect(V[V[1], V[2]].flatten).to eql(V[1,2])
+      expect(V[V[V[V[V[V[1,2,3]]]]]].flatten).to eql(V[1,2,3])
+      expect(V[V[V[1]], V[V[V[2]]]].flatten).to eql(V[1,2])
     end
 
     it "flattens nested arrays as well" do
-      V[[1,2,3],[[4],[5,6]]].flatten.should eql(V[1,2,3,4,5,6])
+      expect(V[[1,2,3],[[4],[5,6]]].flatten).to eql(V[1,2,3,4,5,6])
     end
 
     context "with an integral argument" do
       it "only flattens down to the specified depth" do
-        V[V[V[1,2]]].flatten(1).should eql(V[V[1,2]])
-        V[V[V[V[1]], V[2], V[3]]].flatten(2).should eql(V[V[1], 2, 3])
+        expect(V[V[V[1,2]]].flatten(1)).to eql(V[V[1,2]])
+        expect(V[V[V[V[1]], V[2], V[3]]].flatten(2)).to eql(V[V[1], 2, 3])
       end
     end
 
     context "with an argument of zero" do
       it "returns self" do
         vector = V[1,2,3]
-        vector.flatten(0).should be(vector)
+        expect(vector.flatten(0)).to be(vector)
       end
     end
 
@@ -31,21 +31,21 @@ describe Hamster::Vector do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1,2])
-        instance.flatten.class.should be(subclass)
+        expect(instance.flatten.class).to be(subclass)
       end
     end
 
     context "on a vector with no nested vectors" do
       it "returns an unchanged vector" do
         vector = V[1,2,3]
-        vector.flatten.should.eql?(V[1,2,3])
+        expect(vector.flatten).to eql(V[1,2,3])
       end
 
       context "on a Vector larger than 32 items initialized with Vector.new" do
         # Regression test, for problem discovered while working on GH issue #182
         it "returns an unchanged vector" do
           vector1,vector2 = 2.times.collect { V.new(0..33) }
-          vector1.flatten.should eql(vector2)
+          expect(vector1.flatten).to eql(vector2)
         end
       end
     end
@@ -53,7 +53,7 @@ describe Hamster::Vector do
     it "leaves the original unmodified" do
       vector = V[1,2,3]
       vector.flatten
-      vector.should eql(V[1,2,3])
+      expect(vector).to eql(V[1,2,3])
     end
   end
 end

--- a/spec/lib/hamster/vector/get_spec.rb
+++ b/spec/lib/hamster/vector/get_spec.rb
@@ -7,7 +7,7 @@ describe Hamster::Vector do
       context "when empty" do
         it "always returns nil" do
           (-1..1).each do |i|
-            V.empty.send(method, i).should be_nil
+            expect(V.empty.send(method, i)).to be_nil
           end
         end
       end
@@ -19,14 +19,14 @@ describe Hamster::Vector do
           context "within the absolute bounds of the vector" do
             it "returns the value at the specified index from the head" do
               (0..(vector.size - 1)).each do |i|
-                vector.send(method, i).should == i + 1
+                expect(vector.send(method, i)).to eq(i + 1)
               end
             end
           end
 
           context "outside the absolute bounds of the vector" do
             it "returns nil" do
-              vector.send(method, vector.size).should be_nil
+              expect(vector.send(method, vector.size)).to be_nil
             end
           end
         end
@@ -35,14 +35,14 @@ describe Hamster::Vector do
           context "within the absolute bounds of the vector" do
             it "returns the value at the specified index from the tail" do
               (-vector.size..-1).each do |i|
-                vector.send(method, i).should == vector.size + i + 1
+                expect(vector.send(method, i)).to eq(vector.size + i + 1)
               end
             end
           end
 
           context "outside the absolute bounds of the vector" do
             it "returns nil" do
-              vector.send(method, -vector.size.next).should be_nil
+              expect(vector.send(method, -vector.size.next)).to be_nil
             end
           end
         end
@@ -65,7 +65,7 @@ describe Hamster::Vector do
               end
             end
             0.upto(array.size) do |i|
-              array[i].should == vector.send(method, i)
+              expect(array[i]).to eq(vector.send(method, i))
             end
           end
         end

--- a/spec/lib/hamster/vector/group_by_spec.rb
+++ b/spec/lib/hamster/vector/group_by_spec.rb
@@ -13,8 +13,8 @@ describe Hamster::Vector do
           let(:vector) { V[*values] }
 
           it "returns #{expected.inspect}" do
-            vector.group_by(&:odd?).should eql(H[*expected])
-            vector.should eql(V.new(values)) # make sure it hasn't changed
+            expect(vector.group_by(&:odd?)).to eql(H[*expected])
+            expect(vector).to eql(V.new(values)) # make sure it hasn't changed
           end
         end
       end
@@ -30,8 +30,8 @@ describe Hamster::Vector do
           let(:vector) { V[*values] }
 
           it "returns #{expected.inspect}" do
-            vector.group_by.should eql(H[*expected])
-            vector.should eql(V.new(values)) # make sure it hasn't changed
+            expect(vector.group_by).to eql(H[*expected])
+            expect(vector).to eql(V.new(values)) # make sure it hasn't changed
           end
         end
       end
@@ -39,19 +39,19 @@ describe Hamster::Vector do
 
     context "on an empty vector" do
       it "returns an empty hash" do
-        V.empty.group_by { |x| x }.should eql(H.empty)
+        expect(V.empty.group_by { |x| x }).to eql(H.empty)
       end
     end
 
     it "returns a hash without default proc" do
-      V[1,2,3].group_by { |x| x }.default_proc.should be_nil
+      expect(V[1,2,3].group_by { |x| x }.default_proc).to be_nil
     end
 
     context "from a subclass" do
       it "returns an Hash whose values are instances of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1, 'string', :symbol])
-        instance.group_by { |x| x.class }.values.each { |v| v.class.should be(subclass) }
+        instance.group_by { |x| x.class }.values.each { |v| expect(v.class).to be(subclass) }
       end
     end
   end

--- a/spec/lib/hamster/vector/include_spec.rb
+++ b/spec/lib/hamster/vector/include_spec.rb
@@ -22,7 +22,7 @@ describe Hamster::Vector do
       ].each do |values, item, expected|
         describe "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            V[*values].send(method, item).should == expected
+            expect(V[*values].send(method, item)).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/vector/insert_spec.rb
+++ b/spec/lib/hamster/vector/insert_spec.rb
@@ -8,33 +8,33 @@ describe Hamster::Vector do
 
     it "can add items at the beginning of a vector" do
       vector = original.insert(0, :a, :b)
-      vector.size.should be(5)
-      vector.at(0).should be(:a)
-      vector.at(2).should be(1)
+      expect(vector.size).to be(5)
+      expect(vector.at(0)).to be(:a)
+      expect(vector.at(2)).to be(1)
     end
 
     it "can add items in the middle of a vector" do
       vector = original.insert(1, :a, :b, :c)
-      vector.size.should be(6)
-      vector.to_a.should == [1, :a, :b, :c, 2, 3]
+      expect(vector.size).to be(6)
+      expect(vector.to_a).to eq([1, :a, :b, :c, 2, 3])
     end
 
     it "can add items at the end of a vector" do
       vector = original.insert(3, :a, :b, :c)
-      vector.size.should be(6)
-      vector.to_a.should == [1, 2, 3, :a, :b, :c]
+      expect(vector.size).to be(6)
+      expect(vector.to_a).to eq([1, 2, 3, :a, :b, :c])
     end
 
     it "can add items past the end of a vector" do
       vector = original.insert(6, :a, :b)
-      vector.size.should be(8)
-      vector.to_a.should == [1, 2, 3, nil, nil, nil, :a, :b]
+      expect(vector.size).to be(8)
+      expect(vector.to_a).to eq([1, 2, 3, nil, nil, nil, :a, :b])
     end
 
     it "accepts a negative index, which counts back from the end of the vector" do
       vector = original.insert(-2, :a)
-      vector.size.should be(4)
-      vector.to_a.should == [1, :a, 2, 3]
+      expect(vector.size).to be(4)
+      expect(vector.to_a).to eq([1, :a, 2, 3])
     end
 
     it "raises IndexError if a negative index is too great" do
@@ -43,12 +43,12 @@ describe Hamster::Vector do
 
     it "works when adding an item past boundary when vector trie needs to deepen" do
       vector = original.insert(32, :a, :b)
-      vector.size.should == 34
-      vector.to_a.size.should == 34
+      expect(vector.size).to eq(34)
+      expect(vector.to_a.size).to eq(34)
     end
 
     it "works when adding to an empty Vector" do
-      V.empty.insert(0, :a).should eql(V[:a])
+      expect(V.empty.insert(0, :a)).to eql(V[:a])
     end
 
     it "has the right size and contents after many insertions" do
@@ -59,10 +59,10 @@ describe Hamster::Vector do
         index = rand(vector.size)
         vector = vector.insert(index, *items)
         array.insert(index, *items)
-        vector.size.should == array.size
+        expect(vector.size).to eq(array.size)
         ary = vector.to_a
-        ary.size.should == vector.size
-        ary.should eql(array)
+        expect(ary.size).to eq(vector.size)
+        expect(ary).to eql(array)
       end
     end
   end

--- a/spec/lib/hamster/vector/join_spec.rb
+++ b/spec/lib/hamster/vector/join_spec.rb
@@ -14,11 +14,11 @@ describe Hamster::Vector do
 
           it "preserves the original" do
             vector.join("|")
-            vector.should eql(V[*values])
+            expect(vector).to eql(V[*values])
           end
 
           it "returns #{expected.inspect}" do
-            vector.join("|").should == expected
+            expect(vector.join("|")).to eq(expected)
           end
         end
       end
@@ -35,11 +35,11 @@ describe Hamster::Vector do
 
           it "preserves the original" do
             vector.join
-            vector.should eql(V[*values])
+            expect(vector).to eql(V[*values])
           end
 
           it "returns #{expected.inspect}" do
-            vector.join.should == expected
+            expect(vector.join).to eq(expected)
           end
         end
       end
@@ -51,7 +51,7 @@ describe Hamster::Vector do
 
       describe 'on ["A", "B", "C"]' do
         it 'returns "A**B**C"' do
-          V["A", "B", "C"].join.should == "A**B**C"
+          expect(V["A", "B", "C"].join).to eq("A**B**C")
         end
       end
     end

--- a/spec/lib/hamster/vector/ltlt_spec.rb
+++ b/spec/lib/hamster/vector/ltlt_spec.rb
@@ -59,7 +59,7 @@ describe Hamster::Vector do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass[1,2,3]
-        (instance << 4).class.should be(subclass)
+        expect((instance << 4).class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/vector/map_spec.rb
+++ b/spec/lib/hamster/vector/map_spec.rb
@@ -8,7 +8,7 @@ describe Hamster::Vector do
         let(:vector) { V.empty }
 
         it "returns self" do
-          vector.send(method) {}.should equal(vector)
+          expect(vector.send(method) {}).to equal(vector)
         end
       end
 
@@ -18,18 +18,18 @@ describe Hamster::Vector do
         context "with a block" do
           it "preserves the original values" do
             vector.send(method, &:downcase)
-            vector.should eql(V["A", "B", "C"])
+            expect(vector).to eql(V["A", "B", "C"])
           end
 
           it "returns a new vector with the mapped values" do
-            vector.send(method, &:downcase).should eql(V["a", "b", "c"])
+            expect(vector.send(method, &:downcase)).to eql(V["a", "b", "c"])
           end
         end
 
         context "with no block" do
           it "returns an Enumerator" do
-            vector.send(method).class.should be(Enumerator)
-            vector.send(method).each(&:downcase).should eql(V['a', 'b', 'c'])
+            expect(vector.send(method).class).to be(Enumerator)
+            expect(vector.send(method).each(&:downcase)).to eql(V['a', 'b', 'c'])
           end
         end
       end
@@ -38,13 +38,13 @@ describe Hamster::Vector do
         it "returns an instance of the subclass" do
           subclass = Class.new(Hamster::Vector)
           instance = subclass[1,2,3]
-          instance.map { |x| x + 1 }.class.should be(subclass)
+          expect(instance.map { |x| x + 1 }.class).to be(subclass)
         end
       end
 
       context "on a large vector" do
         it "works" do
-          V.new(1..2000).map { |x| x * 2 }.should eql(V.new((1..2000).map { |x| x * 2}))
+          expect(V.new(1..2000).map { |x| x * 2 }).to eql(V.new((1..2000).map { |x| x * 2}))
         end
       end
     end

--- a/spec/lib/hamster/vector/maximum_spec.rb
+++ b/spec/lib/hamster/vector/maximum_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::Vector do
       ].each do |values, expected|
         describe "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            V[*values].max { |maximum, item| maximum.length <=> item.length }.should == expected
+            expect(V[*values].max { |maximum, item| maximum.length <=> item.length }).to eq(expected)
           end
         end
       end
@@ -25,7 +25,7 @@ describe Hamster::Vector do
       ].each do |values, expected|
         describe "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            V[*values].max.should == expected
+            expect(V[*values].max).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/vector/minimum_spec.rb
+++ b/spec/lib/hamster/vector/minimum_spec.rb
@@ -11,7 +11,7 @@ describe Hamster::Vector do
       ].each do |values, expected|
         describe "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            V[*values].min { |minimum, item| minimum.length <=> item.length }.should == expected
+            expect(V[*values].min { |minimum, item| minimum.length <=> item.length }).to eq(expected)
           end
         end
       end
@@ -25,7 +25,7 @@ describe Hamster::Vector do
       ].each do |values, expected|
         describe "on #{values.inspect}" do
           it "returns #{expected.inspect}" do
-            V[*values].min.should == expected
+            expect(V[*values].min).to eq(expected)
           end
         end
       end

--- a/spec/lib/hamster/vector/multiply_spec.rb
+++ b/spec/lib/hamster/vector/multiply_spec.rb
@@ -7,25 +7,25 @@ describe Hamster::Vector do
 
     context "with a String argument" do
       it "acts just like #join" do
-        (vector * 'boo').should eql(vector.join('boo'))
+        expect(vector * 'boo').to eql(vector.join('boo'))
       end
     end
 
     context "with an Integer argument" do
       it "concatenates n copies of the array" do
-        (vector * 0).should eql(V.empty)
-        (vector * 1).should eql(vector)
-        (vector * 2).should eql(V[1,2,3,1,2,3])
-        (vector * 3).should eql(V[1,2,3,1,2,3,1,2,3])
+        expect(vector * 0).to eql(V.empty)
+        expect(vector * 1).to eql(vector)
+        expect(vector * 2).to eql(V[1,2,3,1,2,3])
+        expect(vector * 3).to eql(V[1,2,3,1,2,3,1,2,3])
       end
 
       it "raises an ArgumentError if integer is negative" do
-        -> { vector * -1 }.should raise_error(ArgumentError)
+        expect { vector * -1 }.to raise_error(ArgumentError)
       end
 
       it "works on large vectors" do
         array = (1..50).to_a
-        (V.new(array) * 25).should eql(V.new(array * 25))
+        expect(V.new(array) * 25).to eql(V.new(array * 25))
       end
     end
 
@@ -33,16 +33,16 @@ describe Hamster::Vector do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1,2,3])
-        (instance * 10).class.should be(subclass)
+        expect((instance * 10).class).to be(subclass)
       end
     end
 
     it "raises a TypeError if passed nil" do
-      -> { vector * nil }.should raise_error(TypeError)
+      expect { vector * nil }.to raise_error(TypeError)
     end
 
     it "raises an ArgumentError if passed no arguments" do
-      -> { vector.* }.should raise_error(ArgumentError)
+      expect { vector.* }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/lib/hamster/vector/new_spec.rb
+++ b/spec/lib/hamster/vector/new_spec.rb
@@ -5,17 +5,17 @@ describe Hamster::Vector do
   describe ".new" do
     it "accepts a single enumerable argument and creates a new vector" do
       vector = Hamster::Vector.new([1,2,3])
-      vector.size.should be(3)
-      vector[0].should be(1)
-      vector[1].should be(2)
-      vector[2].should be(3)
+      expect(vector.size).to be(3)
+      expect(vector[0]).to be(1)
+      expect(vector[1]).to be(2)
+      expect(vector[2]).to be(3)
     end
 
     it "makes a defensive copy of a non-frozen mutable Array passed in" do
       array = [1,2,3]
       vector = Hamster::Vector.new(array)
       array[0] = 'changed'
-      vector[0].should be(1)
+      expect(vector[0]).to be(1)
     end
 
     it "is amenable to overriding of #initialize" do
@@ -26,16 +26,16 @@ describe Hamster::Vector do
       end
 
       vector = SnazzyVector.new
-      vector.size.should be(1)
-      vector.should == ['SNAZZY!!!']
+      expect(vector.size).to be(1)
+      expect(vector).to eq(['SNAZZY!!!'])
     end
 
     context "from a subclass" do
       it "returns a frozen instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new(["some", "values"])
-        instance.class.should be subclass
-        instance.frozen?.should be true
+        expect(instance.class).to be subclass
+        expect(instance.frozen?).to be true
       end
     end
   end
@@ -43,9 +43,9 @@ describe Hamster::Vector do
   describe ".[]" do
     it "accepts a variable number of items and creates a new vector" do
       vector = Hamster::Vector['a', 'b']
-      vector.size.should be(2)
-      vector[0].should == 'a'
-      vector[1].should == 'b'
+      expect(vector.size).to be(2)
+      expect(vector[0]).to eq('a')
+      expect(vector[1]).to eq('b')
     end
   end
 end

--- a/spec/lib/hamster/vector/partition_spec.rb
+++ b/spec/lib/hamster/vector/partition_spec.rb
@@ -23,28 +23,28 @@ describe Hamster::Vector do
 
           it "preserves the original" do
             result
-            vector.should eql(V[*values])
+            expect(vector).to eql(V[*values])
           end
 
           it "returns a frozen array with two items" do
-            result.class.should be(Array)
-            result.should be_frozen
-            result.size.should be(2)
+            expect(result.class).to be(Array)
+            expect(result).to be_frozen
+            expect(result.size).to be(2)
           end
 
           it "correctly identifies the matches" do
-            matches.should eql(V[*expected_matches])
+            expect(matches).to eql(V[*expected_matches])
           end
 
           it "correctly identifies the remainder" do
-            remainder.should eql(V[*expected_remainder])
+            expect(remainder).to eql(V[*expected_remainder])
           end
         end
 
         describe "without a block" do
           it "returns an Enumerator" do
-            vector.partition.class.should be(Enumerator)
-            vector.partition.each(&:odd?).should eql([V.new(expected_matches), V.new(expected_remainder)])
+            expect(vector.partition.class).to be(Enumerator)
+            expect(vector.partition.each(&:odd?)).to eql([V.new(expected_matches), V.new(expected_remainder)])
           end
         end
       end

--- a/spec/lib/hamster/vector/permutation_spec.rb
+++ b/spec/lib/hamster/vector/permutation_spec.rb
@@ -7,30 +7,30 @@ describe Hamster::Vector do
 
     context "without a block or arguments" do
       it "returns an Enumerator of all permutations" do
-        vector.permutation.class.should be(Enumerator)
-        vector.permutation.to_a.should eql(vector.to_a.permutation.to_a)
+        expect(vector.permutation.class).to be(Enumerator)
+        expect(vector.permutation.to_a).to eql(vector.to_a.permutation.to_a)
       end
     end
 
     context "without a block, but with integral argument" do
       it "returns an Enumerator of all permutations of given length" do
-        vector.permutation(2).class.should be(Enumerator)
-        vector.permutation(2).to_a.should eql(vector.to_a.permutation(2).to_a)
-        vector.permutation(3).class.should be(Enumerator)
-        vector.permutation(3).to_a.should eql(vector.to_a.permutation(3).to_a)
+        expect(vector.permutation(2).class).to be(Enumerator)
+        expect(vector.permutation(2).to_a).to eql(vector.to_a.permutation(2).to_a)
+        expect(vector.permutation(3).class).to be(Enumerator)
+        expect(vector.permutation(3).to_a).to eql(vector.to_a.permutation(3).to_a)
       end
     end
 
     context "with a block" do
       it "returns self" do
-        vector.permutation {}.should be(vector)
+        expect(vector.permutation {}).to be(vector)
       end
 
       context "and no argument" do
         it "yields all permutations" do
           yielded = []
           vector.permutation { |obj| yielded << obj }
-          yielded.sort.should eql([[1,2,3,4], [1,2,4,3], [1,3,2,4], [1,3,4,2],
+          expect(yielded.sort).to eql([[1,2,3,4], [1,2,4,3], [1,3,2,4], [1,3,4,2],
             [1,4,2,3], [1,4,3,2], [2,1,3,4], [2,1,4,3], [2,3,1,4], [2,3,4,1],
             [2,4,1,3], [2,4,3,1], [3,1,2,4], [3,1,4,2], [3,2,1,4], [3,2,4,1],
             [3,4,1,2], [3,4,2,1], [4,1,2,3], [4,1,3,2], [4,2,1,3], [4,2,3,1],
@@ -42,7 +42,7 @@ describe Hamster::Vector do
         it "yields all permutations of the given length" do
           yielded = []
           vector.permutation(2) { |obj| yielded << obj }
-          yielded.sort.should eql([[1,2], [1,3], [1,4], [2,1], [2,3], [2,4], [3,1],
+          expect(yielded.sort).to eql([[1,2], [1,3], [1,4], [2,1], [2,3], [2,4], [3,1],
             [3,2], [3,4], [4,1], [4,2], [4,3]])
         end
       end
@@ -52,7 +52,7 @@ describe Hamster::Vector do
       it "yields the empty permutation" do
         yielded = []
         V.empty.permutation { |obj| yielded << obj }
-        yielded.should eql([[]])
+        expect(yielded).to eql([[]])
       end
     end
 
@@ -60,7 +60,7 @@ describe Hamster::Vector do
       it "yields the empty permutation" do
         yielded = []
         vector.permutation(0) { |obj| yielded << obj }
-        yielded.should eql([[]])
+        expect(yielded).to eql([[]])
       end
     end
 
@@ -71,13 +71,13 @@ describe Hamster::Vector do
     end
 
     it "handles duplicate elements correctly" do
-      V[1,2,3,1].permutation(2).sort.should eql([[1,1], [1,1], [1,2], [1,2],
+      expect(V[1,2,3,1].permutation(2).sort).to eql([[1,1], [1,1], [1,2], [1,2],
         [1,3], [1,3], [2,1],[2,1],[2,3], [3,1],[3,1],[3,2]])
     end
 
     it "leaves the original unmodified" do
       vector.permutation(2) {}
-      vector.should eql(V[1,2,3,4])
+      expect(vector).to eql(V[1,2,3,4])
     end
 
     it "behaves like Array#permutation" do
@@ -85,7 +85,7 @@ describe Hamster::Vector do
         array  = rand(8).times.map { rand(10000) }
         vector = V.new(array)
         perm_size = array.size == 0 ? 0 : rand(array.size)
-        array.permutation(perm_size).to_a.should == vector.permutation(perm_size).to_a
+        expect(array.permutation(perm_size).to_a).to eq(vector.permutation(perm_size).to_a)
       end
     end
   end

--- a/spec/lib/hamster/vector/pop_spec.rb
+++ b/spec/lib/hamster/vector/pop_spec.rb
@@ -15,11 +15,11 @@ describe Hamster::Vector do
 
         it "preserves the original" do
           vector.pop
-          vector.should eql(V[*values])
+          expect(vector).to eql(V[*values])
         end
 
         it "returns #{expected.inspect}" do
-          vector.pop.should eql(V[*expected])
+          expect(vector.pop).to eql(V[*expected])
         end
       end
     end

--- a/spec/lib/hamster/vector/product_spec.rb
+++ b/spec/lib/hamster/vector/product_spec.rb
@@ -10,7 +10,7 @@ describe Hamster::Vector do
           [[2], 2],
           [[1, 3, 5, 7, 11], 1155],
         ].each do |values, expected|
-          V[*values].product.should == expected
+          expect(V[*values].product).to eq(expected)
         end
       end
     end
@@ -22,26 +22,26 @@ describe Hamster::Vector do
         it "yields an array for each combination of items from the vectors" do
           yielded = []
           vector.product(vector) { |obj| yielded << obj }
-          yielded.should eql([[1,1], [1,2], [1,3], [2,1], [2,2], [2,3], [3,1], [3,2], [3,3]])
+          expect(yielded).to eql([[1,1], [1,2], [1,3], [2,1], [2,2], [2,3], [3,1], [3,2], [3,3]])
 
           yielded = []
           vector.product(V[3,4,5], V[6,8]) { |obj| yielded << obj }
-          yielded.should eql(
+          expect(yielded).to eql(
             [[1, 3, 6], [1, 3, 8], [1, 4, 6], [1, 4, 8], [1, 5, 6], [1, 5, 8],
              [2, 3, 6], [2, 3, 8], [2, 4, 6], [2, 4, 8], [2, 5, 6], [2, 5, 8],
              [3, 3, 6], [3, 3, 8], [3, 4, 6], [3, 4, 8], [3, 5, 6], [3, 5, 8]])
         end
 
         it "returns self" do
-          vector.product(V.empty) {}.should be(vector)
-          vector.product(V[1,2], V[3]) {}.should be(vector)
-          V.empty.product(vector) {}.should be(V.empty)
+          expect(vector.product(V.empty) {}).to be(vector)
+          expect(vector.product(V[1,2], V[3]) {}).to be(vector)
+          expect(V.empty.product(vector) {}).to be(V.empty)
         end
       end
 
       context "when not passed a block" do
         it "returns the cartesian product in an array" do
-          V[1,2].product(V[3,4,5], V[6,8]).should eql(
+          expect(V[1,2].product(V[3,4,5], V[6,8])).to eql(
             [[1, 3, 6], [1, 3, 8], [1, 4, 6], [1, 4, 8], [1, 5, 6], [1, 5, 8],
             [2, 3, 6], [2, 3, 8], [2, 4, 6], [2, 4, 8], [2, 5, 6], [2, 5, 8]])
         end
@@ -49,20 +49,20 @@ describe Hamster::Vector do
 
       context "when one of the arguments is empty" do
         it "returns an empty array" do
-          vector.product(V.empty, V[4,5,6]).should eql([])
+          expect(vector.product(V.empty, V[4,5,6])).to eql([])
         end
       end
 
       context "when the receiver is empty" do
         it "returns an empty array" do
-          V.empty.product(vector, V[4,5,6]).should eql([])
+          expect(V.empty.product(vector, V[4,5,6])).to eql([])
         end
       end
     end
 
     context "when passed one or more Arrays" do
       it "also calculates the cartesian product correctly" do
-        V[1,2].product([3,4,5], [6,8]).should eql(
+        expect(V[1,2].product([3,4,5], [6,8])).to eql(
           [[1, 3, 6], [1, 3, 8], [1, 4, 6], [1, 4, 8], [1, 5, 6], [1, 5, 8],
           [2, 3, 6], [2, 3, 8], [2, 4, 6], [2, 4, 8], [2, 5, 6], [2, 5, 8]])
       end

--- a/spec/lib/hamster/vector/put_spec.rb
+++ b/spec/lib/hamster/vector/put_spec.rb
@@ -13,8 +13,8 @@ describe Hamster::Vector do
       end
 
       it "allows indexes 0 and 1 to be put" do
-        vector.put(0, :a).should eql(V[:a])
-        vector.put(1, :a).should eql(V[nil, :a])
+        expect(vector.put(0, :a)).to eql(V[:a])
+        expect(vector.put(1, :a)).to eql(V[nil, :a])
       end
     end
 
@@ -25,31 +25,31 @@ describe Hamster::Vector do
         context "and a positive index" do
           context "within the absolute bounds of the vector" do
             it "passes the current value to the block" do
-              vector.put(1) { |value| value.should == "B" }
+              vector.put(1) { |value| expect(value).to eq("B") }
             end
 
             it "replaces the value with the result of the block" do
               result = vector.put(1) { |value| "FLIBBLE" }
-              result.should eql(V["A", "FLIBBLE", "C"])
+              expect(result).to eql(V["A", "FLIBBLE", "C"])
             end
 
             it "supports to_proc methods" do
               result = vector.put(1, &:downcase)
-              result.should eql(V["A", "b", "C"])
+              expect(result).to eql(V["A", "b", "C"])
             end
           end
 
           context "just past the end of the vector" do
             it "passes nil to the block and adds a new value" do
-              result = vector.put(3) { |value| value.should be_nil; "D" }
-              result.should eql(V["A", "B", "C", "D"])
+              result = vector.put(3) { |value| expect(value).to be_nil; "D" }
+              expect(result).to eql(V["A", "B", "C", "D"])
             end
           end
 
           context "further outside the bounds of the vector" do
             it "passes nil to the block, fills up missing nils, and adds a new value" do
-              result = vector.put(5) { |value| value.should be_nil; "D" }
-              result.should eql(V["A", "B", "C", nil, nil, "D"])
+              result = vector.put(5) { |value| expect(value).to be_nil; "D" }
+              expect(result).to eql(V["A", "B", "C", nil, nil, "D"])
             end
           end
         end
@@ -57,17 +57,17 @@ describe Hamster::Vector do
         context "and a negative index" do
           context "within the absolute bounds of the vector" do
             it "passes the current value to the block" do
-              vector.put(-2) { |value| value.should == "B" }
+              vector.put(-2) { |value| expect(value).to eq("B") }
             end
 
             it "replaces the value with the result of the block" do
               result = vector.put(-2) { |value| "FLIBBLE" }
-              result.should eql(V["A", "FLIBBLE", "C"])
+              expect(result).to eql(V["A", "FLIBBLE", "C"])
             end
 
             it "supports to_proc methods" do
               result = vector.put(-2, &:downcase)
-              result.should eql(V["A", "b", "C"])
+              expect(result).to eql(V["A", "b", "C"])
             end
           end
 
@@ -85,25 +85,25 @@ describe Hamster::Vector do
             let(:put) { vector.put(1, "FLIBBLE") }
 
             it "preserves the original" do
-              vector.should eql(V["A", "B", "C"])
+              expect(vector).to eql(V["A", "B", "C"])
             end
 
             it "puts the new value at the specified index" do
-              put.should eql(V["A", "FLIBBLE", "C"])
+              expect(put).to eql(V["A", "FLIBBLE", "C"])
             end
           end
 
           context "just past the end of the vector" do
             it "adds a new value" do
               result = vector.put(3, "FLIBBLE")
-              result.should eql(V["A", "B", "C", "FLIBBLE"])
+              expect(result).to eql(V["A", "B", "C", "FLIBBLE"])
             end
           end
 
           context "outside the absolute bounds of the vector" do
             it "fills up with nils" do
               result = vector.put(5, "FLIBBLE")
-              result.should eql(V["A", "B", "C", nil, nil, "FLIBBLE"])
+              expect(result).to eql(V["A", "B", "C", nil, nil, "FLIBBLE"])
             end
           end
         end
@@ -113,11 +113,11 @@ describe Hamster::Vector do
 
           it "preserves the original" do
             put
-            vector.should eql(V["A", "B", "C"])
+            expect(vector).to eql(V["A", "B", "C"])
           end
 
           it "puts the new value at the specified index" do
-            put.should eql(V["A", "FLIBBLE", "C"])
+            expect(put).to eql(V["A", "FLIBBLE", "C"])
           end
         end
 
@@ -133,7 +133,7 @@ describe Hamster::Vector do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass[1,2,3]
-        instance.put(1, 2.5).class.should be(subclass)
+        expect(instance.put(1, 2.5).class).to be(subclass)
       end
     end
 
@@ -147,11 +147,11 @@ describe Hamster::Vector do
             value = rand(10000)
             array[i] = value
             vector = vector.put(i, value)
-            vector[i].should be(value)
+            expect(vector[i]).to be(value)
           end
 
           0.upto(size-1) do |i|
-            vector.get(i).should == array[i]
+            expect(vector.get(i)).to eq(array[i])
           end
         end
       end
@@ -165,7 +165,7 @@ describe Hamster::Vector do
 
           it "returns self" do
             (0...size).each do |index|
-              vector.put(index, index * index).should equal(vector)
+              expect(vector.put(index, index * index)).to equal(vector)
             end
           end
         end

--- a/spec/lib/hamster/vector/reduce_spec.rb
+++ b/spec/lib/hamster/vector/reduce_spec.rb
@@ -15,7 +15,7 @@ describe Hamster::Vector do
           describe "with an initial value of #{initial}" do
             describe "and a block" do
               it "returns #{expected.inspect}" do
-                vector.send(method, initial) { |memo, item| memo - item }.should == expected
+                expect(vector.send(method, initial) { |memo, item| memo - item }).to eq(expected)
               end
             end
           end
@@ -33,7 +33,7 @@ describe Hamster::Vector do
           describe "with no initial value" do
             describe "and a block" do
               it "returns #{expected.inspect}" do
-                vector.send(method) { |memo, item| memo - item }.should == expected
+                expect(vector.send(method) { |memo, item| memo - item }).to eq(expected)
               end
             end
           end
@@ -42,13 +42,13 @@ describe Hamster::Vector do
 
       describe "with no block and a symbol argument" do
         it "uses the symbol as the name of a method to reduce with" do
-          V[1, 2, 3].send(method, :+).should == 6
+          expect(V[1, 2, 3].send(method, :+)).to eq(6)
         end
       end
 
       describe "with no block and a string argument" do
         it "uses the string as the name of a method to reduce with" do
-          V[1, 2, 3].send(method, '+').should == 6
+          expect(V[1, 2, 3].send(method, '+')).to eq(6)
         end
       end
     end

--- a/spec/lib/hamster/vector/reject_spec.rb
+++ b/spec/lib/hamster/vector/reject_spec.rb
@@ -16,14 +16,14 @@ describe Hamster::Vector do
 
           context "with a block" do
             it "returns #{expected.inspect}" do
-              vector.send(method) { |item| item == item.downcase }.should eql(V[*expected])
+              expect(vector.send(method) { |item| item == item.downcase }).to eql(V[*expected])
             end
           end
 
           context "without a block" do
             it "returns an Enumerator" do
-              vector.send(method).class.should be(Enumerator)
-              vector.send(method).each { |item| item == item.downcase }.should eql(V[*expected])
+              expect(vector.send(method).class).to be(Enumerator)
+              expect(vector.send(method).each { |item| item == item.downcase }).to eql(V[*expected])
             end
           end
         end
@@ -34,8 +34,8 @@ describe Hamster::Vector do
           [0, 5, 32, 50, 500, 800, 1024].each do |threshold|
             vector = V.new(1..size)
             result = vector.send(method) { |item| item > threshold }
-            result.size.should == [size, threshold].min
-            result.should eql(V.new(1..[size, threshold].min))
+            expect(result.size).to eq([size, threshold].min)
+            expect(result).to eql(V.new(1..[size, threshold].min))
           end
         end
       end

--- a/spec/lib/hamster/vector/repeated_combination_spec.rb
+++ b/spec/lib/hamster/vector/repeated_combination_spec.rb
@@ -7,21 +7,21 @@ describe Hamster::Vector do
 
     context "with no block" do
       it "returns an Enumerator" do
-        vector.repeated_combination(2).class.should be(Enumerator)
+        expect(vector.repeated_combination(2).class).to be(Enumerator)
       end
     end
 
     context "with a block" do
       it "returns self" do
-        vector.repeated_combination(2) {}.should be(vector)
+        expect(vector.repeated_combination(2) {}).to be(vector)
       end
     end
 
     context "with a negative argument" do
       it "yields nothing and returns self" do
         result = []
-        vector.repeated_combination(-1) { |obj| result << obj }.should be(vector)
-        result.should eql([])
+        expect(vector.repeated_combination(-1) { |obj| result << obj }).to be(vector)
+        expect(result).to eql([])
       end
     end
 
@@ -29,7 +29,7 @@ describe Hamster::Vector do
       it "yields an empty array" do
         result = []
         vector.repeated_combination(0) { |obj| result << obj }
-        result.should eql([[]])
+        expect(result).to eql([[]])
       end
     end
 
@@ -37,7 +37,7 @@ describe Hamster::Vector do
       it "yields each item in the vector, as single-item vectors" do
         result = []
         vector.repeated_combination(1) { |obj| result << obj }
-        result.should eql([[1],[2],[3],[4]])
+        expect(result).to eql([[1],[2],[3],[4]])
       end
     end
 
@@ -45,34 +45,34 @@ describe Hamster::Vector do
       it "yields nothing" do
         result = []
         V.empty.repeated_combination(1) { |obj| result << obj }
-        result.should eql([])
+        expect(result).to eql([])
       end
     end
 
     context "with a positive argument, greater than 1" do
       it "yields all combinations of the given size (where a single element can appear more than once in a row)" do
-        vector.repeated_combination(2).to_a.should == [[1,1], [1,2], [1,3], [1,4], [2,2], [2,3], [2,4], [3,3], [3,4], [4,4]]
-        vector.repeated_combination(3).to_a.should == [[1,1,1], [1,1,2], [1,1,3], [1,1,4],
+        expect(vector.repeated_combination(2).to_a).to eq([[1,1], [1,2], [1,3], [1,4], [2,2], [2,3], [2,4], [3,3], [3,4], [4,4]])
+        expect(vector.repeated_combination(3).to_a).to eq([[1,1,1], [1,1,2], [1,1,3], [1,1,4],
           [1,2,2], [1,2,3], [1,2,4], [1,3,3], [1,3,4], [1,4,4], [2,2,2], [2,2,3],
-          [2,2,4], [2,3,3], [2,3,4], [2,4,4], [3,3,3], [3,3,4], [3,4,4], [4,4,4]]
-        V[1,2,3].repeated_combination(3).to_a.should == [[1,1,1], [1,1,2],
-          [1,1,3], [1,2,2], [1,2,3], [1,3,3], [2,2,2], [2,2,3], [2,3,3], [3,3,3]]
+          [2,2,4], [2,3,3], [2,3,4], [2,4,4], [3,3,3], [3,3,4], [3,4,4], [4,4,4]])
+        expect(V[1,2,3].repeated_combination(3).to_a).to eq([[1,1,1], [1,1,2],
+          [1,1,3], [1,2,2], [1,2,3], [1,3,3], [2,2,2], [2,2,3], [2,3,3], [3,3,3]])
       end
     end
 
     it "leaves the original unmodified" do
       vector.repeated_combination(2) {}
-      vector.should eql(V[1,2,3,4])
+      expect(vector).to eql(V[1,2,3,4])
     end
 
     it "behaves like Array#repeated_combination" do
       0.upto(5) do |comb_size|
         array = 10.times.map { rand(1000) }
-        V.new(array).repeated_combination(comb_size).to_a.should == array.repeated_combination(comb_size).to_a
+        expect(V.new(array).repeated_combination(comb_size).to_a).to eq(array.repeated_combination(comb_size).to_a)
       end
 
       array = 18.times.map { rand(1000) }
-      V.new(array).repeated_combination(2).to_a.should == array.repeated_combination(2).to_a
+      expect(V.new(array).repeated_combination(2).to_a).to eq(array.repeated_combination(2).to_a)
     end
   end
 end

--- a/spec/lib/hamster/vector/repeated_permutation_spec.rb
+++ b/spec/lib/hamster/vector/repeated_permutation_spec.rb
@@ -8,31 +8,31 @@ describe Hamster::Vector do
     context "without a block" do
       context "and without argument" do
         it "returns an Enumerator of all repeated permutations" do
-          vector.repeated_permutation.class.should be(Enumerator)
-          vector.repeated_permutation.to_a.sort.should eql(vector.to_a.repeated_permutation(4).to_a.sort)
+          expect(vector.repeated_permutation.class).to be(Enumerator)
+          expect(vector.repeated_permutation.to_a.sort).to eql(vector.to_a.repeated_permutation(4).to_a.sort)
         end
       end
 
       context "with an integral argument" do
         it "returns an Enumerator of all repeated permutations of the given length" do
-          vector.repeated_permutation(2).class.should be(Enumerator)
-          vector.repeated_permutation(2).to_a.sort.should eql(vector.to_a.repeated_permutation(2).to_a.sort)
-          vector.repeated_permutation(3).class.should be(Enumerator)
-          vector.repeated_permutation(3).to_a.sort.should eql(vector.to_a.repeated_permutation(3).to_a.sort)
+          expect(vector.repeated_permutation(2).class).to be(Enumerator)
+          expect(vector.repeated_permutation(2).to_a.sort).to eql(vector.to_a.repeated_permutation(2).to_a.sort)
+          expect(vector.repeated_permutation(3).class).to be(Enumerator)
+          expect(vector.repeated_permutation(3).to_a.sort).to eql(vector.to_a.repeated_permutation(3).to_a.sort)
         end
       end
     end
 
     context "with a block" do
       it "returns self" do
-        vector.repeated_permutation {}.should be(vector)
+        expect(vector.repeated_permutation {}).to be(vector)
       end
 
       context "on an empty vector" do
         it "yields the empty permutation" do
           yielded = []
           V.empty.repeated_permutation { |obj| yielded << obj }
-          yielded.should eql([[]])
+          expect(yielded).to eql([[]])
         end
       end
 
@@ -40,7 +40,7 @@ describe Hamster::Vector do
         it "yields the empty permutation" do
           yielded = []
           vector.repeated_permutation(0) { |obj| yielded << obj }
-          yielded.should eql([[]])
+          expect(yielded).to eql([[]])
         end
       end
 
@@ -48,7 +48,7 @@ describe Hamster::Vector do
         it "yields all repeated permutations" do
           yielded = []
           V[1,2,3].repeated_permutation { |obj| yielded << obj }
-          yielded.sort.should eql([[1,1,1], [1,1,2], [1,1,3], [1,2,1], [1,2,2],
+          expect(yielded.sort).to eql([[1,1,1], [1,1,2], [1,1,3], [1,2,1], [1,2,2],
             [1,2,3], [1,3,1], [1,3,2], [1,3,3], [2,1,1], [2,1,2], [2,1,3], [2,2,1],
             [2,2,2], [2,2,3], [2,3,1], [2,3,2], [2,3,3], [3,1,1], [3,1,2], [3,1,3],
             [3,2,1], [3,2,2], [3,2,3], [3,3,1], [3,3,2], [3,3,3]])
@@ -59,19 +59,19 @@ describe Hamster::Vector do
         it "yields all repeated permutations of the given length" do
           yielded = []
           vector.repeated_permutation(2) { |obj| yielded << obj }
-          yielded.sort.should eql([[1,1], [1,2], [1,3], [1,4], [2,1], [2,2], [2,3], [2,4],
+          expect(yielded.sort).to eql([[1,1], [1,2], [1,3], [1,4], [2,1], [2,2], [2,3], [2,4],
             [3,1], [3,2], [3,3], [3,4], [4,1], [4,2], [4,3], [4,4]])
         end
       end
     end
 
     it "handles duplicate elements correctly" do
-    V[10,11,10].repeated_permutation(2).sort.should eql([[10, 10], [10, 10],
+    expect(V[10,11,10].repeated_permutation(2).sort).to eql([[10, 10], [10, 10],
       [10, 10], [10, 10], [10, 11], [10, 11], [11, 10], [11, 10], [11, 11]])
     end
 
     it "allows permutations larger than the number of elements" do
-      V[1,2].repeated_permutation(3).sort.should eql(
+      expect(V[1,2].repeated_permutation(3).sort).to eql(
         [[1, 1, 1], [1, 1, 2], [1, 2, 1],
          [1, 2, 2], [2, 1, 1], [2, 1, 2],
          [2, 2, 1], [2, 2, 2]])
@@ -79,7 +79,7 @@ describe Hamster::Vector do
 
     it "leaves the original unmodified" do
       vector.repeated_permutation(2) {}
-      vector.should eql(V[1,2,3,4])
+      expect(vector).to eql(V[1,2,3,4])
     end
 
     it "behaves like Array#repeated_permutation" do
@@ -87,7 +87,7 @@ describe Hamster::Vector do
         array  = rand(8).times.map { rand(10000) }
         vector = V.new(array)
         perm_size = array.size == 0 ? 0 : rand(array.size)
-        array.repeated_permutation(perm_size).to_a.should == vector.repeated_permutation(perm_size).to_a
+        expect(array.repeated_permutation(perm_size).to_a).to eq(vector.repeated_permutation(perm_size).to_a)
       end
     end
   end

--- a/spec/lib/hamster/vector/reverse_each_spec.rb
+++ b/spec/lib/hamster/vector/reverse_each_spec.rb
@@ -9,21 +9,21 @@ describe Hamster::Vector do
 
         context "with a block (internal iteration)" do
           it "returns self" do
-            vector.reverse_each {}.should be(vector)
+            expect(vector.reverse_each {}).to be(vector)
           end
 
           it "yields all items in the opposite order as #each" do
             result = []
             vector.reverse_each { |item| result << item }
-            result.should eql(vector.to_a.reverse)
+            expect(result).to eql(vector.to_a.reverse)
           end
         end
 
         context "with no block" do
           it "returns an Enumerator" do
             result = vector.reverse_each
-            result.class.should be(Enumerator)
-            result.to_a.should eql(vector.to_a.reverse)
+            expect(result.class).to be(Enumerator)
+            expect(result.to_a).to eql(vector.to_a.reverse)
           end
         end
       end

--- a/spec/lib/hamster/vector/reverse_spec.rb
+++ b/spec/lib/hamster/vector/reverse_spec.rb
@@ -14,7 +14,7 @@ describe Hamster::Vector do
     ].each do |initial, expected|
       describe "on #{initial}" do
         it "returns #{expected}" do
-          V.new(initial).reverse.should eql(V.new(expected))
+          expect(V.new(initial).reverse).to eql(V.new(expected))
         end
       end
     end

--- a/spec/lib/hamster/vector/rindex_spec.rb
+++ b/spec/lib/hamster/vector/rindex_spec.rb
@@ -7,30 +7,30 @@ describe Hamster::Vector do
 
     context "when passed an object present in the vector" do
       it "returns the last index where the object is present" do
-        vector.rindex(1).should be(5)
-        vector.rindex(2).should be(4)
-        vector.rindex(3).should be(3)
+        expect(vector.rindex(1)).to be(5)
+        expect(vector.rindex(2)).to be(4)
+        expect(vector.rindex(3)).to be(3)
       end
     end
 
     context "when passed an object not present in the vector" do
       it "returns nil" do
-        vector.rindex(0).should be_nil
-        vector.rindex(nil).should be_nil
-        vector.rindex('string').should be_nil
+        expect(vector.rindex(0)).to be_nil
+        expect(vector.rindex(nil)).to be_nil
+        expect(vector.rindex('string')).to be_nil
       end
     end
 
     context "with a block" do
       it "returns the last index of an object which the predicate is true for" do
-        vector.rindex { |n| n > 2 }.should be(3)
+        expect(vector.rindex { |n| n > 2 }).to be(3)
       end
     end
 
     context "without an argument OR block" do
       it "returns an Enumerator" do
-        vector.rindex.class.should be(Enumerator)
-        vector.rindex.each { |n| n > 2 }.should be(3)
+        expect(vector.rindex.class).to be(Enumerator)
+        expect(vector.rindex.each { |n| n > 2 }).to be(3)
       end
     end
   end

--- a/spec/lib/hamster/vector/rotate_spec.rb
+++ b/spec/lib/hamster/vector/rotate_spec.rb
@@ -7,41 +7,41 @@ describe Hamster::Vector do
 
     context "when passed no argument" do
       it "returns a new vector with the first element moved to the end" do
-        vector.rotate.should eql(V[2,3,4,5,1])
+        expect(vector.rotate).to eql(V[2,3,4,5,1])
       end
     end
 
     context "with an integral argument n" do
       it "returns a new vector with the first (n % size) elements moved to the end" do
-        vector.rotate(2).should eql(V[3,4,5,1,2])
-        vector.rotate(3).should eql(V[4,5,1,2,3])
-        vector.rotate(4).should eql(V[5,1,2,3,4])
-        vector.rotate(5).should eql(V[1,2,3,4,5])
-        vector.rotate(-1).should eql(V[5,1,2,3,4])
+        expect(vector.rotate(2)).to eql(V[3,4,5,1,2])
+        expect(vector.rotate(3)).to eql(V[4,5,1,2,3])
+        expect(vector.rotate(4)).to eql(V[5,1,2,3,4])
+        expect(vector.rotate(5)).to eql(V[1,2,3,4,5])
+        expect(vector.rotate(-1)).to eql(V[5,1,2,3,4])
       end
     end
 
     context "with a floating-point argument n" do
       it "coerces the argument to integer using to_int" do
-        vector.rotate(2.1).should eql(V[3,4,5,1,2])
+        expect(vector.rotate(2.1)).to eql(V[3,4,5,1,2])
       end
     end
 
     context "with a non-numeric argument" do
       it "raises a TypeError" do
-        -> { vector.rotate('hello') }.should raise_error(TypeError)
+        expect { vector.rotate('hello') }.to raise_error(TypeError)
       end
     end
 
     context "with an argument of zero" do
       it "returns self" do
-        vector.rotate(0).should be(vector)
+        expect(vector.rotate(0)).to be(vector)
       end
     end
 
     context "with an argument equal to the vector's size" do
       it "returns self" do
-        vector.rotate(5).should be(vector)
+        expect(vector.rotate(5)).to be(vector)
       end
     end
 
@@ -52,7 +52,7 @@ describe Hamster::Vector do
           vector = V.new(array)
           10.times do
             offset = rand(size)
-            vector.rotate(offset).should == array.rotate(offset)
+            expect(vector.rotate(offset)).to eq(array.rotate(offset))
           end
         end
       end
@@ -62,13 +62,13 @@ describe Hamster::Vector do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1,2,3])
-        instance.rotate(2).class.should be(subclass)
+        expect(instance.rotate(2).class).to be(subclass)
       end
     end
 
     it "leaves the original unmodified" do
       vector.rotate(3)
-      vector.should eql(V[1,2,3,4,5])
+      expect(vector).to eql(V[1,2,3,4,5])
     end
   end
 end

--- a/spec/lib/hamster/vector/sample_spec.rb
+++ b/spec/lib/hamster/vector/sample_spec.rb
@@ -7,8 +7,8 @@ describe Hamster::Vector do
 
     it "returns a randomly chosen item" do
       chosen = 100.times.map { vector.sample }
-      chosen.each { |item| vector.include?(item).should == true }
-      vector.each { |item| chosen.include?(item).should == true }
+      chosen.each { |item| expect(vector.include?(item)).to eq(true) }
+      vector.each { |item| expect(chosen.include?(item)).to eq(true) }
     end
   end
 end

--- a/spec/lib/hamster/vector/select_spec.rb
+++ b/spec/lib/hamster/vector/select_spec.rb
@@ -9,35 +9,35 @@ describe Hamster::Vector do
       describe "with a block" do
         it "preserves the original" do
           vector.send(method) { |item| item == "A" }
-          vector.should eql(V["A", "B", "C"])
+          expect(vector).to eql(V["A", "B", "C"])
         end
 
         it "returns a vector with the matching values" do
-          vector.send(method) { |item| item == "A" }.should eql(V["A"])
+          expect(vector.send(method) { |item| item == "A" }).to eql(V["A"])
         end
       end
 
       describe "with no block" do
         it "returns an Enumerator" do
-          vector.send(method).class.should be(Enumerator)
-          vector.send(method).each { |item| item == "A" }.should eql(V["A"])
+          expect(vector.send(method).class).to be(Enumerator)
+          expect(vector.send(method).each { |item| item == "A" }).to eql(V["A"])
         end
       end
 
       describe "when nothing matches" do
         it "preserves the original" do
           vector.send(method) { |item| false }
-          vector.should eql(V["A", "B", "C"])
+          expect(vector).to eql(V["A", "B", "C"])
         end
 
         it "returns an empty vector" do
-          vector.send(method) { |item| false }.should equal(V.empty)
+          expect(vector.send(method) { |item| false }).to equal(V.empty)
         end
       end
 
       context "on an empty vector" do
         it "returns self" do
-          V.empty.send(method) { |item| true }.should be(V.empty)
+          expect(V.empty.send(method) { |item| true }).to be(V.empty)
         end
       end
 
@@ -45,7 +45,7 @@ describe Hamster::Vector do
         it "returns an instance of the subclass" do
           subclass = Class.new(Hamster::Vector)
           instance = subclass[1,2,3]
-          instance.send(method) { |x| x > 1 }.class.should be(subclass)
+          expect(instance.send(method) { |x| x > 1 }.class).to be(subclass)
         end
       end
 
@@ -54,8 +54,8 @@ describe Hamster::Vector do
           [0, 5, 32, 50, 500, 800, 1024].each do |threshold|
             vector = V.new(1..size)
             result = vector.send(method) { |item| item <= threshold }
-            result.size.should == [size, threshold].min
-            result.should eql(V.new(1..[size, threshold].min))
+            expect(result.size).to eq([size, threshold].min)
+            expect(result).to eql(V.new(1..[size, threshold].min))
           end
         end
       end

--- a/spec/lib/hamster/vector/set_spec.rb
+++ b/spec/lib/hamster/vector/set_spec.rb
@@ -12,14 +12,14 @@ describe Hamster::Vector do
     context "without block" do
       it "replaces the element" do
         result = vector.set(1, 100)
-        result.should eql(V[5, 100, 7])
+        expect(result).to eql(V[5, 100, 7])
       end
     end
 
     context "with block" do
       it "passes the existing element to the block and replaces the result" do
         result = vector.set(1) { |e| e + 100 }
-        result.should eql(V[5, 106, 7])
+        expect(result).to eql(V[5, 106, 7])
       end
     end
   end

--- a/spec/lib/hamster/vector/shift_spec.rb
+++ b/spec/lib/hamster/vector/shift_spec.rb
@@ -16,11 +16,11 @@ describe Hamster::Vector do
 
         it "preserves the original" do
           vector.shift
-          vector.should eql(V[*values])
+          expect(vector).to eql(V[*values])
         end
 
         it "returns #{expected.inspect}" do
-          vector.shift.should eql(V[*expected])
+          expect(vector.shift).to eql(V[*expected])
         end
       end
     end

--- a/spec/lib/hamster/vector/shuffle_spec.rb
+++ b/spec/lib/hamster/vector/shuffle_spec.rb
@@ -9,22 +9,22 @@ describe Hamster::Vector do
       different = false
       10.times do
         shuffled = vector.shuffle
-        shuffled.sort.should eql(vector)
+        expect(shuffled.sort).to eql(vector)
         different ||= (shuffled != vector)
       end
-      different.should be(true)
+      expect(different).to be(true)
     end
 
     it "leaves the original unchanged" do
       vector.shuffle
-      vector.should eql(V[1,2,3,4])
+      expect(vector).to eql(V[1,2,3,4])
     end
 
     context "from a subclass" do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1,2,3])
-        instance.shuffle.class.should be(subclass)
+        expect(instance.shuffle.class).to be(subclass)
       end
     end
 
@@ -34,9 +34,9 @@ describe Hamster::Vector do
           vector = V.new(1..size)
           shuffled = vector.shuffle
           shuffled = vector.shuffle while shuffled.eql?(vector) # in case we get the same
-          vector.should eql(V.new(1..size))
-          shuffled.size.should == vector.size
-          shuffled.sort.should eql(vector)
+          expect(vector).to eql(V.new(1..size))
+          expect(shuffled.size).to eq(vector.size)
+          expect(shuffled.sort).to eql(vector)
         end
       end
     end

--- a/spec/lib/hamster/vector/slice_spec.rb
+++ b/spec/lib/hamster/vector/slice_spec.rb
@@ -9,212 +9,212 @@ describe Hamster::Vector do
     describe "##{method}" do
       context "when passed a positive integral index" do
         it "returns the element at that index" do
-          vector.send(method, 0).should be(1)
-          vector.send(method, 1).should be(2)
-          vector.send(method, 2).should be(3)
-          vector.send(method, 3).should be(4)
-          vector.send(method, 4).should be(nil)
-          vector.send(method, 10).should be(nil)
+          expect(vector.send(method, 0)).to be(1)
+          expect(vector.send(method, 1)).to be(2)
+          expect(vector.send(method, 2)).to be(3)
+          expect(vector.send(method, 3)).to be(4)
+          expect(vector.send(method, 4)).to be(nil)
+          expect(vector.send(method, 10)).to be(nil)
 
-          big.send(method, 0).should be(1)
-          big.send(method, 9999).should be(10000)
+          expect(big.send(method, 0)).to be(1)
+          expect(big.send(method, 9999)).to be(10000)
         end
 
         it "leaves the original unchanged" do
-          vector.should eql(V[1,2,3,4])
+          expect(vector).to eql(V[1,2,3,4])
         end
       end
 
       context "when passed a negative integral index" do
         it "returns the element which is number (index.abs) counting from the end of the vector" do
-          vector.send(method, -1).should be(4)
-          vector.send(method, -2).should be(3)
-          vector.send(method, -3).should be(2)
-          vector.send(method, -4).should be(1)
-          vector.send(method, -5).should be(nil)
-          vector.send(method, -10).should be(nil)
+          expect(vector.send(method, -1)).to be(4)
+          expect(vector.send(method, -2)).to be(3)
+          expect(vector.send(method, -3)).to be(2)
+          expect(vector.send(method, -4)).to be(1)
+          expect(vector.send(method, -5)).to be(nil)
+          expect(vector.send(method, -10)).to be(nil)
 
-          big.send(method, -1).should be(10000)
-          big.send(method, -10000).should be(1)
+          expect(big.send(method, -1)).to be(10000)
+          expect(big.send(method, -10000)).to be(1)
         end
       end
 
       context "when passed a positive integral index and count" do
         it "returns 'count' elements starting from 'index'" do
-          vector.send(method, 0, 0).should  eql(V.empty)
-          vector.send(method, 0, 1).should  eql(V[1])
-          vector.send(method, 0, 2).should  eql(V[1,2])
-          vector.send(method, 0, 4).should  eql(V[1,2,3,4])
-          vector.send(method, 0, 6).should  eql(V[1,2,3,4])
-          vector.send(method, 0, -1).should be_nil
-          vector.send(method, 0, -2).should be_nil
-          vector.send(method, 0, -4).should be_nil
-          vector.send(method, 2, 0).should  eql(V.empty)
-          vector.send(method, 2, 1).should  eql(V[3])
-          vector.send(method, 2, 2).should  eql(V[3,4])
-          vector.send(method, 2, 4).should  eql(V[3,4])
-          vector.send(method, 2, -1).should be_nil
-          vector.send(method, 4, 0).should  eql(V.empty)
-          vector.send(method, 4, 2).should  eql(V.empty)
-          vector.send(method, 4, -1).should be_nil
-          vector.send(method, 5, 0).should  be_nil
-          vector.send(method, 5, 2).should  be_nil
-          vector.send(method, 5, -1).should be_nil
-          vector.send(method, 6, 0).should  be_nil
-          vector.send(method, 6, 2).should  be_nil
-          vector.send(method, 6, -1).should be_nil
+          expect(vector.send(method, 0, 0)).to  eql(V.empty)
+          expect(vector.send(method, 0, 1)).to  eql(V[1])
+          expect(vector.send(method, 0, 2)).to  eql(V[1,2])
+          expect(vector.send(method, 0, 4)).to  eql(V[1,2,3,4])
+          expect(vector.send(method, 0, 6)).to  eql(V[1,2,3,4])
+          expect(vector.send(method, 0, -1)).to be_nil
+          expect(vector.send(method, 0, -2)).to be_nil
+          expect(vector.send(method, 0, -4)).to be_nil
+          expect(vector.send(method, 2, 0)).to  eql(V.empty)
+          expect(vector.send(method, 2, 1)).to  eql(V[3])
+          expect(vector.send(method, 2, 2)).to  eql(V[3,4])
+          expect(vector.send(method, 2, 4)).to  eql(V[3,4])
+          expect(vector.send(method, 2, -1)).to be_nil
+          expect(vector.send(method, 4, 0)).to  eql(V.empty)
+          expect(vector.send(method, 4, 2)).to  eql(V.empty)
+          expect(vector.send(method, 4, -1)).to be_nil
+          expect(vector.send(method, 5, 0)).to  be_nil
+          expect(vector.send(method, 5, 2)).to  be_nil
+          expect(vector.send(method, 5, -1)).to be_nil
+          expect(vector.send(method, 6, 0)).to  be_nil
+          expect(vector.send(method, 6, 2)).to  be_nil
+          expect(vector.send(method, 6, -1)).to be_nil
 
-          big.send(method, 0, 3).should    eql(V[1,2,3])
-          big.send(method, 1023, 4).should eql(V[1024,1025,1026,1027])
-          big.send(method, 1024, 4).should eql(V[1025,1026,1027,1028])
+          expect(big.send(method, 0, 3)).to    eql(V[1,2,3])
+          expect(big.send(method, 1023, 4)).to eql(V[1024,1025,1026,1027])
+          expect(big.send(method, 1024, 4)).to eql(V[1025,1026,1027,1028])
         end
 
         it "leaves the original unchanged" do
-          vector.should eql(V[1,2,3,4])
+          expect(vector).to eql(V[1,2,3,4])
         end
       end
 
       context "when passed a negative integral index and count" do
         it "returns 'count' elements, starting from index which is number 'index.abs' counting from the end of the array" do
-          vector.send(method, -1, 0).should  eql(V.empty)
-          vector.send(method, -1, 1).should  eql(V[4])
-          vector.send(method, -1, 2).should  eql(V[4])
-          vector.send(method, -1, -1).should be_nil
-          vector.send(method, -2, 0).should  eql(V.empty)
-          vector.send(method, -2, 1).should  eql(V[3])
-          vector.send(method, -2, 2).should  eql(V[3,4])
-          vector.send(method, -2, 4).should  eql(V[3,4])
-          vector.send(method, -2, -1).should be_nil
-          vector.send(method, -4, 0).should  eql(V.empty)
-          vector.send(method, -4, 1).should  eql(V[1])
-          vector.send(method, -4, 2).should  eql(V[1,2])
-          vector.send(method, -4, 4).should  eql(V[1,2,3,4])
-          vector.send(method, -4, 6).should  eql(V[1,2,3,4])
-          vector.send(method, -4, -1).should be_nil
-          vector.send(method, -5, 0).should  be_nil
-          vector.send(method, -5, 1).should  be_nil
-          vector.send(method, -5, 10).should be_nil
-          vector.send(method, -5, -1).should be_nil
+          expect(vector.send(method, -1, 0)).to  eql(V.empty)
+          expect(vector.send(method, -1, 1)).to  eql(V[4])
+          expect(vector.send(method, -1, 2)).to  eql(V[4])
+          expect(vector.send(method, -1, -1)).to be_nil
+          expect(vector.send(method, -2, 0)).to  eql(V.empty)
+          expect(vector.send(method, -2, 1)).to  eql(V[3])
+          expect(vector.send(method, -2, 2)).to  eql(V[3,4])
+          expect(vector.send(method, -2, 4)).to  eql(V[3,4])
+          expect(vector.send(method, -2, -1)).to be_nil
+          expect(vector.send(method, -4, 0)).to  eql(V.empty)
+          expect(vector.send(method, -4, 1)).to  eql(V[1])
+          expect(vector.send(method, -4, 2)).to  eql(V[1,2])
+          expect(vector.send(method, -4, 4)).to  eql(V[1,2,3,4])
+          expect(vector.send(method, -4, 6)).to  eql(V[1,2,3,4])
+          expect(vector.send(method, -4, -1)).to be_nil
+          expect(vector.send(method, -5, 0)).to  be_nil
+          expect(vector.send(method, -5, 1)).to  be_nil
+          expect(vector.send(method, -5, 10)).to be_nil
+          expect(vector.send(method, -5, -1)).to be_nil
 
-          big.send(method, -1, 1).should eql(V[10000])
-          big.send(method, -1, 2).should eql(V[10000])
-          big.send(method, -6, 2).should eql(V[9995,9996])
+          expect(big.send(method, -1, 1)).to eql(V[10000])
+          expect(big.send(method, -1, 2)).to eql(V[10000])
+          expect(big.send(method, -6, 2)).to eql(V[9995,9996])
         end
       end
 
       context "when passed a Range" do
         it "returns the elements whose indexes are within the given Range" do
-          vector.send(method, 0..-1).should  eql(V[1,2,3,4])
-          vector.send(method, 0..-10).should eql(V.empty)
-          vector.send(method, 0..0).should   eql(V[1])
-          vector.send(method, 0..1).should   eql(V[1,2])
-          vector.send(method, 0..2).should   eql(V[1,2,3])
-          vector.send(method, 0..3).should   eql(V[1,2,3,4])
-          vector.send(method, 0..4).should   eql(V[1,2,3,4])
-          vector.send(method, 0..10).should  eql(V[1,2,3,4])
-          vector.send(method, 2..-10).should eql(V.empty)
-          vector.send(method, 2..0).should   eql(V.empty)
-          vector.send(method, 2..2).should   eql(V[3])
-          vector.send(method, 2..3).should   eql(V[3,4])
-          vector.send(method, 2..4).should   eql(V[3,4])
-          vector.send(method, 3..0).should   eql(V.empty)
-          vector.send(method, 3..3).should   eql(V[4])
-          vector.send(method, 3..4).should   eql(V[4])
-          vector.send(method, 4..0).should   eql(V.empty)
-          vector.send(method, 4..4).should   eql(V.empty)
-          vector.send(method, 4..5).should   eql(V.empty)
-          vector.send(method, 5..0).should   be_nil
-          vector.send(method, 5..5).should   be_nil
-          vector.send(method, 5..6).should   be_nil
+          expect(vector.send(method, 0..-1)).to  eql(V[1,2,3,4])
+          expect(vector.send(method, 0..-10)).to eql(V.empty)
+          expect(vector.send(method, 0..0)).to   eql(V[1])
+          expect(vector.send(method, 0..1)).to   eql(V[1,2])
+          expect(vector.send(method, 0..2)).to   eql(V[1,2,3])
+          expect(vector.send(method, 0..3)).to   eql(V[1,2,3,4])
+          expect(vector.send(method, 0..4)).to   eql(V[1,2,3,4])
+          expect(vector.send(method, 0..10)).to  eql(V[1,2,3,4])
+          expect(vector.send(method, 2..-10)).to eql(V.empty)
+          expect(vector.send(method, 2..0)).to   eql(V.empty)
+          expect(vector.send(method, 2..2)).to   eql(V[3])
+          expect(vector.send(method, 2..3)).to   eql(V[3,4])
+          expect(vector.send(method, 2..4)).to   eql(V[3,4])
+          expect(vector.send(method, 3..0)).to   eql(V.empty)
+          expect(vector.send(method, 3..3)).to   eql(V[4])
+          expect(vector.send(method, 3..4)).to   eql(V[4])
+          expect(vector.send(method, 4..0)).to   eql(V.empty)
+          expect(vector.send(method, 4..4)).to   eql(V.empty)
+          expect(vector.send(method, 4..5)).to   eql(V.empty)
+          expect(vector.send(method, 5..0)).to   be_nil
+          expect(vector.send(method, 5..5)).to   be_nil
+          expect(vector.send(method, 5..6)).to   be_nil
 
-          big.send(method, 159..162).should     eql(V[160,161,162,163])
-          big.send(method, 160..162).should     eql(V[161,162,163])
-          big.send(method, 161..162).should     eql(V[162,163])
-          big.send(method, 9999..10100).should  eql(V[10000])
-          big.send(method, 10000..10100).should eql(V.empty)
-          big.send(method, 10001..10100).should be_nil
+          expect(big.send(method, 159..162)).to     eql(V[160,161,162,163])
+          expect(big.send(method, 160..162)).to     eql(V[161,162,163])
+          expect(big.send(method, 161..162)).to     eql(V[162,163])
+          expect(big.send(method, 9999..10100)).to  eql(V[10000])
+          expect(big.send(method, 10000..10100)).to eql(V.empty)
+          expect(big.send(method, 10001..10100)).to be_nil
 
-          vector.send(method, 0...-1).should  eql(V[1,2,3])
-          vector.send(method, 0...-10).should eql(V.empty)
-          vector.send(method, 0...0).should   eql(V.empty)
-          vector.send(method, 0...1).should   eql(V[1])
-          vector.send(method, 0...2).should   eql(V[1,2])
-          vector.send(method, 0...3).should   eql(V[1,2,3])
-          vector.send(method, 0...4).should   eql(V[1,2,3,4])
-          vector.send(method, 0...10).should  eql(V[1,2,3,4])
-          vector.send(method, 2...-10).should eql(V.empty)
-          vector.send(method, 2...0).should   eql(V.empty)
-          vector.send(method, 2...2).should   eql(V.empty)
-          vector.send(method, 2...3).should   eql(V[3])
-          vector.send(method, 2...4).should   eql(V[3,4])
-          vector.send(method, 3...0).should   eql(V.empty)
-          vector.send(method, 3...3).should   eql(V.empty)
-          vector.send(method, 3...4).should   eql(V[4])
-          vector.send(method, 4...0).should   eql(V.empty)
-          vector.send(method, 4...4).should   eql(V.empty)
-          vector.send(method, 4...5).should   eql(V.empty)
-          vector.send(method, 5...0).should   be_nil
-          vector.send(method, 5...5).should   be_nil
-          vector.send(method, 5...6).should   be_nil
+          expect(vector.send(method, 0...-1)).to  eql(V[1,2,3])
+          expect(vector.send(method, 0...-10)).to eql(V.empty)
+          expect(vector.send(method, 0...0)).to   eql(V.empty)
+          expect(vector.send(method, 0...1)).to   eql(V[1])
+          expect(vector.send(method, 0...2)).to   eql(V[1,2])
+          expect(vector.send(method, 0...3)).to   eql(V[1,2,3])
+          expect(vector.send(method, 0...4)).to   eql(V[1,2,3,4])
+          expect(vector.send(method, 0...10)).to  eql(V[1,2,3,4])
+          expect(vector.send(method, 2...-10)).to eql(V.empty)
+          expect(vector.send(method, 2...0)).to   eql(V.empty)
+          expect(vector.send(method, 2...2)).to   eql(V.empty)
+          expect(vector.send(method, 2...3)).to   eql(V[3])
+          expect(vector.send(method, 2...4)).to   eql(V[3,4])
+          expect(vector.send(method, 3...0)).to   eql(V.empty)
+          expect(vector.send(method, 3...3)).to   eql(V.empty)
+          expect(vector.send(method, 3...4)).to   eql(V[4])
+          expect(vector.send(method, 4...0)).to   eql(V.empty)
+          expect(vector.send(method, 4...4)).to   eql(V.empty)
+          expect(vector.send(method, 4...5)).to   eql(V.empty)
+          expect(vector.send(method, 5...0)).to   be_nil
+          expect(vector.send(method, 5...5)).to   be_nil
+          expect(vector.send(method, 5...6)).to   be_nil
 
-          big.send(method, 159...162).should     eql(V[160,161,162])
-          big.send(method, 160...162).should     eql(V[161,162])
-          big.send(method, 161...162).should     eql(V[162])
-          big.send(method, 9999...10100).should  eql(V[10000])
-          big.send(method, 10000...10100).should eql(V.empty)
-          big.send(method, 10001...10100).should be_nil
+          expect(big.send(method, 159...162)).to     eql(V[160,161,162])
+          expect(big.send(method, 160...162)).to     eql(V[161,162])
+          expect(big.send(method, 161...162)).to     eql(V[162])
+          expect(big.send(method, 9999...10100)).to  eql(V[10000])
+          expect(big.send(method, 10000...10100)).to eql(V.empty)
+          expect(big.send(method, 10001...10100)).to be_nil
 
-          vector.send(method, -1..-1).should  eql(V[4])
-          vector.send(method, -1...-1).should eql(V.empty)
-          vector.send(method, -1..3).should   eql(V[4])
-          vector.send(method, -1...3).should  eql(V.empty)
-          vector.send(method, -1..4).should   eql(V[4])
-          vector.send(method, -1...4).should  eql(V[4])
-          vector.send(method, -1..10).should  eql(V[4])
-          vector.send(method, -1...10).should eql(V[4])
-          vector.send(method, -1..0).should   eql(V.empty)
-          vector.send(method, -1..-4).should  eql(V.empty)
-          vector.send(method, -1...-4).should eql(V.empty)
-          vector.send(method, -1..-6).should  eql(V.empty)
-          vector.send(method, -1...-6).should eql(V.empty)
-          vector.send(method, -2..-2).should  eql(V[3])
-          vector.send(method, -2...-2).should eql(V.empty)
-          vector.send(method, -2..-1).should  eql(V[3,4])
-          vector.send(method, -2...-1).should eql(V[3])
-          vector.send(method, -2..10).should  eql(V[3,4])
-          vector.send(method, -2...10).should eql(V[3,4])
+          expect(vector.send(method, -1..-1)).to  eql(V[4])
+          expect(vector.send(method, -1...-1)).to eql(V.empty)
+          expect(vector.send(method, -1..3)).to   eql(V[4])
+          expect(vector.send(method, -1...3)).to  eql(V.empty)
+          expect(vector.send(method, -1..4)).to   eql(V[4])
+          expect(vector.send(method, -1...4)).to  eql(V[4])
+          expect(vector.send(method, -1..10)).to  eql(V[4])
+          expect(vector.send(method, -1...10)).to eql(V[4])
+          expect(vector.send(method, -1..0)).to   eql(V.empty)
+          expect(vector.send(method, -1..-4)).to  eql(V.empty)
+          expect(vector.send(method, -1...-4)).to eql(V.empty)
+          expect(vector.send(method, -1..-6)).to  eql(V.empty)
+          expect(vector.send(method, -1...-6)).to eql(V.empty)
+          expect(vector.send(method, -2..-2)).to  eql(V[3])
+          expect(vector.send(method, -2...-2)).to eql(V.empty)
+          expect(vector.send(method, -2..-1)).to  eql(V[3,4])
+          expect(vector.send(method, -2...-1)).to eql(V[3])
+          expect(vector.send(method, -2..10)).to  eql(V[3,4])
+          expect(vector.send(method, -2...10)).to eql(V[3,4])
 
-          big.send(method, -1..-1).should    eql(V[10000])
-          big.send(method, -1..9999).should  eql(V[10000])
-          big.send(method, -1...9999).should eql(V.empty)
-          big.send(method, -2...9999).should eql(V[9999])
-          big.send(method, -2..-1).should    eql(V[9999,10000])
+          expect(big.send(method, -1..-1)).to    eql(V[10000])
+          expect(big.send(method, -1..9999)).to  eql(V[10000])
+          expect(big.send(method, -1...9999)).to eql(V.empty)
+          expect(big.send(method, -2...9999)).to eql(V[9999])
+          expect(big.send(method, -2..-1)).to    eql(V[9999,10000])
 
-          vector.send(method, -4..-4).should  eql(V[1])
-          vector.send(method, -4..-2).should  eql(V[1,2,3])
-          vector.send(method, -4...-2).should eql(V[1,2])
-          vector.send(method, -4..-1).should  eql(V[1,2,3,4])
-          vector.send(method, -4...-1).should eql(V[1,2,3])
-          vector.send(method, -4..3).should   eql(V[1,2,3,4])
-          vector.send(method, -4...3).should  eql(V[1,2,3])
-          vector.send(method, -4..4).should   eql(V[1,2,3,4])
-          vector.send(method, -4...4).should  eql(V[1,2,3,4])
-          vector.send(method, -4..0).should   eql(V[1])
-          vector.send(method, -4...0).should  eql(V.empty)
-          vector.send(method, -4..1).should   eql(V[1,2])
-          vector.send(method, -4...1).should  eql(V[1])
+          expect(vector.send(method, -4..-4)).to  eql(V[1])
+          expect(vector.send(method, -4..-2)).to  eql(V[1,2,3])
+          expect(vector.send(method, -4...-2)).to eql(V[1,2])
+          expect(vector.send(method, -4..-1)).to  eql(V[1,2,3,4])
+          expect(vector.send(method, -4...-1)).to eql(V[1,2,3])
+          expect(vector.send(method, -4..3)).to   eql(V[1,2,3,4])
+          expect(vector.send(method, -4...3)).to  eql(V[1,2,3])
+          expect(vector.send(method, -4..4)).to   eql(V[1,2,3,4])
+          expect(vector.send(method, -4...4)).to  eql(V[1,2,3,4])
+          expect(vector.send(method, -4..0)).to   eql(V[1])
+          expect(vector.send(method, -4...0)).to  eql(V.empty)
+          expect(vector.send(method, -4..1)).to   eql(V[1,2])
+          expect(vector.send(method, -4...1)).to  eql(V[1])
 
-          vector.send(method, -5..-5).should be_nil
-          vector.send(method, -5...-5).should be_nil
-          vector.send(method, -5..-4).should be_nil
-          vector.send(method, -5..-1).should be_nil
-          vector.send(method, -5..10).should be_nil
+          expect(vector.send(method, -5..-5)).to be_nil
+          expect(vector.send(method, -5...-5)).to be_nil
+          expect(vector.send(method, -5..-4)).to be_nil
+          expect(vector.send(method, -5..-1)).to be_nil
+          expect(vector.send(method, -5..10)).to be_nil
 
-          big.send(method, -10001..-1).should be_nil
+          expect(big.send(method, -10001..-1)).to be_nil
         end
 
         it "leaves the original unchanged" do
-          vector.should eql(V[1,2,3,4])
+          expect(vector).to eql(V[1,2,3,4])
         end
       end
     end
@@ -222,8 +222,8 @@ describe Hamster::Vector do
     context "when passed a subclass of Range" do
       it "works the same as with a Range" do
         subclass = Class.new(Range)
-        vector.send(method, subclass.new(1,2)).should eql(V[2,3])
-        vector.send(method, subclass.new(-3,-1,true)).should eql(V[2,3])
+        expect(vector.send(method, subclass.new(1,2))).to eql(V[2,3])
+        expect(vector.send(method, subclass.new(-3,-1,true))).to eql(V[2,3])
       end
     end
 
@@ -231,10 +231,10 @@ describe Hamster::Vector do
       it "with index and count or a range, returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1,2,3])
-        instance.send(method, 0, 0).class.should be(subclass)
-        instance.send(method, 0, 2).class.should be(subclass)
-        instance.send(method, 0..0).class.should be(subclass)
-        instance.send(method, 1..-1).class.should be(subclass)
+        expect(instance.send(method, 0, 0).class).to be(subclass)
+        expect(instance.send(method, 0, 2).class).to be(subclass)
+        expect(instance.send(method, 0..0).class).to be(subclass)
+        expect(instance.send(method, 1..-1).class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/vector/sorting_spec.rb
+++ b/spec/lib/hamster/vector/sorting_spec.rb
@@ -18,22 +18,22 @@ describe Hamster::Vector do
           context "with a block" do
             it "preserves the original" do
               vector.send(method, &comparator)
-              vector.should eql(V[*values])
+              expect(vector).to eql(V[*values])
             end
 
             it "returns #{expected.inspect}" do
-              vector.send(method, &comparator).should eql(V[*expected])
+              expect(vector.send(method, &comparator)).to eql(V[*expected])
             end
           end
 
           context "without a block" do
             it "preserves the original" do
               vector.send(method)
-              vector.should eql(V[*values])
+              expect(vector).to eql(V[*values])
             end
 
             it "returns #{expected.sort.inspect}" do
-              vector.send(method).should eql(V[*expected.sort])
+              expect(vector.send(method)).to eql(V[*expected.sort])
             end
           end
         end
@@ -45,9 +45,9 @@ describe Hamster::Vector do
             array = size.times.map { rand(10000) }
             vector = V.new(array)
             if method == :sort
-              vector.sort.should == array.sort
+              expect(vector.sort).to eq(array.sort)
             else
-              vector.sort_by { |x| -x }.should == array.sort_by { |x| -x }
+              expect(vector.sort_by { |x| -x }).to eq(array.sort_by { |x| -x })
             end
           end
         end

--- a/spec/lib/hamster/vector/sum_spec.rb
+++ b/spec/lib/hamster/vector/sum_spec.rb
@@ -10,7 +10,7 @@ describe Hamster::Vector do
     ].each do |values, expected|
       describe "on #{values.inspect}" do
         it "returns #{expected.inspect}" do
-          V[*values].sum.should == expected
+          expect(V[*values].sum).to eq(expected)
         end
       end
     end

--- a/spec/lib/hamster/vector/take_spec.rb
+++ b/spec/lib/hamster/vector/take_spec.rb
@@ -17,11 +17,11 @@ describe Hamster::Vector do
 
         it "preserves the original" do
           vector.take(number)
-          vector.should eql(V[*values])
+          expect(vector).to eql(V[*values])
         end
 
         it "returns #{expected.inspect}" do
-          vector.take(number).should eql(V[*expected])
+          expect(vector.take(number)).to eql(V[*expected])
         end
       end
     end
@@ -29,14 +29,14 @@ describe Hamster::Vector do
     context "when number of elements specified is identical to size" do
       let(:vector) { V[1, 2, 3, 4, 5, 6] }
       it "returns self" do
-        vector.take(vector.size).should be(vector)
+        expect(vector.take(vector.size)).to be(vector)
       end
     end
 
     context "when number of elements specified is bigger than size" do
       let(:vector) { V[1, 2, 3, 4, 5, 6] }
       it "returns self" do
-        vector.take(vector.size + 1).should be(vector)
+        expect(vector.take(vector.size + 1)).to be(vector)
       end
     end
   end

--- a/spec/lib/hamster/vector/take_while_spec.rb
+++ b/spec/lib/hamster/vector/take_while_spec.rb
@@ -14,19 +14,19 @@ describe Hamster::Vector do
 
         describe "with a block" do
           it "returns #{expected.inspect}" do
-            result.should eql(V[*expected])
+            expect(result).to eql(V[*expected])
           end
 
           it "preserves the original" do
             result
-            vector.should eql(V[*values])
+            expect(vector).to eql(V[*values])
           end
         end
 
         describe "without a block" do
           it "returns an Enumerator" do
-            vector.take_while.class.should be(Enumerator)
-            vector.take_while.each { |item| item < "C" }.should eql(V[*expected])
+            expect(vector.take_while.class).to be(Enumerator)
+            expect(vector.take_while.each { |item| item < "C" }).to eql(V[*expected])
           end
         end
       end

--- a/spec/lib/hamster/vector/to_list_spec.rb
+++ b/spec/lib/hamster/vector/to_list_spec.rb
@@ -15,16 +15,16 @@ describe Hamster::Vector do
         let(:list) { vector.to_list }
 
         it "returns a list" do
-          list.is_a?(Hamster::List).should == true
+          expect(list.is_a?(Hamster::List)).to eq(true)
         end
 
         describe "the returned list" do
           it "has the correct length" do
-            list.size.should == values.size
+            expect(list.size).to eq(values.size)
           end
 
           it "contains all values" do
-            list.to_a.should == values
+            expect(list.to_a).to eq(values)
           end
         end
       end

--- a/spec/lib/hamster/vector/to_set_spec.rb
+++ b/spec/lib/hamster/vector/to_set_spec.rb
@@ -15,7 +15,7 @@ describe Hamster::Vector do
     ].each do |values|
       describe "on #{values.inspect}" do
         it "returns a set with the same values" do
-          V[*values].to_set.should eql(S[*values])
+          expect(V[*values].to_set).to eql(S[*values])
         end
       end
     end

--- a/spec/lib/hamster/vector/transpose_spec.rb
+++ b/spec/lib/hamster/vector/transpose_spec.rb
@@ -4,21 +4,21 @@ require "hamster/vector"
 describe Hamster::Vector do
   describe "#transpose" do
     it "takes a vector of vectors and transposes rows and columns" do
-      V[V[1, 'a'], V[2, 'b'], V[3, 'c']].transpose.should eql(V[V[1, 2, 3], V["a", "b", "c"]])
-      V[V[1, 2, 3], V["a", "b", "c"]].transpose.should eql(V[V[1, 'a'], V[2, 'b'], V[3, 'c']])
-      V[].transpose.should eql(V[])
-      V[V[]].transpose.should eql(V[])
-      V[V[], V[]].transpose.should eql(V[])
-      V[V[0]].transpose.should eql(V[V[0]])
-      V[V[0], V[1]].transpose.should eql(V[V[0, 1]])
+      expect(V[V[1, 'a'], V[2, 'b'], V[3, 'c']].transpose).to eql(V[V[1, 2, 3], V["a", "b", "c"]])
+      expect(V[V[1, 2, 3], V["a", "b", "c"]].transpose).to eql(V[V[1, 'a'], V[2, 'b'], V[3, 'c']])
+      expect(V[].transpose).to eql(V[])
+      expect(V[V[]].transpose).to eql(V[])
+      expect(V[V[], V[]].transpose).to eql(V[])
+      expect(V[V[0]].transpose).to eql(V[V[0]])
+      expect(V[V[0], V[1]].transpose).to eql(V[V[0, 1]])
     end
 
     it "raises an IndexError if the vectors are not of the same length" do
-      -> { V[V[1,2], V[:a]].transpose }.should raise_error(IndexError)
+      expect { V[V[1,2], V[:a]].transpose }.to raise_error(IndexError)
     end
 
     it "also works on Vectors of Arrays" do
-      V[[1,2,3], [4,5,6]].transpose.should eql(V[V[1,4], V[2,5], V[3,6]])
+      expect(V[[1,2,3], [4,5,6]].transpose).to eql(V[V[1,4], V[2,5], V[3,6]])
     end
 
     [10, 31, 32, 33, 1000, 1023, 1024, 1025, 2000].each do |size|
@@ -31,8 +31,8 @@ describe Hamster::Vector do
           #   so although Vector#== does type coercion, it does not consider
           #   nested Arrays and corresponding nested Vectors to be equal
           # That is why the following ".map { |a| V.new(a) }" is needed
-          result.should == array.transpose.map { |a| V.new(a) }
-          result.each { |v| v.class.should be(Hamster::Vector) }
+          expect(result).to eq(array.transpose.map { |a| V.new(a) })
+          result.each { |v| expect(v.class).to be(Hamster::Vector) }
         end
       end
     end
@@ -41,8 +41,8 @@ describe Hamster::Vector do
       it "returns instances of the subclass" do
         subclass = Class.new(V)
         instance = subclass.new([[1,2,3], [4,5,6]])
-        instance.transpose.class.should be(subclass)
-        instance.transpose.each { |v| v.class.should be(subclass) }
+        expect(instance.transpose.class).to be(subclass)
+        instance.transpose.each { |v| expect(v.class).to be(subclass) }
       end
     end
   end

--- a/spec/lib/hamster/vector/uniq_spec.rb
+++ b/spec/lib/hamster/vector/uniq_spec.rb
@@ -6,50 +6,50 @@ describe Hamster::Vector do
     let(:vector) { V['a', 'b', 'a', 'a', 'c', 'b'] }
 
     it "returns a vector with no duplicates" do
-      vector.uniq.should eql(V['a', 'b', 'c'])
+      expect(vector.uniq).to eql(V['a', 'b', 'c'])
     end
 
     it "leaves the original unmodified" do
       vector.uniq
-      vector.should eql(V['a', 'b', 'a', 'a', 'c', 'b'])
+      expect(vector).to eql(V['a', 'b', 'a', 'a', 'c', 'b'])
     end
 
     it "uses #eql? semantics" do
-      V[1.0, 1].uniq.should eql(V[1.0, 1])
+      expect(V[1.0, 1].uniq).to eql(V[1.0, 1])
     end
 
     it "also uses #hash when determining which values are duplicates" do
       x = double(1)
-      x.should_receive(:hash).at_least(1).times.and_return(1)
+      expect(x).to receive(:hash).at_least(1).times.and_return(1)
       y = double(2)
-      y.should_receive(:hash).at_least(1).times.and_return(2)
+      expect(y).to receive(:hash).at_least(1).times.and_return(2)
       V[x, y].uniq
     end
 
     it "keeps the first of each group of duplicate values" do
       x, y, z = 'a', 'a', 'a'
       result = V[x, y, z].uniq
-      result.size.should == 1
-      result[0].should be(x)
+      expect(result.size).to eq(1)
+      expect(result[0]).to be(x)
     end
 
     context "when passed a block" do
       it "uses the return value of the block to determine which items are duplicate" do
         v = V['a', 'A', 'B', 'b']
-        v.uniq(&:upcase).should == V['a', 'B']
+        expect(v.uniq(&:upcase)).to eq(V['a', 'B'])
       end
     end
 
     context "on a vector with no duplicates" do
       it "returns an unchanged vector" do
-        V[1, 2, 3].uniq.should eql(V[1, 2, 3])
+        expect(V[1, 2, 3].uniq).to eql(V[1, 2, 3])
       end
 
       context "if the vector has more than 32 elements and is initialized with Vector.new" do
         # Regression test for GitHub issue #182
         it "returns an unchanged vector" do
           vector1,vector2 = 2.times.collect { V.new(0..36) }
-          vector1.uniq.should eql(vector2)
+          expect(vector1.uniq).to eql(vector2)
         end
       end
     end
@@ -60,8 +60,8 @@ describe Hamster::Vector do
           array = size.times.map { rand(size*2) }
           vector = V.new(array)
           result = vector.uniq
-          result.should == array.uniq
-          result.class.should be(Hamster::Vector)
+          expect(result).to eq(array.uniq)
+          expect(result.class).to be(Hamster::Vector)
         end
       end
     end
@@ -70,7 +70,7 @@ describe Hamster::Vector do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1,2,3])
-        instance.uniq.class.should be(subclass)
+        expect(instance.uniq.class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/vector/unshift_spec.rb
+++ b/spec/lib/hamster/vector/unshift_spec.rb
@@ -17,11 +17,11 @@ describe Hamster::Vector do
 
         it "preserves the original" do
           vector.unshift(new_value)
-          vector.should eql(V[*values])
+          expect(vector).to eql(V[*values])
         end
 
         it "returns #{expected.inspect}" do
-          vector.unshift(new_value).should eql(V[*expected])
+          expect(vector.unshift(new_value)).to eql(V[*expected])
         end
       end
     end

--- a/spec/lib/hamster/vector/values_at_spec.rb
+++ b/spec/lib/hamster/vector/values_at_spec.rb
@@ -6,20 +6,20 @@ describe Hamster::Vector do
     let(:vector) { V['a', 'b', 'c'] }
 
     it "accepts any number of indices, and returns a vector of items at those indices" do
-      vector.values_at(0).should eql(V['a'])
-      vector.values_at(1,2).should eql(V['b', 'c'])
+      expect(vector.values_at(0)).to eql(V['a'])
+      expect(vector.values_at(1,2)).to eql(V['b', 'c'])
     end
 
     context "when passed invalid indices" do
       it "fills in with nils" do
-        vector.values_at(1,2,3).should  eql(V['b', 'c', nil])
-        vector.values_at(-10,10).should eql(V[nil, nil])
+        expect(vector.values_at(1,2,3)).to  eql(V['b', 'c', nil])
+        expect(vector.values_at(-10,10)).to eql(V[nil, nil])
       end
     end
 
     context "when passed no arguments" do
       it "returns an empty vector" do
-        vector.values_at.should eql(V.empty)
+        expect(vector.values_at).to eql(V.empty)
       end
     end
 
@@ -27,7 +27,7 @@ describe Hamster::Vector do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1,2,3])
-        instance.values_at(1,2).class.should be(subclass)
+        expect(instance.values_at(1,2).class).to be(subclass)
       end
     end
   end

--- a/spec/lib/hamster/vector/zip_spec.rb
+++ b/spec/lib/hamster/vector/zip_spec.rb
@@ -9,29 +9,29 @@ describe Hamster::Vector do
       it "yields arrays of one corresponding element from each input sequence" do
         result = []
         vector.zip(['a', 'b', 'c', 'd']) { |obj| result << obj }
-        result.should eql([[1,'a'], [2,'b'], [3,'c'], [4,'d']])
+        expect(result).to eql([[1,'a'], [2,'b'], [3,'c'], [4,'d']])
       end
 
       it "fills in the missing values with nils" do
         result = []
         vector.zip(['a', 'b']) { |obj| result << obj }
-        result.should eql([[1,'a'], [2,'b'], [3,nil], [4,nil]])
+        expect(result).to eql([[1,'a'], [2,'b'], [3,nil], [4,nil]])
       end
 
       it "returns nil" do
-        vector.zip([2,3,4]) {}.should be_nil
+        expect(vector.zip([2,3,4]) {}).to be_nil
       end
 
       it "can handle multiple inputs, of different classes" do
         result = []
         vector.zip(V[2,3,4,5], [5,6,7,8]) { |obj| result << obj }
-        result.should eql([[1,2,5], [2,3,6], [3,4,7], [4,5,8]])
+        expect(result).to eql([[1,2,5], [2,3,6], [3,4,7], [4,5,8]])
       end
     end
 
     context "without a block" do
       it "returns a vector of arrays (one corresponding element from each input sequence)" do
-        vector.zip([2,3,4,5]).should eql(V[[1,2], [2,3], [3,4], [4,5]])
+        expect(vector.zip([2,3,4,5])).to eql(V[[1,2], [2,3], [3,4], [4,5]])
       end
     end
 
@@ -41,8 +41,8 @@ describe Hamster::Vector do
           array   = (rand(9)+1).times.map { size.times.map { rand(10000) }}
           vectors = array.map { |a| V.new(a) }
           result  = vectors.first.zip(*vectors.drop(1))
-          result.class.should be(Hamster::Vector)
-          result.should == array[0].zip(*array.drop(1))
+          expect(result.class).to be(Hamster::Vector)
+          expect(result).to eq(array[0].zip(*array.drop(1)))
         end
       end
     end
@@ -51,7 +51,7 @@ describe Hamster::Vector do
       it "returns an instance of the subclass" do
         subclass = Class.new(Hamster::Vector)
         instance = subclass.new([1,2,3])
-        instance.zip([4,5,6]).class.should be(subclass)
+        expect(instance.zip([4,5,6]).class).to be(subclass)
       end
     end
   end

--- a/spec/lib/load_spec.rb
+++ b/spec/lib/load_spec.rb
@@ -6,37 +6,37 @@ hamster_lib_dir = File.join(File.dirname(__FILE__), "..", "..", 'lib')
 describe :Hamster do
   describe :Hash do
     it "can be loaded separately" do
-      system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/hash'; Hamster::Hash.new"}).should be(true)
+      expect(system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/hash'; Hamster::Hash.new"})).to be(true)
     end
   end
 
   describe :Set do
     it "can be loaded separately" do
-      system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/set'; Hamster::Set.new"}).should be(true)
+      expect(system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/set'; Hamster::Set.new"})).to be(true)
     end
   end
 
   describe :Vector do
     it "can be loaded separately" do
-      system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/vector'; Hamster::Vector.new"}).should be(true)
+      expect(system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/vector'; Hamster::Vector.new"})).to be(true)
     end
   end
 
   describe :List do
     it "can be loaded separately" do
-      system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/list'; Hamster::List[]"}).should be(true)
+      expect(system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/list'; Hamster::List[]"})).to be(true)
     end
   end
 
   describe :SortedSet do
     it "can be loaded separately" do
-      system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/sorted_set'; Hamster::SortedSet.new"}).should be(true)
+      expect(system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/sorted_set'; Hamster::SortedSet.new"})).to be(true)
     end
   end
 
   describe :Deque do
     it "can be loaded separately" do
-      system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/deque'; Hamster::Deque.new"}).should be(true)
+      expect(system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/deque'; Hamster::Deque.new"})).to be(true)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,17 +11,6 @@ require "hamster/list"
 require "hamster/deque"
 require "hamster/core_ext"
 
-# Suppress warnings from use of old RSpec expectation and mock syntax
-# If all tests are eventually updated to use the new syntax, this can be removed
-RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = [:should, :expect]
-  end
-  config.mock_with :rspec do |c|
-    c.syntax = [:should, :expect]
-  end
-end
-
 V = Hamster::Vector
 L = Hamster::List
 H = Hamster::Hash


### PR DESCRIPTION
Hello there! Thanks for your awesome work on hamster! :tada:

I work on a gem called [`persistent-💎`](https://github.com/ivoanjo/persistent-dmnd) that builds on top of Hamster but offers a nice beautiful (opinionated?) shorthand syntax to create the persistent data structures.

As part of my work I'd like to contribute some improvements I did on top of Hamster back upstream.

As a start, this CR updates the test suite to use the latest rspec syntax. These changes were automatically performed using the [`transpec`](https://github.com/yujinakayama/transpec) gem.

