### PR TITLE
Add more rubies and jrubies to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,24 @@ before_install:
   - gem --version
   - gem update bundler
   - bundle --version
+
 rvm:
   - 1.9.3
   - 2.0
   - 2.1
   - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - ruby-2.6.0-preview1
   - ruby-head
+  - jruby-1.7.9
+  - jruby-1.7.27
   - jruby-9.0.0.0
+  - jruby-9.1.16.0
   - jruby-head
   - rbx
+
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ rvm:
   - 2.5
   - ruby-2.6.0-preview1
   - ruby-head
-  - jruby-1.7.9
   - jruby-1.7.27
   - jruby-9.0.0.0
   - jruby-9.1.16.0


### PR DESCRIPTION
Hello there! Thanks for your awesome work on hamster! :tada:

I work on a gem called [persistent-💎](https://github.com/ivoanjo/persistent-dmnd) that builds on top of Hamster but offers a nice beautiful (opinionated?) shorthand syntax to create the persistent data structures.

As part of my work I'd like to contribute some improvements I did on top of Hamster back upstream.

This CR adds the latest Ruby versions and a few more JRuby versions to the
travis configuration. These match [the same versions](https://github.com/ivoanjo/persistent-dmnd/blob/master/.travis.yml) that `persistent-💎` is tested with currently.