### PR TITLE
Modernize rspec configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # Ignore all tempfiles
 /tmp
+spec/examples.txt
 
 # Ignores that should be in the global gitignore
 /coverage

--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --format documentation
 --fail-fast
 --profile
+--require spec_helper

--- a/.rspec
+++ b/.rspec
@@ -1,5 +1,2 @@
---colour
---format documentation
 --fail-fast
---profile
 --require spec_helper

--- a/spec/lib/hamster/associable/associable_spec.rb
+++ b/spec/lib/hamster/associable/associable_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 require "hamster/vector"
 

--- a/spec/lib/hamster/associable/associable_spec.rb
+++ b/spec/lib/hamster/associable/associable_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/hash"
 require "hamster/vector"
 
-describe Hamster::Associable do
+RSpec.describe Hamster::Associable do
   describe "#update_in" do
     let(:hash) {
       Hamster::Hash[

--- a/spec/lib/hamster/core_ext/array_spec.rb
+++ b/spec/lib/hamster/core_ext/array_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/core_ext/enumerable"
 
-describe Array do
+RSpec.describe Array do
   let(:array) { %w[A B C] }
 
   describe "#to_list" do

--- a/spec/lib/hamster/core_ext/array_spec.rb
+++ b/spec/lib/hamster/core_ext/array_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/core_ext/enumerable"
 
 describe Array do

--- a/spec/lib/hamster/core_ext/enumerable_spec.rb
+++ b/spec/lib/hamster/core_ext/enumerable_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/core_ext/enumerable"
 
-describe Enumerable do
+RSpec.describe Enumerable do
   class TestEnumerable
     include Enumerable
 

--- a/spec/lib/hamster/core_ext/enumerable_spec.rb
+++ b/spec/lib/hamster/core_ext/enumerable_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/core_ext/enumerable"
 
 describe Enumerable do

--- a/spec/lib/hamster/core_ext/io_spec.rb
+++ b/spec/lib/hamster/core_ext/io_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/core_ext/io"
 
 describe IO do

--- a/spec/lib/hamster/core_ext/io_spec.rb
+++ b/spec/lib/hamster/core_ext/io_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/core_ext/io"
 
-describe IO do
+RSpec.describe IO do
   describe "#to_list" do
     let(:list) { L["A\n", "B\n", "C\n"] }
     let(:to_list) { io.to_list }

--- a/spec/lib/hamster/deque/clear_spec.rb
+++ b/spec/lib/hamster/deque/clear_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/clear_spec.rb
+++ b/spec/lib/hamster/deque/clear_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#clear" do
     [
       [],

--- a/spec/lib/hamster/deque/construction_spec.rb
+++ b/spec/lib/hamster/deque/construction_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/construction_spec.rb
+++ b/spec/lib/hamster/deque/construction_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe ".[]" do
     context "with no arguments" do
       it "always returns the same instance" do

--- a/spec/lib/hamster/deque/copying_spec.rb
+++ b/spec/lib/hamster/deque/copying_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   [:dup, :clone].each do |method|
     [
       [],

--- a/spec/lib/hamster/deque/copying_spec.rb
+++ b/spec/lib/hamster/deque/copying_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/dequeue_spec.rb
+++ b/spec/lib/hamster/deque/dequeue_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   [:dequeue, :shift].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/deque/dequeue_spec.rb
+++ b/spec/lib/hamster/deque/dequeue_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/empty_spec.rb
+++ b/spec/lib/hamster/deque/empty_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/empty_spec.rb
+++ b/spec/lib/hamster/deque/empty_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#empty?" do
     [
       [[], true],

--- a/spec/lib/hamster/deque/enqueue_spec.rb
+++ b/spec/lib/hamster/deque/enqueue_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   [:enqueue, :push].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/deque/enqueue_spec.rb
+++ b/spec/lib/hamster/deque/enqueue_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/first_spec.rb
+++ b/spec/lib/hamster/deque/first_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/first_spec.rb
+++ b/spec/lib/hamster/deque/first_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#first" do
     [
       [[], nil],

--- a/spec/lib/hamster/deque/inspect_spec.rb
+++ b/spec/lib/hamster/deque/inspect_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#inspect" do
     [
       [[], 'Hamster::Deque[]'],

--- a/spec/lib/hamster/deque/inspect_spec.rb
+++ b/spec/lib/hamster/deque/inspect_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/last_spec.rb
+++ b/spec/lib/hamster/deque/last_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/last_spec.rb
+++ b/spec/lib/hamster/deque/last_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#last" do
     [
       [[], nil],

--- a/spec/lib/hamster/deque/marshal_spec.rb
+++ b/spec/lib/hamster/deque/marshal_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#marshal_dump/#marshal_load" do
     let(:ruby) do
       File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])

--- a/spec/lib/hamster/deque/marshal_spec.rb
+++ b/spec/lib/hamster/deque/marshal_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/new_spec.rb
+++ b/spec/lib/hamster/deque/new_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/new_spec.rb
+++ b/spec/lib/hamster/deque/new_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe ".new" do
     it "accepts a single enumerable argument and creates a new deque" do
       deque = Hamster::Deque.new([1,2,3])

--- a/spec/lib/hamster/deque/pop_spec.rb
+++ b/spec/lib/hamster/deque/pop_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/pop_spec.rb
+++ b/spec/lib/hamster/deque/pop_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#pop" do
     [
       [[], []],

--- a/spec/lib/hamster/deque/pretty_print_spec.rb
+++ b/spec/lib/hamster/deque/pretty_print_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 require "pp"
 require "stringio"

--- a/spec/lib/hamster/deque/pretty_print_spec.rb
+++ b/spec/lib/hamster/deque/pretty_print_spec.rb
@@ -2,7 +2,7 @@ require "hamster/deque"
 require "pp"
 require "stringio"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#pretty_print" do
     let(:deque) { Hamster::Deque["AAAA", "BBBB", "CCCC"] }
     let(:stringio) { StringIO.new }

--- a/spec/lib/hamster/deque/push_spec.rb
+++ b/spec/lib/hamster/deque/push_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/push_spec.rb
+++ b/spec/lib/hamster/deque/push_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#push" do
     [
       [[], "A", ["A"]],

--- a/spec/lib/hamster/deque/random_modification_spec.rb
+++ b/spec/lib/hamster/deque/random_modification_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "modification (using #push, #pop, #shift, and #unshift)" do
     it "works when applied in many random combinations" do
       array = [1,2,3]

--- a/spec/lib/hamster/deque/random_modification_spec.rb
+++ b/spec/lib/hamster/deque/random_modification_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/shift_spec.rb
+++ b/spec/lib/hamster/deque/shift_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#shift" do
     [
       [[], []],

--- a/spec/lib/hamster/deque/shift_spec.rb
+++ b/spec/lib/hamster/deque/shift_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/size_spec.rb
+++ b/spec/lib/hamster/deque/size_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/size_spec.rb
+++ b/spec/lib/hamster/deque/size_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   [:size, :length].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/deque/to_a_spec.rb
+++ b/spec/lib/hamster/deque/to_a_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   [:to_a, :entries].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/deque/to_a_spec.rb
+++ b/spec/lib/hamster/deque/to_a_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/to_ary_spec.rb
+++ b/spec/lib/hamster/deque/to_ary_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/deque/to_ary_spec.rb
+++ b/spec/lib/hamster/deque/to_ary_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   let(:deque) { D["A", "B", "C", "D"] }
 
   describe "#to_ary" do

--- a/spec/lib/hamster/deque/to_list_spec.rb
+++ b/spec/lib/hamster/deque/to_list_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 require "hamster/list"
 

--- a/spec/lib/hamster/deque/to_list_spec.rb
+++ b/spec/lib/hamster/deque/to_list_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/deque"
 require "hamster/list"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#to_list" do
     [
       [],

--- a/spec/lib/hamster/deque/unshift_spec.rb
+++ b/spec/lib/hamster/deque/unshift_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/deque"
 
-describe Hamster::Deque do
+RSpec.describe Hamster::Deque do
   describe "#unshift" do
     [
       [[], "A", ["A"]],

--- a/spec/lib/hamster/deque/unshift_spec.rb
+++ b/spec/lib/hamster/deque/unshift_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/deque"
 
 describe Hamster::Deque do

--- a/spec/lib/hamster/experimental/mutable_set/add_qm_spec.rb
+++ b/spec/lib/hamster/experimental/mutable_set/add_qm_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/experimental/mutable_set"
 
-describe Hamster::MutableSet do
+RSpec.describe Hamster::MutableSet do
   let(:mutable) { Hamster::MutableSet[*values] }
 
   describe "#add?" do

--- a/spec/lib/hamster/experimental/mutable_set/add_qm_spec.rb
+++ b/spec/lib/hamster/experimental/mutable_set/add_qm_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 require "hamster/experimental/mutable_set"
 
 describe Hamster::MutableSet do

--- a/spec/lib/hamster/experimental/mutable_set/add_spec.rb
+++ b/spec/lib/hamster/experimental/mutable_set/add_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/experimental/mutable_set"
 
-describe Hamster::MutableSet do
+RSpec.describe Hamster::MutableSet do
   let(:mutable) { Hamster::MutableSet[*values] }
 
   describe "#add" do

--- a/spec/lib/hamster/experimental/mutable_set/add_spec.rb
+++ b/spec/lib/hamster/experimental/mutable_set/add_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/experimental/mutable_set"
 
 describe Hamster::MutableSet do

--- a/spec/lib/hamster/experimental/mutable_set/delete_qm_spec.rb
+++ b/spec/lib/hamster/experimental/mutable_set/delete_qm_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/experimental/mutable_set"
 
-describe Hamster::MutableSet do
+RSpec.describe Hamster::MutableSet do
   let(:mutable) { Hamster::MutableSet[*values] }
 
   describe "#delete?" do

--- a/spec/lib/hamster/experimental/mutable_set/delete_qm_spec.rb
+++ b/spec/lib/hamster/experimental/mutable_set/delete_qm_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/experimental/mutable_set"
 
 describe Hamster::MutableSet do

--- a/spec/lib/hamster/experimental/mutable_set/delete_spec.rb
+++ b/spec/lib/hamster/experimental/mutable_set/delete_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/experimental/mutable_set"
 
-describe Hamster::MutableSet do
+RSpec.describe Hamster::MutableSet do
   let(:mutable) { Hamster::MutableSet[*values] }
 
   describe "#delete" do

--- a/spec/lib/hamster/experimental/mutable_set/delete_spec.rb
+++ b/spec/lib/hamster/experimental/mutable_set/delete_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/experimental/mutable_set"
 
 describe Hamster::MutableSet do

--- a/spec/lib/hamster/hash/all_spec.rb
+++ b/spec/lib/hamster/hash/all_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/all_spec.rb
+++ b/spec/lib/hamster/hash/all_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H[values] }
 
   describe "#all?" do

--- a/spec/lib/hamster/hash/any_spec.rb
+++ b/spec/lib/hamster/hash/any_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/any_spec.rb
+++ b/spec/lib/hamster/hash/any_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#any?" do
     context "when empty" do
       it "with a block returns false" do

--- a/spec/lib/hamster/hash/assoc_spec.rb
+++ b/spec/lib/hamster/hash/assoc_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/assoc_spec.rb
+++ b/spec/lib/hamster/hash/assoc_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H[a: 3, b: 2, c: 1] }
 
   describe "#assoc" do

--- a/spec/lib/hamster/hash/clear_spec.rb
+++ b/spec/lib/hamster/hash/clear_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#clear" do
     [
       [],

--- a/spec/lib/hamster/hash/clear_spec.rb
+++ b/spec/lib/hamster/hash/clear_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/construction_spec.rb
+++ b/spec/lib/hamster/hash/construction_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/construction_spec.rb
+++ b/spec/lib/hamster/hash/construction_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe ".hash" do
     context "with nothing" do
       it "returns the canonical empty hash" do

--- a/spec/lib/hamster/hash/copying_spec.rb
+++ b/spec/lib/hamster/hash/copying_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/copying_spec.rb
+++ b/spec/lib/hamster/hash/copying_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 
   [:dup, :clone].each do |method|

--- a/spec/lib/hamster/hash/default_proc_spec.rb
+++ b/spec/lib/hamster/hash/default_proc_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/default_proc_spec.rb
+++ b/spec/lib/hamster/hash/default_proc_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#default_proc" do
     let(:hash) { H.new(1 => 2, 2 => 4) { |k| k * 2 } }
 

--- a/spec/lib/hamster/hash/delete_spec.rb
+++ b/spec/lib/hamster/hash/delete_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#delete" do
     let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 

--- a/spec/lib/hamster/hash/delete_spec.rb
+++ b/spec/lib/hamster/hash/delete_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/dig_spec.rb
+++ b/spec/lib/hamster/hash/dig_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/dig_spec.rb
+++ b/spec/lib/hamster/hash/dig_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#dig" do
     let(:h) { H[:a => 9, :b => H[:c => 'a', :d => 4], :e => nil] }
     it "returns the value with one argument to dig" do

--- a/spec/lib/hamster/hash/each_spec.rb
+++ b/spec/lib/hamster/hash/each_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/each_spec.rb
+++ b/spec/lib/hamster/hash/each_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 
   [:each, :each_pair].each do |method|

--- a/spec/lib/hamster/hash/each_with_index_spec.rb
+++ b/spec/lib/hamster/hash/each_with_index_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#each_with_index" do
     let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 

--- a/spec/lib/hamster/hash/each_with_index_spec.rb
+++ b/spec/lib/hamster/hash/each_with_index_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/empty_spec.rb
+++ b/spec/lib/hamster/hash/empty_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/empty_spec.rb
+++ b/spec/lib/hamster/hash/empty_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#empty?" do
     [
       [[], true],

--- a/spec/lib/hamster/hash/eql_spec.rb
+++ b/spec/lib/hamster/hash/eql_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/eql_spec.rb
+++ b/spec/lib/hamster/hash/eql_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 
   describe "#eql?" do

--- a/spec/lib/hamster/hash/except_spec.rb
+++ b/spec/lib/hamster/hash/except_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/except_spec.rb
+++ b/spec/lib/hamster/hash/except_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#except" do
     let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see", nil => "NIL"] }
 

--- a/spec/lib/hamster/hash/fetch_spec.rb
+++ b/spec/lib/hamster/hash/fetch_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#fetch" do
     context "with no default provided" do
       context "when the key exists" do

--- a/spec/lib/hamster/hash/fetch_spec.rb
+++ b/spec/lib/hamster/hash/fetch_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/fetch_values_spec.rb
+++ b/spec/lib/hamster/hash/fetch_values_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/fetch_values_spec.rb
+++ b/spec/lib/hamster/hash/fetch_values_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#fetch_values" do
     context "when the all the requests keys exist" do
       it "returns a vector of values for the given keys" do

--- a/spec/lib/hamster/hash/find_spec.rb
+++ b/spec/lib/hamster/hash/find_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/find_spec.rb
+++ b/spec/lib/hamster/hash/find_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   [:find, :detect].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/hash/flat_map_spec.rb
+++ b/spec/lib/hamster/hash/flat_map_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 
   describe "#flat_map" do

--- a/spec/lib/hamster/hash/flat_map_spec.rb
+++ b/spec/lib/hamster/hash/flat_map_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/flatten_spec.rb
+++ b/spec/lib/hamster/hash/flatten_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/flatten_spec.rb
+++ b/spec/lib/hamster/hash/flatten_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#flatten" do
     context "with flatten depth of zero" do
       it "returns a vector of keys/value" do

--- a/spec/lib/hamster/hash/get_spec.rb
+++ b/spec/lib/hamster/hash/get_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/get_spec.rb
+++ b/spec/lib/hamster/hash/get_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   [:get, :[]].each do |method|
     describe "##{method}" do
       context "with a default block" do

--- a/spec/lib/hamster/hash/has_key_spec.rb
+++ b/spec/lib/hamster/hash/has_key_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/has_key_spec.rb
+++ b/spec/lib/hamster/hash/has_key_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   [:key?, :has_key?, :include?, :member?].each do |method|
     describe "##{method}" do
       let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see", nil => "NIL", 2.0 => "two"] }

--- a/spec/lib/hamster/hash/has_value_spec.rb
+++ b/spec/lib/hamster/hash/has_value_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/has_value_spec.rb
+++ b/spec/lib/hamster/hash/has_value_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H[toast: 'buttered', jam: 'strawberry'] }
 
   [:value?, :has_value?].each do |method|

--- a/spec/lib/hamster/hash/hash_spec.rb
+++ b/spec/lib/hamster/hash/hash_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/hash_spec.rb
+++ b/spec/lib/hamster/hash/hash_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#hash" do
     it "values are sufficiently distributed" do
       expect((1..4000).each_slice(4).map { |ka, va, kb, vb| H[ka => va, kb => vb].hash }.uniq.size).to eq(1000)

--- a/spec/lib/hamster/hash/immutable_spec.rb
+++ b/spec/lib/hamster/hash/immutable_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/immutable"
 require "hamster/hash"
 

--- a/spec/lib/hamster/hash/immutable_spec.rb
+++ b/spec/lib/hamster/hash/immutable_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/immutable"
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   it "includes Immutable" do
     expect(Hamster::Hash).to include(Hamster::Immutable)
   end

--- a/spec/lib/hamster/hash/inspect_spec.rb
+++ b/spec/lib/hamster/hash/inspect_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/inspect_spec.rb
+++ b/spec/lib/hamster/hash/inspect_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#inspect" do
     [
       [[], 'Hamster::Hash[]'],

--- a/spec/lib/hamster/hash/invert_spec.rb
+++ b/spec/lib/hamster/hash/invert_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/invert_spec.rb
+++ b/spec/lib/hamster/hash/invert_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#invert" do
     let(:hash) { H[a: 3, b: 2, c: 1] }
 

--- a/spec/lib/hamster/hash/key_spec.rb
+++ b/spec/lib/hamster/hash/key_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/key_spec.rb
+++ b/spec/lib/hamster/hash/key_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#key" do
     let(:hash) { H[a: 1, b: 1, c: 2, d: 3] }
 

--- a/spec/lib/hamster/hash/keys_spec.rb
+++ b/spec/lib/hamster/hash/keys_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 require "hamster/set"
 

--- a/spec/lib/hamster/hash/keys_spec.rb
+++ b/spec/lib/hamster/hash/keys_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/hash"
 require "hamster/set"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#keys" do
     let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 

--- a/spec/lib/hamster/hash/map_spec.rb
+++ b/spec/lib/hamster/hash/map_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/map_spec.rb
+++ b/spec/lib/hamster/hash/map_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   [:map, :collect].each do |method|
     describe "##{method}" do
       context "when empty" do

--- a/spec/lib/hamster/hash/marshal_spec.rb
+++ b/spec/lib/hamster/hash/marshal_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/marshal_spec.rb
+++ b/spec/lib/hamster/hash/marshal_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#marshal_dump/#marshal_load" do
     let(:ruby) do
       File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])

--- a/spec/lib/hamster/hash/merge_spec.rb
+++ b/spec/lib/hamster/hash/merge_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#merge" do
     [
       [{}, {}, {}],

--- a/spec/lib/hamster/hash/merge_spec.rb
+++ b/spec/lib/hamster/hash/merge_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/min_max_spec.rb
+++ b/spec/lib/hamster/hash/min_max_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/min_max_spec.rb
+++ b/spec/lib/hamster/hash/min_max_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H["a" => 3, "b" => 2, "c" => 1] }
 
   describe "#min" do

--- a/spec/lib/hamster/hash/new_spec.rb
+++ b/spec/lib/hamster/hash/new_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/new_spec.rb
+++ b/spec/lib/hamster/hash/new_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe ".new" do
     it "is amenable to overriding of #initialize" do
       class SnazzyHash < Hamster::Hash

--- a/spec/lib/hamster/hash/none_spec.rb
+++ b/spec/lib/hamster/hash/none_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#none?" do
     context "when empty" do
       it "with a block returns true" do

--- a/spec/lib/hamster/hash/none_spec.rb
+++ b/spec/lib/hamster/hash/none_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/partition_spec.rb
+++ b/spec/lib/hamster/hash/partition_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/partition_spec.rb
+++ b/spec/lib/hamster/hash/partition_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H["a" => 1, "b" => 2, "c" => 3, "d" => 4] }
   let(:partition) { hash.partition { |k,v| v % 2 == 0 }}
 

--- a/spec/lib/hamster/hash/pretty_print_spec.rb
+++ b/spec/lib/hamster/hash/pretty_print_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 require "pp"
 require "stringio"

--- a/spec/lib/hamster/hash/pretty_print_spec.rb
+++ b/spec/lib/hamster/hash/pretty_print_spec.rb
@@ -2,7 +2,7 @@ require "hamster/hash"
 require "pp"
 require "stringio"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#pretty_print" do
     let(:hash) { Hamster::Hash.new(DeterministicHash.new(1,1) => "tin", DeterministicHash.new(2,2) => "earwax", DeterministicHash.new(3,3) => "neanderthal") }
     let(:stringio) { StringIO.new }

--- a/spec/lib/hamster/hash/put_spec.rb
+++ b/spec/lib/hamster/hash/put_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/put_spec.rb
+++ b/spec/lib/hamster/hash/put_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#[]=" do
     it 'raises error pointing to #put' do
       expect { subject[:A] = 'aye' }

--- a/spec/lib/hamster/hash/reduce_spec.rb
+++ b/spec/lib/hamster/hash/reduce_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   [:reduce, :inject].each do |method|
     describe "##{method}" do
       context "when empty" do

--- a/spec/lib/hamster/hash/reduce_spec.rb
+++ b/spec/lib/hamster/hash/reduce_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/reject_spec.rb
+++ b/spec/lib/hamster/hash/reject_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/reject_spec.rb
+++ b/spec/lib/hamster/hash/reject_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   [:reject, :delete_if].each do |method|
     describe "##{method}" do
       let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }

--- a/spec/lib/hamster/hash/reverse_each_spec.rb
+++ b/spec/lib/hamster/hash/reverse_each_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/reverse_each_spec.rb
+++ b/spec/lib/hamster/hash/reverse_each_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 
   describe "#reverse_each" do

--- a/spec/lib/hamster/hash/sample_spec.rb
+++ b/spec/lib/hamster/hash/sample_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/sample_spec.rb
+++ b/spec/lib/hamster/hash/sample_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#sample" do
     let(:hash) { Hamster::Hash.new((:a..:z).zip(1..26)) }
 

--- a/spec/lib/hamster/hash/select_spec.rb
+++ b/spec/lib/hamster/hash/select_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/select_spec.rb
+++ b/spec/lib/hamster/hash/select_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   [:select, :find_all, :keep_if].each do |method|
     describe "##{method}" do
       let(:original) { H["A" => "aye", "B" => "bee", "C" => "see"] }

--- a/spec/lib/hamster/hash/size_spec.rb
+++ b/spec/lib/hamster/hash/size_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/size_spec.rb
+++ b/spec/lib/hamster/hash/size_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   [:size, :length].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/hash/slice_spec.rb
+++ b/spec/lib/hamster/hash/slice_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/slice_spec.rb
+++ b/spec/lib/hamster/hash/slice_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H.new("A" => "aye", "B" => "bee", "C" => "see", nil => "NIL") }
 
   describe "#slice" do

--- a/spec/lib/hamster/hash/sort_spec.rb
+++ b/spec/lib/hamster/hash/sort_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/sort_spec.rb
+++ b/spec/lib/hamster/hash/sort_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H[a: 3, b: 2, c: 1] }
 
   describe "#sort" do

--- a/spec/lib/hamster/hash/store_spec.rb
+++ b/spec/lib/hamster/hash/store_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/store_spec.rb
+++ b/spec/lib/hamster/hash/store_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#store" do
     let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 

--- a/spec/lib/hamster/hash/subset_spec.rb
+++ b/spec/lib/hamster/hash/subset_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 RSpec.describe Hamster::Hash do

--- a/spec/lib/hamster/hash/superset_spec.rb
+++ b/spec/lib/hamster/hash/superset_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 RSpec.describe Hamster::Hash do

--- a/spec/lib/hamster/hash/take_spec.rb
+++ b/spec/lib/hamster/hash/take_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/take_spec.rb
+++ b/spec/lib/hamster/hash/take_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
 
   describe "#take" do

--- a/spec/lib/hamster/hash/to_a_spec.rb
+++ b/spec/lib/hamster/hash/to_a_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/to_a_spec.rb
+++ b/spec/lib/hamster/hash/to_a_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#to_a" do
     it "returns an Array of [key, value] pairs in same order as #each" do
       hash = H[:a => 1, 1 => :a, 3 => :b, :b => 5]

--- a/spec/lib/hamster/hash/to_hash_spec.rb
+++ b/spec/lib/hamster/hash/to_hash_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/to_hash_spec.rb
+++ b/spec/lib/hamster/hash/to_hash_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   [:to_hash, :to_h].each do |method|
     describe "##{method}" do
       it "converts an empty Hamster::Hash to an empty Ruby Hash" do

--- a/spec/lib/hamster/hash/to_proc_spec.rb
+++ b/spec/lib/hamster/hash/to_proc_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/to_proc_spec.rb
+++ b/spec/lib/hamster/hash/to_proc_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#to_proc" do
     context "on Hash without default proc" do
       let(:hash) { H.new("A" => "aye") }

--- a/spec/lib/hamster/hash/values_at_spec.rb
+++ b/spec/lib/hamster/hash/values_at_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 
 describe Hamster::Hash do

--- a/spec/lib/hamster/hash/values_at_spec.rb
+++ b/spec/lib/hamster/hash/values_at_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/hash"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#values_at" do
     context "on Hash without default proc" do
       let(:hash) { H[:a => 9, :b => 'a', :c => -10, :d => nil] }

--- a/spec/lib/hamster/hash/values_spec.rb
+++ b/spec/lib/hamster/hash/values_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/hash"
 require "hamster/set"
 

--- a/spec/lib/hamster/hash/values_spec.rb
+++ b/spec/lib/hamster/hash/values_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/hash"
 require "hamster/set"
 
-describe Hamster::Hash do
+RSpec.describe Hamster::Hash do
   describe "#values" do
     let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
     let(:result) { hash.values }

--- a/spec/lib/hamster/immutable/copying_spec.rb
+++ b/spec/lib/hamster/immutable/copying_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/immutable"
 
-describe Hamster::Immutable do
+RSpec.describe Hamster::Immutable do
   class Fixture
     include Hamster::Immutable
   end

--- a/spec/lib/hamster/immutable/copying_spec.rb
+++ b/spec/lib/hamster/immutable/copying_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/immutable"
 
 describe Hamster::Immutable do

--- a/spec/lib/hamster/immutable/immutable_spec.rb
+++ b/spec/lib/hamster/immutable/immutable_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/immutable"
 
 describe Hamster::Immutable do

--- a/spec/lib/hamster/immutable/immutable_spec.rb
+++ b/spec/lib/hamster/immutable/immutable_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/immutable"
 
-describe Hamster::Immutable do
+RSpec.describe Hamster::Immutable do
   describe "#immutable?" do
     describe "object constructed after its class becomes Immutable" do
       class Fixture

--- a/spec/lib/hamster/immutable/memoize_spec.rb
+++ b/spec/lib/hamster/immutable/memoize_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/immutable"
 
-describe Hamster::Immutable do
+RSpec.describe Hamster::Immutable do
   class Fixture
     include Hamster::Immutable
 

--- a/spec/lib/hamster/immutable/memoize_spec.rb
+++ b/spec/lib/hamster/immutable/memoize_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/immutable"
 
 describe Hamster::Immutable do

--- a/spec/lib/hamster/immutable/new_spec.rb
+++ b/spec/lib/hamster/immutable/new_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/immutable"
 
-describe Hamster::Immutable do
+RSpec.describe Hamster::Immutable do
   class NewPerson < Struct.new(:first, :last)
     include Hamster::Immutable
   end

--- a/spec/lib/hamster/immutable/new_spec.rb
+++ b/spec/lib/hamster/immutable/new_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/immutable"
 
 describe Hamster::Immutable do

--- a/spec/lib/hamster/immutable/transform_spec.rb
+++ b/spec/lib/hamster/immutable/transform_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/immutable"
 
-describe Hamster::Immutable do
+RSpec.describe Hamster::Immutable do
   class TransformPerson < Struct.new(:first, :last)
     include Hamster::Immutable
 

--- a/spec/lib/hamster/immutable/transform_spec.rb
+++ b/spec/lib/hamster/immutable/transform_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/immutable"
 
 describe Hamster::Immutable do

--- a/spec/lib/hamster/immutable/transform_unless_spec.rb
+++ b/spec/lib/hamster/immutable/transform_unless_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/immutable"
 
 describe Hamster::Immutable do

--- a/spec/lib/hamster/immutable/transform_unless_spec.rb
+++ b/spec/lib/hamster/immutable/transform_unless_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/immutable"
 
-describe Hamster::Immutable do
+RSpec.describe Hamster::Immutable do
   class TransformUnlessPerson < Struct.new(:first, :last)
     include Hamster::Immutable
 

--- a/spec/lib/hamster/list/add_spec.rb
+++ b/spec/lib/hamster/list/add_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/add_spec.rb
+++ b/spec/lib/hamster/list/add_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#add" do
     [
       [[], "A", ["A"]],

--- a/spec/lib/hamster/list/all_spec.rb
+++ b/spec/lib/hamster/list/all_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#all?" do
     context "on a really big list" do
       let(:list) { Hamster.interval(0, STACK_OVERFLOW_DEPTH) }

--- a/spec/lib/hamster/list/all_spec.rb
+++ b/spec/lib/hamster/list/all_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/any_spec.rb
+++ b/spec/lib/hamster/list/any_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#any?" do
     context "on a really big list" do
       let(:list) { Hamster.interval(0, STACK_OVERFLOW_DEPTH) }

--- a/spec/lib/hamster/list/any_spec.rb
+++ b/spec/lib/hamster/list/any_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/append_spec.rb
+++ b/spec/lib/hamster/list/append_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:append, :concat, :+].each do |method|
     describe "##{method}" do
       it "is lazy" do

--- a/spec/lib/hamster/list/append_spec.rb
+++ b/spec/lib/hamster/list/append_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/at_spec.rb
+++ b/spec/lib/hamster/list/at_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#at" do
     context "on a really big list" do
       let(:list) { Hamster.interval(0, STACK_OVERFLOW_DEPTH) }

--- a/spec/lib/hamster/list/at_spec.rb
+++ b/spec/lib/hamster/list/at_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/break_spec.rb
+++ b/spec/lib/hamster/list/break_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/break_spec.rb
+++ b/spec/lib/hamster/list/break_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#break" do
     it "is lazy" do
       expect { Hamster.stream { fail }.break { |item| false } }.not_to raise_error

--- a/spec/lib/hamster/list/cadr_spec.rb
+++ b/spec/lib/hamster/list/cadr_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [
     [[], :car, nil],
     [["A"], :car, "A"],

--- a/spec/lib/hamster/list/cadr_spec.rb
+++ b/spec/lib/hamster/list/cadr_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/chunk_spec.rb
+++ b/spec/lib/hamster/list/chunk_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/chunk_spec.rb
+++ b/spec/lib/hamster/list/chunk_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#chunk" do
     it "is lazy" do
       expect { Hamster.stream { fail }.chunk(2) }.not_to raise_error

--- a/spec/lib/hamster/list/clear_spec.rb
+++ b/spec/lib/hamster/list/clear_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#clear" do
     [
       [],

--- a/spec/lib/hamster/list/clear_spec.rb
+++ b/spec/lib/hamster/list/clear_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/combination_spec.rb
+++ b/spec/lib/hamster/list/combination_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#combination" do
     it "is lazy" do
       expect { Hamster.stream { fail }.combination(2) }.not_to raise_error

--- a/spec/lib/hamster/list/combination_spec.rb
+++ b/spec/lib/hamster/list/combination_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/compact_spec.rb
+++ b/spec/lib/hamster/list/compact_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#compact" do
     it "is lazy" do
       expect { Hamster.stream { fail }.compact }.not_to raise_error

--- a/spec/lib/hamster/list/compact_spec.rb
+++ b/spec/lib/hamster/list/compact_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/compare_spec.rb
+++ b/spec/lib/hamster/list/compare_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#<=>" do
     [
       [[], [1]],

--- a/spec/lib/hamster/list/compare_spec.rb
+++ b/spec/lib/hamster/list/compare_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/cons_spec.rb
+++ b/spec/lib/hamster/list/cons_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#cons" do
     [
       [[], "A", ["A"]],

--- a/spec/lib/hamster/list/cons_spec.rb
+++ b/spec/lib/hamster/list/cons_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/construction_spec.rb
+++ b/spec/lib/hamster/list/construction_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster do

--- a/spec/lib/hamster/list/construction_spec.rb
+++ b/spec/lib/hamster/list/construction_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster do
+RSpec.describe Hamster do
   describe ".list" do
     context "with no arguments" do
       it "always returns the same instance" do

--- a/spec/lib/hamster/list/copying_spec.rb
+++ b/spec/lib/hamster/list/copying_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/copying_spec.rb
+++ b/spec/lib/hamster/list/copying_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:dup, :clone].each do |method|
     [
       [],

--- a/spec/lib/hamster/list/count_spec.rb
+++ b/spec/lib/hamster/list/count_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#count" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/count_spec.rb
+++ b/spec/lib/hamster/list/count_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/cycle_spec.rb
+++ b/spec/lib/hamster/list/cycle_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster do

--- a/spec/lib/hamster/list/cycle_spec.rb
+++ b/spec/lib/hamster/list/cycle_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster do
+RSpec.describe Hamster do
   describe "#cycle" do
     it "is lazy" do
       expect { Hamster.stream { fail }.cycle }.not_to raise_error

--- a/spec/lib/hamster/list/delete_at_spec.rb
+++ b/spec/lib/hamster/list/delete_at_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#delete_at" do
     let(:list) { L[1,2,3,4,5] }
 

--- a/spec/lib/hamster/list/delete_at_spec.rb
+++ b/spec/lib/hamster/list/delete_at_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/delete_spec.rb
+++ b/spec/lib/hamster/list/delete_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/delete_spec.rb
+++ b/spec/lib/hamster/list/delete_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#delete" do
     it "removes elements that are #== to the argument" do
       expect(L[1,2,3].delete(1)).to eql(L[2,3])

--- a/spec/lib/hamster/list/drop_spec.rb
+++ b/spec/lib/hamster/list/drop_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#drop" do
     it "is lazy" do
       expect { Hamster.stream { fail }.drop(1) }.not_to raise_error

--- a/spec/lib/hamster/list/drop_spec.rb
+++ b/spec/lib/hamster/list/drop_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/drop_while_spec.rb
+++ b/spec/lib/hamster/list/drop_while_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/drop_while_spec.rb
+++ b/spec/lib/hamster/list/drop_while_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#drop_while" do
     it "is lazy" do
       expect { Hamster.stream { fail }.drop_while { false } }.not_to raise_error

--- a/spec/lib/hamster/list/each_slice_spec.rb
+++ b/spec/lib/hamster/list/each_slice_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:each_chunk, :each_slice].each do |method|
     describe "##{method}" do
       context "on a really big list" do

--- a/spec/lib/hamster/list/each_slice_spec.rb
+++ b/spec/lib/hamster/list/each_slice_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/each_spec.rb
+++ b/spec/lib/hamster/list/each_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#each" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/each_spec.rb
+++ b/spec/lib/hamster/list/each_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/each_with_index_spec.rb
+++ b/spec/lib/hamster/list/each_with_index_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/each_with_index_spec.rb
+++ b/spec/lib/hamster/list/each_with_index_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#each_with_index" do
     context "with no block" do
       let(:list) { L["A", "B", "C"] }

--- a/spec/lib/hamster/list/empty_spec.rb
+++ b/spec/lib/hamster/list/empty_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#empty?" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/empty_spec.rb
+++ b/spec/lib/hamster/list/empty_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/eql_spec.rb
+++ b/spec/lib/hamster/list/eql_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#eql?" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/eql_spec.rb
+++ b/spec/lib/hamster/list/eql_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/fill_spec.rb
+++ b/spec/lib/hamster/list/fill_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#fill" do
     let(:list) { L[1, 2, 3, 4, 5, 6] }
 

--- a/spec/lib/hamster/list/fill_spec.rb
+++ b/spec/lib/hamster/list/fill_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/find_all_spec.rb
+++ b/spec/lib/hamster/list/find_all_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   let(:list) { L[*values] }
   let(:found_list) { L[*found_values] }
 

--- a/spec/lib/hamster/list/find_all_spec.rb
+++ b/spec/lib/hamster/list/find_all_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/find_index_spec.rb
+++ b/spec/lib/hamster/list/find_index_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/find_index_spec.rb
+++ b/spec/lib/hamster/list/find_index_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:find_index, :index].each do |method|
     describe "##{method}" do
       context "on a really big list" do

--- a/spec/lib/hamster/list/find_spec.rb
+++ b/spec/lib/hamster/list/find_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:find, :detect].each do |method|
     describe "##{method}" do
       context "on a really big list" do

--- a/spec/lib/hamster/list/find_spec.rb
+++ b/spec/lib/hamster/list/find_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/flat_map_spec.rb
+++ b/spec/lib/hamster/list/flat_map_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   let(:list) { L[*values] }
 
   describe "#flat_map" do

--- a/spec/lib/hamster/list/flat_map_spec.rb
+++ b/spec/lib/hamster/list/flat_map_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/flatten_spec.rb
+++ b/spec/lib/hamster/list/flatten_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster do

--- a/spec/lib/hamster/list/flatten_spec.rb
+++ b/spec/lib/hamster/list/flatten_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster do
+RSpec.describe Hamster do
   describe "#flatten" do
     it "is lazy" do
       expect { Hamster.stream { fail }.flatten }.not_to raise_error

--- a/spec/lib/hamster/list/grep_spec.rb
+++ b/spec/lib/hamster/list/grep_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#grep" do
     it "is lazy" do
       expect { Hamster.stream { fail }.grep(Object) { |item| item } }.not_to raise_error

--- a/spec/lib/hamster/list/grep_spec.rb
+++ b/spec/lib/hamster/list/grep_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/group_by_spec.rb
+++ b/spec/lib/hamster/list/group_by_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:group_by, :group].each do |method|
     describe "##{method}" do
       context "on a really big list" do

--- a/spec/lib/hamster/list/group_by_spec.rb
+++ b/spec/lib/hamster/list/group_by_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/hash_spec.rb
+++ b/spec/lib/hamster/list/hash_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/hash_spec.rb
+++ b/spec/lib/hamster/list/hash_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#hash" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/head_spec.rb
+++ b/spec/lib/hamster/list/head_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:head, :first].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/list/head_spec.rb
+++ b/spec/lib/hamster/list/head_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/include_spec.rb
+++ b/spec/lib/hamster/list/include_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:include?, :member?].each do |method|
     describe "##{method}" do
       context "on a really big list" do

--- a/spec/lib/hamster/list/include_spec.rb
+++ b/spec/lib/hamster/list/include_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/index_spec.rb
+++ b/spec/lib/hamster/list/index_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#index" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/index_spec.rb
+++ b/spec/lib/hamster/list/index_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/indices_spec.rb
+++ b/spec/lib/hamster/list/indices_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#indices" do
     context "when called with a block" do
       it "is lazy" do

--- a/spec/lib/hamster/list/indices_spec.rb
+++ b/spec/lib/hamster/list/indices_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/init_spec.rb
+++ b/spec/lib/hamster/list/init_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/init_spec.rb
+++ b/spec/lib/hamster/list/init_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#init" do
     it "is lazy" do
       expect { Hamster.stream { false }.init }.not_to raise_error

--- a/spec/lib/hamster/list/inits_spec.rb
+++ b/spec/lib/hamster/list/inits_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#inits" do
     it "is lazy" do
       expect { Hamster.stream { fail }.inits }.not_to raise_error

--- a/spec/lib/hamster/list/inits_spec.rb
+++ b/spec/lib/hamster/list/inits_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/insert_spec.rb
+++ b/spec/lib/hamster/list/insert_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#insert" do
     let(:original) { L[1, 2, 3] }
 

--- a/spec/lib/hamster/list/insert_spec.rb
+++ b/spec/lib/hamster/list/insert_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/inspect_spec.rb
+++ b/spec/lib/hamster/list/inspect_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/inspect_spec.rb
+++ b/spec/lib/hamster/list/inspect_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#inspect" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/intersperse_spec.rb
+++ b/spec/lib/hamster/list/intersperse_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/intersperse_spec.rb
+++ b/spec/lib/hamster/list/intersperse_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#intersperse" do
     it "is lazy" do
       expect { Hamster.stream { fail }.intersperse("") }.not_to raise_error

--- a/spec/lib/hamster/list/join_spec.rb
+++ b/spec/lib/hamster/list/join_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/join_spec.rb
+++ b/spec/lib/hamster/list/join_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#join" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/last_spec.rb
+++ b/spec/lib/hamster/list/last_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/last_spec.rb
+++ b/spec/lib/hamster/list/last_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#last" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/ltlt_spec.rb
+++ b/spec/lib/hamster/list/ltlt_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#<<" do
     it "adds an item onto the end of a list" do
       list = L["a", "b"]

--- a/spec/lib/hamster/list/ltlt_spec.rb
+++ b/spec/lib/hamster/list/ltlt_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/map_spec.rb
+++ b/spec/lib/hamster/list/map_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:map, :collect].each do |method|
     describe "##{method}" do
       it "is lazy" do

--- a/spec/lib/hamster/list/map_spec.rb
+++ b/spec/lib/hamster/list/map_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/maximum_spec.rb
+++ b/spec/lib/hamster/list/maximum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#max" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/maximum_spec.rb
+++ b/spec/lib/hamster/list/maximum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/merge_by_spec.rb
+++ b/spec/lib/hamster/list/merge_by_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/merge_by_spec.rb
+++ b/spec/lib/hamster/list/merge_by_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   context "without a comparator" do
     context "on an empty list" do
       it "returns an empty list" do

--- a/spec/lib/hamster/list/merge_spec.rb
+++ b/spec/lib/hamster/list/merge_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   context "without a comparator" do
     context "on an empty list" do
       subject { L.empty }

--- a/spec/lib/hamster/list/merge_spec.rb
+++ b/spec/lib/hamster/list/merge_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/minimum_spec.rb
+++ b/spec/lib/hamster/list/minimum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/minimum_spec.rb
+++ b/spec/lib/hamster/list/minimum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#min" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/multithreading_spec.rb
+++ b/spec/lib/hamster/list/multithreading_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 require "concurrent/atomics"
 

--- a/spec/lib/hamster/list/multithreading_spec.rb
+++ b/spec/lib/hamster/list/multithreading_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/list"
 require "concurrent/atomics"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   it "ensures each node of a lazy list will only be realized on ONE thread, even when accessed by multiple threads" do
     counter = Concurrent::AtomicReference.new(0)
     list = (1..10000).to_list.map { |x| counter.update { |count| count + 1 }; x * 2 }

--- a/spec/lib/hamster/list/none_spec.rb
+++ b/spec/lib/hamster/list/none_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/none_spec.rb
+++ b/spec/lib/hamster/list/none_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#none?" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/one_spec.rb
+++ b/spec/lib/hamster/list/one_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/one_spec.rb
+++ b/spec/lib/hamster/list/one_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#one?" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/partition_spec.rb
+++ b/spec/lib/hamster/list/partition_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 require "thread"
 

--- a/spec/lib/hamster/list/partition_spec.rb
+++ b/spec/lib/hamster/list/partition_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/list"
 require "thread"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#partition" do
     it "is lazy" do
       expect { Hamster.stream { fail }.partition }.not_to raise_error

--- a/spec/lib/hamster/list/permutation_spec.rb
+++ b/spec/lib/hamster/list/permutation_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#permutation" do
     let(:list) { L[1,2,3,4] }
 

--- a/spec/lib/hamster/list/permutation_spec.rb
+++ b/spec/lib/hamster/list/permutation_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/pop_spec.rb
+++ b/spec/lib/hamster/list/pop_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/pop_spec.rb
+++ b/spec/lib/hamster/list/pop_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   let(:list) { L[*values] }
 
   describe "#pop" do

--- a/spec/lib/hamster/list/product_spec.rb
+++ b/spec/lib/hamster/list/product_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#product" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/product_spec.rb
+++ b/spec/lib/hamster/list/product_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/reduce_spec.rb
+++ b/spec/lib/hamster/list/reduce_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:reduce, :inject].each do |method|
     describe "##{method}" do
       context "on a really big list" do

--- a/spec/lib/hamster/list/reduce_spec.rb
+++ b/spec/lib/hamster/list/reduce_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/reject_spec.rb
+++ b/spec/lib/hamster/list/reject_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:reject, :delete_if].each do |method|
     describe "##{method}" do
       it "is lazy" do

--- a/spec/lib/hamster/list/reject_spec.rb
+++ b/spec/lib/hamster/list/reject_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/reverse_spec.rb
+++ b/spec/lib/hamster/list/reverse_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#reverse" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/reverse_spec.rb
+++ b/spec/lib/hamster/list/reverse_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/rotate_spec.rb
+++ b/spec/lib/hamster/list/rotate_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/rotate_spec.rb
+++ b/spec/lib/hamster/list/rotate_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#rotate" do
     let(:list) { L[1,2,3,4,5] }
 

--- a/spec/lib/hamster/list/sample_spec.rb
+++ b/spec/lib/hamster/list/sample_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#sample" do
     let(:list) { (1..10).to_list }
 

--- a/spec/lib/hamster/list/sample_spec.rb
+++ b/spec/lib/hamster/list/sample_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/select_spec.rb
+++ b/spec/lib/hamster/list/select_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/select_spec.rb
+++ b/spec/lib/hamster/list/select_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   let(:list) { L[*values] }
   let(:selected_list) { L[*selected_values] }
 

--- a/spec/lib/hamster/list/size_spec.rb
+++ b/spec/lib/hamster/list/size_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:size, :length].each do |method|
     describe "##{method}" do
       context "on a really big list" do

--- a/spec/lib/hamster/list/size_spec.rb
+++ b/spec/lib/hamster/list/size_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/slice_spec.rb
+++ b/spec/lib/hamster/list/slice_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   let(:list) { L[1,2,3,4] }
   let(:big)  { (1..10000).to_list }
 

--- a/spec/lib/hamster/list/slice_spec.rb
+++ b/spec/lib/hamster/list/slice_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/sorting_spec.rb
+++ b/spec/lib/hamster/list/sorting_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/sorting_spec.rb
+++ b/spec/lib/hamster/list/sorting_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [
     [:sort, ->(left, right) { left.length <=> right.length }],
     [:sort_by, ->(item) { item.length }],

--- a/spec/lib/hamster/list/span_spec.rb
+++ b/spec/lib/hamster/list/span_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe "Hamster::list#span" do
+RSpec.describe "Hamster::list#span" do
   it "is lazy" do
     expect { Hamster.stream { |item| fail }.span { true } }.not_to raise_error
   end

--- a/spec/lib/hamster/list/span_spec.rb
+++ b/spec/lib/hamster/list/span_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe "Hamster::list#span" do

--- a/spec/lib/hamster/list/split_at_spec.rb
+++ b/spec/lib/hamster/list/split_at_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#split_at" do
     it "is lazy" do
       expect { Hamster.stream { fail }.split_at(1) }.not_to raise_error

--- a/spec/lib/hamster/list/split_at_spec.rb
+++ b/spec/lib/hamster/list/split_at_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/subsequences_spec.rb
+++ b/spec/lib/hamster/list/subsequences_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#subsequences" do
     let(:list) { L[1,2,3,4,5] }
 

--- a/spec/lib/hamster/list/subsequences_spec.rb
+++ b/spec/lib/hamster/list/subsequences_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/sum_spec.rb
+++ b/spec/lib/hamster/list/sum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#sum" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/sum_spec.rb
+++ b/spec/lib/hamster/list/sum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/tail_spec.rb
+++ b/spec/lib/hamster/list/tail_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/tail_spec.rb
+++ b/spec/lib/hamster/list/tail_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#tail" do
     context "on a really big list" do
       it "doesn't run out of stack" do

--- a/spec/lib/hamster/list/tails_spec.rb
+++ b/spec/lib/hamster/list/tails_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/tails_spec.rb
+++ b/spec/lib/hamster/list/tails_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#tails" do
     it "is lazy" do
       expect { Hamster.stream { fail }.tails }.not_to raise_error

--- a/spec/lib/hamster/list/take_spec.rb
+++ b/spec/lib/hamster/list/take_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#take" do
     it "is lazy" do
       expect { Hamster.stream { fail }.take(1) }.not_to raise_error

--- a/spec/lib/hamster/list/take_spec.rb
+++ b/spec/lib/hamster/list/take_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/take_while_spec.rb
+++ b/spec/lib/hamster/list/take_while_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#take_while" do
     it "is lazy" do
       expect { Hamster.stream { fail }.take_while { false } }.not_to raise_error

--- a/spec/lib/hamster/list/take_while_spec.rb
+++ b/spec/lib/hamster/list/take_while_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/to_a_spec.rb
+++ b/spec/lib/hamster/list/to_a_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:to_a, :entries].each do |method|
     describe "##{method}" do
       context "on a really big list" do

--- a/spec/lib/hamster/list/to_a_spec.rb
+++ b/spec/lib/hamster/list/to_a_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/to_ary_spec.rb
+++ b/spec/lib/hamster/list/to_ary_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   let(:list) { L["A", "B", "C", "D"] }
 
   describe "#to_ary" do

--- a/spec/lib/hamster/list/to_ary_spec.rb
+++ b/spec/lib/hamster/list/to_ary_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/to_list_spec.rb
+++ b/spec/lib/hamster/list/to_list_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#to_list" do
     [
       [],

--- a/spec/lib/hamster/list/to_list_spec.rb
+++ b/spec/lib/hamster/list/to_list_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/to_set_spec.rb
+++ b/spec/lib/hamster/list/to_set_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/list"
 require "hamster/set"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#to_set" do
     [
       [],

--- a/spec/lib/hamster/list/to_set_spec.rb
+++ b/spec/lib/hamster/list/to_set_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 require "hamster/set"
 

--- a/spec/lib/hamster/list/transpose_spec.rb
+++ b/spec/lib/hamster/list/transpose_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/transpose_spec.rb
+++ b/spec/lib/hamster/list/transpose_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#transpose" do
     it "takes a list of lists and returns a list of all the first elements, all the 2nd elements, and so on" do
       expect(L[L[1, 'a'], L[2, 'b'], L[3, 'c']].transpose).to eql(L[L[1, 2, 3], L["a", "b", "c"]])

--- a/spec/lib/hamster/list/union_spec.rb
+++ b/spec/lib/hamster/list/union_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/union_spec.rb
+++ b/spec/lib/hamster/list/union_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   [:union, :|].each do |method|
     describe "##{method}" do
       it "is lazy" do

--- a/spec/lib/hamster/list/uniq_spec.rb
+++ b/spec/lib/hamster/list/uniq_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/uniq_spec.rb
+++ b/spec/lib/hamster/list/uniq_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#uniq" do
     it "is lazy" do
       expect { Hamster.stream { fail }.uniq }.not_to raise_error

--- a/spec/lib/hamster/list/zip_spec.rb
+++ b/spec/lib/hamster/list/zip_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/list"
 
 describe Hamster::List do

--- a/spec/lib/hamster/list/zip_spec.rb
+++ b/spec/lib/hamster/list/zip_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/list"
 
-describe Hamster::List do
+RSpec.describe Hamster::List do
   describe "#zip" do
     it "is lazy" do
       expect { Hamster.stream { fail }.zip(Hamster.stream { fail }) }.not_to raise_error

--- a/spec/lib/hamster/nested/construction_spec.rb
+++ b/spec/lib/hamster/nested/construction_spec.rb
@@ -2,7 +2,7 @@ require "hamster/nested"
 require "hamster/deque"
 require "set"
 
-describe Hamster do
+RSpec.describe Hamster do
   expectations = [
     # [Ruby, Hamster]
     [ { "a" => 1,

--- a/spec/lib/hamster/nested/construction_spec.rb
+++ b/spec/lib/hamster/nested/construction_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/nested"
 require "hamster/deque"
 require "set"

--- a/spec/lib/hamster/set/add_spec.rb
+++ b/spec/lib/hamster/set/add_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/add_spec.rb
+++ b/spec/lib/hamster/set/add_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   let(:original) { S["A", "B", "C"] }
 
   [:add, :<<].each do |method|

--- a/spec/lib/hamster/set/all_spec.rb
+++ b/spec/lib/hamster/set/all_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/all_spec.rb
+++ b/spec/lib/hamster/set/all_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#all?" do
     context "when empty" do
       it "with a block returns true" do

--- a/spec/lib/hamster/set/any_spec.rb
+++ b/spec/lib/hamster/set/any_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/any_spec.rb
+++ b/spec/lib/hamster/set/any_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#any?" do
     context "when empty" do
       it "with a block returns false" do

--- a/spec/lib/hamster/set/clear_spec.rb
+++ b/spec/lib/hamster/set/clear_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#clear" do
     [
       [],

--- a/spec/lib/hamster/set/clear_spec.rb
+++ b/spec/lib/hamster/set/clear_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/compact_spec.rb
+++ b/spec/lib/hamster/set/compact_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#compact" do
     [
       [[], []],

--- a/spec/lib/hamster/set/compact_spec.rb
+++ b/spec/lib/hamster/set/compact_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/construction_spec.rb
+++ b/spec/lib/hamster/set/construction_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/construction_spec.rb
+++ b/spec/lib/hamster/set/construction_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe ".set" do
     context "with no values" do
       it "returns the empty set" do

--- a/spec/lib/hamster/set/copying_spec.rb
+++ b/spec/lib/hamster/set/copying_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/copying_spec.rb
+++ b/spec/lib/hamster/set/copying_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:dup, :clone].each do |method|
     let(:set) { S["A", "B", "C"] }
 

--- a/spec/lib/hamster/set/count_spec.rb
+++ b/spec/lib/hamster/set/count_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#count" do
     [
       [[], 0],

--- a/spec/lib/hamster/set/count_spec.rb
+++ b/spec/lib/hamster/set/count_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/delete_spec.rb
+++ b/spec/lib/hamster/set/delete_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   let(:set) { S["A", "B", "C"] }
 
   describe "#delete" do

--- a/spec/lib/hamster/set/delete_spec.rb
+++ b/spec/lib/hamster/set/delete_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/difference_spec.rb
+++ b/spec/lib/hamster/set/difference_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/difference_spec.rb
+++ b/spec/lib/hamster/set/difference_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:difference, :subtract, :-].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/set/disjoint_spec.rb
+++ b/spec/lib/hamster/set/disjoint_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#disjoint?" do
     [
       [[], [], true],

--- a/spec/lib/hamster/set/disjoint_spec.rb
+++ b/spec/lib/hamster/set/disjoint_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/each_spec.rb
+++ b/spec/lib/hamster/set/each_spec.rb
@@ -1,7 +1,7 @@
 require "set"
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   let(:set) { S["A", "B", "C"] }
 
   describe "#each" do

--- a/spec/lib/hamster/set/each_spec.rb
+++ b/spec/lib/hamster/set/each_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "set"
 require "hamster/set"
 

--- a/spec/lib/hamster/set/empty_spec.rb
+++ b/spec/lib/hamster/set/empty_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/empty_spec.rb
+++ b/spec/lib/hamster/set/empty_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#empty?" do
     [
       [[], true],

--- a/spec/lib/hamster/set/eqeq_spec.rb
+++ b/spec/lib/hamster/set/eqeq_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "set"
 require "hamster/set"
 

--- a/spec/lib/hamster/set/eqeq_spec.rb
+++ b/spec/lib/hamster/set/eqeq_spec.rb
@@ -1,7 +1,7 @@
 require "set"
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   let(:set) { S[*values] }
   let(:comparison) { S[*comparison_values] }
 

--- a/spec/lib/hamster/set/eql_spec.rb
+++ b/spec/lib/hamster/set/eql_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "set"
 require "hamster/set"
 

--- a/spec/lib/hamster/set/eql_spec.rb
+++ b/spec/lib/hamster/set/eql_spec.rb
@@ -1,7 +1,7 @@
 require "set"
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   let(:set) { S[*values] }
   let(:comparison) { S[*comparison_values] }
 

--- a/spec/lib/hamster/set/exclusion_spec.rb
+++ b/spec/lib/hamster/set/exclusion_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:exclusion, :^].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/set/exclusion_spec.rb
+++ b/spec/lib/hamster/set/exclusion_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/find_spec.rb
+++ b/spec/lib/hamster/set/find_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:find, :detect].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/set/find_spec.rb
+++ b/spec/lib/hamster/set/find_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/first_spec.rb
+++ b/spec/lib/hamster/set/first_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#first" do
     context "on an empty set" do
       it "returns nil" do

--- a/spec/lib/hamster/set/first_spec.rb
+++ b/spec/lib/hamster/set/first_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/flatten_spec.rb
+++ b/spec/lib/hamster/set/flatten_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster do
+RSpec.describe Hamster do
   describe "#flatten" do
     [
       [["A"], ["A"]],

--- a/spec/lib/hamster/set/flatten_spec.rb
+++ b/spec/lib/hamster/set/flatten_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster do

--- a/spec/lib/hamster/set/grep_spec.rb
+++ b/spec/lib/hamster/set/grep_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   let(:set) { S[*values] }
 
   describe "#grep" do

--- a/spec/lib/hamster/set/grep_spec.rb
+++ b/spec/lib/hamster/set/grep_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/grep_v_spec.rb
+++ b/spec/lib/hamster/set/grep_v_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   let(:set) { S[*values] }
 
   describe "#grep_v" do

--- a/spec/lib/hamster/set/grep_v_spec.rb
+++ b/spec/lib/hamster/set/grep_v_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/group_by_spec.rb
+++ b/spec/lib/hamster/set/group_by_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:group_by, :group, :classify].each do |method|
     describe "##{method}" do
       context "with a block" do

--- a/spec/lib/hamster/set/group_by_spec.rb
+++ b/spec/lib/hamster/set/group_by_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/hash_spec.rb
+++ b/spec/lib/hamster/set/hash_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/hash_spec.rb
+++ b/spec/lib/hamster/set/hash_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#hash" do
     context "on an empty set" do
       it "returns 0" do

--- a/spec/lib/hamster/set/immutable_spec.rb
+++ b/spec/lib/hamster/set/immutable_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/immutable"
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   it "includes Immutable" do
     expect(Hamster::Set).to include(Hamster::Immutable)
   end

--- a/spec/lib/hamster/set/immutable_spec.rb
+++ b/spec/lib/hamster/set/immutable_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/immutable"
 require "hamster/set"
 

--- a/spec/lib/hamster/set/include_spec.rb
+++ b/spec/lib/hamster/set/include_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 require 'set'
 

--- a/spec/lib/hamster/set/include_spec.rb
+++ b/spec/lib/hamster/set/include_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/set"
 require 'set'
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:include?, :member?].each do |method|
     describe "##{method}" do
       let(:set) { S["A", "B", "C", 2.0, nil] }

--- a/spec/lib/hamster/set/inspect_spec.rb
+++ b/spec/lib/hamster/set/inspect_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/inspect_spec.rb
+++ b/spec/lib/hamster/set/inspect_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#inspect" do
     [
       [[], "Hamster::Set[]"],

--- a/spec/lib/hamster/set/intersect_spec.rb
+++ b/spec/lib/hamster/set/intersect_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/intersect_spec.rb
+++ b/spec/lib/hamster/set/intersect_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#intersect?" do
     [
       [[], [], false],

--- a/spec/lib/hamster/set/intersection_spec.rb
+++ b/spec/lib/hamster/set/intersection_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/intersection_spec.rb
+++ b/spec/lib/hamster/set/intersection_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:intersection, :&].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/set/join_spec.rb
+++ b/spec/lib/hamster/set/join_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/join_spec.rb
+++ b/spec/lib/hamster/set/join_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#join" do
     context "with a separator" do
       [

--- a/spec/lib/hamster/set/map_spec.rb
+++ b/spec/lib/hamster/set/map_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/map_spec.rb
+++ b/spec/lib/hamster/set/map_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:map, :collect].each do |method|
     describe "##{method}" do
       context "when empty" do

--- a/spec/lib/hamster/set/marshal_spec.rb
+++ b/spec/lib/hamster/set/marshal_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/marshal_spec.rb
+++ b/spec/lib/hamster/set/marshal_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#marshal_dump/#marshal_load" do
     let(:ruby) { File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"]) }
 

--- a/spec/lib/hamster/set/maximum_spec.rb
+++ b/spec/lib/hamster/set/maximum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/maximum_spec.rb
+++ b/spec/lib/hamster/set/maximum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#max" do
     context "with a block" do
       [

--- a/spec/lib/hamster/set/minimum_spec.rb
+++ b/spec/lib/hamster/set/minimum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/minimum_spec.rb
+++ b/spec/lib/hamster/set/minimum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#min" do
     context "with a block" do
       [

--- a/spec/lib/hamster/set/new_spec.rb
+++ b/spec/lib/hamster/set/new_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/new_spec.rb
+++ b/spec/lib/hamster/set/new_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe ".new" do
     it "initializes a new set" do
       set = S.new([1,2,3])

--- a/spec/lib/hamster/set/none_spec.rb
+++ b/spec/lib/hamster/set/none_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/none_spec.rb
+++ b/spec/lib/hamster/set/none_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#none?" do
     context "when empty" do
       it "with a block returns true" do

--- a/spec/lib/hamster/set/one_spec.rb
+++ b/spec/lib/hamster/set/one_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/one_spec.rb
+++ b/spec/lib/hamster/set/one_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#one?" do
     context "when empty" do
       it "with a block returns false" do

--- a/spec/lib/hamster/set/partition_spec.rb
+++ b/spec/lib/hamster/set/partition_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#partition" do
     [
       [[], [], []],

--- a/spec/lib/hamster/set/partition_spec.rb
+++ b/spec/lib/hamster/set/partition_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/product_spec.rb
+++ b/spec/lib/hamster/set/product_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#product" do
     [
       [[], 1],

--- a/spec/lib/hamster/set/product_spec.rb
+++ b/spec/lib/hamster/set/product_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/reduce_spec.rb
+++ b/spec/lib/hamster/set/reduce_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/reduce_spec.rb
+++ b/spec/lib/hamster/set/reduce_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:reduce, :inject].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/set/reject_spec.rb
+++ b/spec/lib/hamster/set/reject_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/reject_spec.rb
+++ b/spec/lib/hamster/set/reject_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:reject, :delete_if].each do |method|
     describe "##{method}" do
       let(:set) { S["A", "B", "C"] }

--- a/spec/lib/hamster/set/reverse_each_spec.rb
+++ b/spec/lib/hamster/set/reverse_each_spec.rb
@@ -1,7 +1,7 @@
 require "set"
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   let(:set) { S["A", "B", "C"] }
 
   describe "#reverse_each" do

--- a/spec/lib/hamster/set/reverse_each_spec.rb
+++ b/spec/lib/hamster/set/reverse_each_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "set"
 require "hamster/set"
 

--- a/spec/lib/hamster/set/sample_spec.rb
+++ b/spec/lib/hamster/set/sample_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/sample_spec.rb
+++ b/spec/lib/hamster/set/sample_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#sample" do
     let(:set) { S.new(1..10) }
 

--- a/spec/lib/hamster/set/select_spec.rb
+++ b/spec/lib/hamster/set/select_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:select, :find_all].each do |method|
     describe "##{method}" do
       let(:set) { S["A", "B", "C"] }

--- a/spec/lib/hamster/set/select_spec.rb
+++ b/spec/lib/hamster/set/select_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/size_spec.rb
+++ b/spec/lib/hamster/set/size_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/size_spec.rb
+++ b/spec/lib/hamster/set/size_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:size, :length].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/set/sorting_spec.rb
+++ b/spec/lib/hamster/set/sorting_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/sorting_spec.rb
+++ b/spec/lib/hamster/set/sorting_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [
     [:sort, ->(left, right) { left.length <=> right.length }],
     [:sort_by, ->(item) { item.length }],

--- a/spec/lib/hamster/set/subset_spec.rb
+++ b/spec/lib/hamster/set/subset_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/subset_spec.rb
+++ b/spec/lib/hamster/set/subset_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:subset?, :<=].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/set/sum_spec.rb
+++ b/spec/lib/hamster/set/sum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/sum_spec.rb
+++ b/spec/lib/hamster/set/sum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#sum" do
     [
       [[], 0],

--- a/spec/lib/hamster/set/superset_spec.rb
+++ b/spec/lib/hamster/set/superset_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/superset_spec.rb
+++ b/spec/lib/hamster/set/superset_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:superset?, :>=].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/set/to_a_spec.rb
+++ b/spec/lib/hamster/set/to_a_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:to_a, :entries].each do |method|
     describe "##{method}" do
       ('a'..'z').each do |letter|

--- a/spec/lib/hamster/set/to_a_spec.rb
+++ b/spec/lib/hamster/set/to_a_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/to_list_spec.rb
+++ b/spec/lib/hamster/set/to_list_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/set"
 require "hamster/list"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#to_list" do
     [
       [],

--- a/spec/lib/hamster/set/to_list_spec.rb
+++ b/spec/lib/hamster/set/to_list_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 require "hamster/list"
 

--- a/spec/lib/hamster/set/to_set_spec.rb
+++ b/spec/lib/hamster/set/to_set_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/to_set_spec.rb
+++ b/spec/lib/hamster/set/to_set_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   describe "#to_set" do
     [
       [],

--- a/spec/lib/hamster/set/union_spec.rb
+++ b/spec/lib/hamster/set/union_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::Set do

--- a/spec/lib/hamster/set/union_spec.rb
+++ b/spec/lib/hamster/set/union_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::Set do
+RSpec.describe Hamster::Set do
   [:union, :|, :+, :merge].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/sorted_set/above_spec.rb
+++ b/spec/lib/hamster/sorted_set/above_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/above_spec.rb
+++ b/spec/lib/hamster/sorted_set/above_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#above" do
     context "when called without a block" do
       it "returns a sorted set of all items higher than the argument" do

--- a/spec/lib/hamster/sorted_set/add_spec.rb
+++ b/spec/lib/hamster/sorted_set/add_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/add_spec.rb
+++ b/spec/lib/hamster/sorted_set/add_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   let(:sorted_set) { SS["B", "C", "D"] }
 
   [:add, :<<].each do |method|

--- a/spec/lib/hamster/sorted_set/at_spec.rb
+++ b/spec/lib/hamster/sorted_set/at_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/at_spec.rb
+++ b/spec/lib/hamster/sorted_set/at_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#at" do
     [
       [[], 10, nil],

--- a/spec/lib/hamster/sorted_set/below_spec.rb
+++ b/spec/lib/hamster/sorted_set/below_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/below_spec.rb
+++ b/spec/lib/hamster/sorted_set/below_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#below" do
     context "when called without a block" do
       it "returns a sorted set of all items lower than the argument" do

--- a/spec/lib/hamster/sorted_set/between_spec.rb
+++ b/spec/lib/hamster/sorted_set/between_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/between_spec.rb
+++ b/spec/lib/hamster/sorted_set/between_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#between" do
     context "when called without a block" do
       it "returns a sorted set of all items from the first argument to the second" do

--- a/spec/lib/hamster/sorted_set/clear_spec.rb
+++ b/spec/lib/hamster/sorted_set/clear_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#clear" do
     [
       [],

--- a/spec/lib/hamster/sorted_set/clear_spec.rb
+++ b/spec/lib/hamster/sorted_set/clear_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/copying_spec.rb
+++ b/spec/lib/hamster/sorted_set/copying_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/copying_spec.rb
+++ b/spec/lib/hamster/sorted_set/copying_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:dup, :clone].each do |method|
     [
       [],

--- a/spec/lib/hamster/sorted_set/delete_at_spec.rb
+++ b/spec/lib/hamster/sorted_set/delete_at_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/delete_at_spec.rb
+++ b/spec/lib/hamster/sorted_set/delete_at_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#delete_at" do
     let(:sorted_set) { SS[1,2,3,4,5] }
 

--- a/spec/lib/hamster/sorted_set/delete_spec.rb
+++ b/spec/lib/hamster/sorted_set/delete_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/delete_spec.rb
+++ b/spec/lib/hamster/sorted_set/delete_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   let(:sorted_set) { SS["A", "B", "C"] }
 
   describe "#delete" do

--- a/spec/lib/hamster/sorted_set/difference_spec.rb
+++ b/spec/lib/hamster/sorted_set/difference_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/difference_spec.rb
+++ b/spec/lib/hamster/sorted_set/difference_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:difference, :subtract, :-].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/sorted_set/disjoint_spec.rb
+++ b/spec/lib/hamster/sorted_set/disjoint_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#disjoint?" do
     [
       [[], [], true],

--- a/spec/lib/hamster/sorted_set/disjoint_spec.rb
+++ b/spec/lib/hamster/sorted_set/disjoint_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/drop_spec.rb
+++ b/spec/lib/hamster/sorted_set/drop_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/drop_spec.rb
+++ b/spec/lib/hamster/sorted_set/drop_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#drop" do
     [
       [[], 0, []],

--- a/spec/lib/hamster/sorted_set/drop_while_spec.rb
+++ b/spec/lib/hamster/sorted_set/drop_while_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/drop_while_spec.rb
+++ b/spec/lib/hamster/sorted_set/drop_while_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#drop_while" do
     [
       [[], []],

--- a/spec/lib/hamster/sorted_set/each_spec.rb
+++ b/spec/lib/hamster/sorted_set/each_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/each_spec.rb
+++ b/spec/lib/hamster/sorted_set/each_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#each" do
     context "with no block" do
       let(:sorted_set) { SS["A", "B", "C"] }

--- a/spec/lib/hamster/sorted_set/empty_spec.rb
+++ b/spec/lib/hamster/sorted_set/empty_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#empty?" do
     [
       [[], true],

--- a/spec/lib/hamster/sorted_set/empty_spec.rb
+++ b/spec/lib/hamster/sorted_set/empty_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/eql_spec.rb
+++ b/spec/lib/hamster/sorted_set/eql_spec.rb
@@ -1,7 +1,7 @@
 require "set"
 require "hamster/set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   let(:set) { SS[*values] }
   let(:comparison) { SS[*comparison_values] }
 

--- a/spec/lib/hamster/sorted_set/eql_spec.rb
+++ b/spec/lib/hamster/sorted_set/eql_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "set"
 require "hamster/set"
 

--- a/spec/lib/hamster/sorted_set/exclusion_spec.rb
+++ b/spec/lib/hamster/sorted_set/exclusion_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:exclusion, :^].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/sorted_set/exclusion_spec.rb
+++ b/spec/lib/hamster/sorted_set/exclusion_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/fetch_spec.rb
+++ b/spec/lib/hamster/sorted_set/fetch_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/fetch_spec.rb
+++ b/spec/lib/hamster/sorted_set/fetch_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#fetch" do
     let(:sorted_set) { SS['a', 'b', 'c'] }
 

--- a/spec/lib/hamster/sorted_set/find_index_spec.rb
+++ b/spec/lib/hamster/sorted_set/find_index_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:find_index, :index].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/sorted_set/find_index_spec.rb
+++ b/spec/lib/hamster/sorted_set/find_index_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/first_spec.rb
+++ b/spec/lib/hamster/sorted_set/first_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/first_spec.rb
+++ b/spec/lib/hamster/sorted_set/first_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#first" do
     [
       [[], nil],

--- a/spec/lib/hamster/sorted_set/from_spec.rb
+++ b/spec/lib/hamster/sorted_set/from_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#from" do
     context "when called without a block" do
       it "returns a sorted set of all items equal to or greater than the argument" do

--- a/spec/lib/hamster/sorted_set/from_spec.rb
+++ b/spec/lib/hamster/sorted_set/from_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/group_by_spec.rb
+++ b/spec/lib/hamster/sorted_set/group_by_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:group_by, :group, :classify].each do |method|
     describe "##{method}" do
       context "with a block" do

--- a/spec/lib/hamster/sorted_set/group_by_spec.rb
+++ b/spec/lib/hamster/sorted_set/group_by_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/include_spec.rb
+++ b/spec/lib/hamster/sorted_set/include_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/include_spec.rb
+++ b/spec/lib/hamster/sorted_set/include_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:include?, :member?].each do |method|
     describe "##{method}" do
       let(:sorted_set) { SS[1, 2, 3, 4.0] }

--- a/spec/lib/hamster/sorted_set/inspect_spec.rb
+++ b/spec/lib/hamster/sorted_set/inspect_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/inspect_spec.rb
+++ b/spec/lib/hamster/sorted_set/inspect_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#inspect" do
     [
       [[], "Hamster::SortedSet[]"],

--- a/spec/lib/hamster/sorted_set/intersect_spec.rb
+++ b/spec/lib/hamster/sorted_set/intersect_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/intersect_spec.rb
+++ b/spec/lib/hamster/sorted_set/intersect_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#intersect?" do
     [
       [[], [], false],

--- a/spec/lib/hamster/sorted_set/intersection_spec.rb
+++ b/spec/lib/hamster/sorted_set/intersection_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/intersection_spec.rb
+++ b/spec/lib/hamster/sorted_set/intersection_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:intersection, :&].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/sorted_set/last_spec.rb
+++ b/spec/lib/hamster/sorted_set/last_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/last_spec.rb
+++ b/spec/lib/hamster/sorted_set/last_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   let(:sorted_set) { SS[*values] }
 
   describe "#last" do

--- a/spec/lib/hamster/sorted_set/map_spec.rb
+++ b/spec/lib/hamster/sorted_set/map_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:map, :collect].each do |method|
     describe "##{method}" do
       context "when empty" do

--- a/spec/lib/hamster/sorted_set/map_spec.rb
+++ b/spec/lib/hamster/sorted_set/map_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/marshal_spec.rb
+++ b/spec/lib/hamster/sorted_set/marshal_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/marshal_spec.rb
+++ b/spec/lib/hamster/sorted_set/marshal_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#marshal_dump/#marshal_load" do
     let(:ruby) do
       File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])

--- a/spec/lib/hamster/sorted_set/maximum_spec.rb
+++ b/spec/lib/hamster/sorted_set/maximum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#max" do
     context "with a block" do
       [

--- a/spec/lib/hamster/sorted_set/maximum_spec.rb
+++ b/spec/lib/hamster/sorted_set/maximum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/minimum_spec.rb
+++ b/spec/lib/hamster/sorted_set/minimum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/minimum_spec.rb
+++ b/spec/lib/hamster/sorted_set/minimum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#min" do
     [
       [[], nil],

--- a/spec/lib/hamster/sorted_set/new_spec.rb
+++ b/spec/lib/hamster/sorted_set/new_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/new_spec.rb
+++ b/spec/lib/hamster/sorted_set/new_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe ".new" do
     it "accepts a single enumerable argument and creates a new sorted set" do
       sorted_set = SS.new([1,2,3])

--- a/spec/lib/hamster/sorted_set/reverse_each_spec.rb
+++ b/spec/lib/hamster/sorted_set/reverse_each_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#reverse_each" do
     context "with no block" do
       let(:sorted_set) { SS["A", "B", "C"] }

--- a/spec/lib/hamster/sorted_set/reverse_each_spec.rb
+++ b/spec/lib/hamster/sorted_set/reverse_each_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/sample_spec.rb
+++ b/spec/lib/hamster/sorted_set/sample_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/sample_spec.rb
+++ b/spec/lib/hamster/sorted_set/sample_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#sample" do
     let(:sorted_set) { Hamster::SortedSet.new(1..10) }
 

--- a/spec/lib/hamster/sorted_set/select_spec.rb
+++ b/spec/lib/hamster/sorted_set/select_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/select_spec.rb
+++ b/spec/lib/hamster/sorted_set/select_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:select, :find_all].each do |method|
     describe "##{method}" do
       let(:sorted_set) { SS["A", "B", "C"] }

--- a/spec/lib/hamster/sorted_set/size_spec.rb
+++ b/spec/lib/hamster/sorted_set/size_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/size_spec.rb
+++ b/spec/lib/hamster/sorted_set/size_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:size, :length].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/sorted_set/slice_spec.rb
+++ b/spec/lib/hamster/sorted_set/slice_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/slice_spec.rb
+++ b/spec/lib/hamster/sorted_set/slice_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   let(:sorted_set) { SS[1,2,3,4] }
   let(:big) { SS.new(1..10000) }
 

--- a/spec/lib/hamster/sorted_set/sorting_spec.rb
+++ b/spec/lib/hamster/sorted_set/sorting_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [
     [:sort, ->(left, right) { left.length <=> right.length }],
     [:sort_by, ->(item) { item.length }],

--- a/spec/lib/hamster/sorted_set/sorting_spec.rb
+++ b/spec/lib/hamster/sorted_set/sorting_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/subset_spec.rb
+++ b/spec/lib/hamster/sorted_set/subset_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/subset_spec.rb
+++ b/spec/lib/hamster/sorted_set/subset_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#subset?" do
     [
       [[], [], true],

--- a/spec/lib/hamster/sorted_set/superset_spec.rb
+++ b/spec/lib/hamster/sorted_set/superset_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/superset_spec.rb
+++ b/spec/lib/hamster/sorted_set/superset_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#superset?" do
     [
       [[], [], true],

--- a/spec/lib/hamster/sorted_set/take_spec.rb
+++ b/spec/lib/hamster/sorted_set/take_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#take" do
     [
       [[], 10, []],

--- a/spec/lib/hamster/sorted_set/take_spec.rb
+++ b/spec/lib/hamster/sorted_set/take_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/take_while_spec.rb
+++ b/spec/lib/hamster/sorted_set/take_while_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#take_while" do
     [
       [[], []],

--- a/spec/lib/hamster/sorted_set/take_while_spec.rb
+++ b/spec/lib/hamster/sorted_set/take_while_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/to_set_spec.rb
+++ b/spec/lib/hamster/sorted_set/to_set_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 require "hamster/set"
 

--- a/spec/lib/hamster/sorted_set/to_set_spec.rb
+++ b/spec/lib/hamster/sorted_set/to_set_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/sorted_set"
 require "hamster/set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#to_set" do
     [
       [],

--- a/spec/lib/hamster/sorted_set/union_spec.rb
+++ b/spec/lib/hamster/sorted_set/union_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/union_spec.rb
+++ b/spec/lib/hamster/sorted_set/union_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   [:union, :|, :+, :merge].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/sorted_set/up_to_spec.rb
+++ b/spec/lib/hamster/sorted_set/up_to_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/up_to_spec.rb
+++ b/spec/lib/hamster/sorted_set/up_to_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#up_to" do
     context "when called without a block" do
       it "returns a sorted set of all items equal to or less than the argument" do

--- a/spec/lib/hamster/sorted_set/values_at_spec.rb
+++ b/spec/lib/hamster/sorted_set/values_at_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/sorted_set"
 
 describe Hamster::SortedSet do

--- a/spec/lib/hamster/sorted_set/values_at_spec.rb
+++ b/spec/lib/hamster/sorted_set/values_at_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/sorted_set"
 
-describe Hamster::SortedSet do
+RSpec.describe Hamster::SortedSet do
   describe "#values_at" do
     let(:sorted_set) { SS['a', 'b', 'c'] }
 

--- a/spec/lib/hamster/vector/add_spec.rb
+++ b/spec/lib/hamster/vector/add_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/add_spec.rb
+++ b/spec/lib/hamster/vector/add_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   [:add, :<<, :push].each do |method|

--- a/spec/lib/hamster/vector/any_spec.rb
+++ b/spec/lib/hamster/vector/any_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/any_spec.rb
+++ b/spec/lib/hamster/vector/any_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   describe "#any?" do

--- a/spec/lib/hamster/vector/assoc_spec.rb
+++ b/spec/lib/hamster/vector/assoc_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[[:a, 3], [:b, 2], [:c, 1]] }
 
   describe "#assoc" do

--- a/spec/lib/hamster/vector/assoc_spec.rb
+++ b/spec/lib/hamster/vector/assoc_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/bsearch_spec.rb
+++ b/spec/lib/hamster/vector/bsearch_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#bsearch" do
     let(:vector) { V[5,10,20,30] }
 

--- a/spec/lib/hamster/vector/bsearch_spec.rb
+++ b/spec/lib/hamster/vector/bsearch_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/clear_spec.rb
+++ b/spec/lib/hamster/vector/clear_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/clear_spec.rb
+++ b/spec/lib/hamster/vector/clear_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#clear" do
     [
       [],

--- a/spec/lib/hamster/vector/combination_spec.rb
+++ b/spec/lib/hamster/vector/combination_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#combination" do
     let(:vector) { V[1,2,3,4] }
 

--- a/spec/lib/hamster/vector/combination_spec.rb
+++ b/spec/lib/hamster/vector/combination_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/compact_spec.rb
+++ b/spec/lib/hamster/vector/compact_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/compact_spec.rb
+++ b/spec/lib/hamster/vector/compact_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#compact" do
     it "returns a new Vector with all nils removed" do
       expect(V[1, nil, 2, nil].compact).to eql(V[1, 2])

--- a/spec/lib/hamster/vector/compare_spec.rb
+++ b/spec/lib/hamster/vector/compare_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#<=>" do
     [
       [[], [1]],

--- a/spec/lib/hamster/vector/compare_spec.rb
+++ b/spec/lib/hamster/vector/compare_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/concat_spec.rb
+++ b/spec/lib/hamster/vector/concat_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   [:+, :concat].each do |method|
     describe "##{method}" do
       let(:vector) { V.new(1..100) }

--- a/spec/lib/hamster/vector/concat_spec.rb
+++ b/spec/lib/hamster/vector/concat_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/copying_spec.rb
+++ b/spec/lib/hamster/vector/copying_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/copying_spec.rb
+++ b/spec/lib/hamster/vector/copying_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   [:dup, :clone].each do |method|
     [
       [],

--- a/spec/lib/hamster/vector/count_spec.rb
+++ b/spec/lib/hamster/vector/count_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#count" do
     it "returns the number of elements" do
       expect(V[:a, :b, :c].count).to eq(3)

--- a/spec/lib/hamster/vector/count_spec.rb
+++ b/spec/lib/hamster/vector/count_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/delete_at_spec.rb
+++ b/spec/lib/hamster/vector/delete_at_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/delete_at_spec.rb
+++ b/spec/lib/hamster/vector/delete_at_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#delete_at" do
     let(:vector) { V[1,2,3,4,5] }
 

--- a/spec/lib/hamster/vector/delete_spec.rb
+++ b/spec/lib/hamster/vector/delete_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#delete" do
     it "removes elements that are #== to the argument" do
       expect(V[1,2,3].delete(1)).to eql(V[2,3])

--- a/spec/lib/hamster/vector/delete_spec.rb
+++ b/spec/lib/hamster/vector/delete_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/dig_spec.rb
+++ b/spec/lib/hamster/vector/dig_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/dig_spec.rb
+++ b/spec/lib/hamster/vector/dig_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:v) { V[1, 2, V[3, 4]] }
 
   describe "#dig" do

--- a/spec/lib/hamster/vector/drop_spec.rb
+++ b/spec/lib/hamster/vector/drop_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#drop" do
     [
       [[], 10, []],

--- a/spec/lib/hamster/vector/drop_spec.rb
+++ b/spec/lib/hamster/vector/drop_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/drop_while_spec.rb
+++ b/spec/lib/hamster/vector/drop_while_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/drop_while_spec.rb
+++ b/spec/lib/hamster/vector/drop_while_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#drop_while" do
     [
       [[], []],

--- a/spec/lib/hamster/vector/each_index_spec.rb
+++ b/spec/lib/hamster/vector/each_index_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/each_index_spec.rb
+++ b/spec/lib/hamster/vector/each_index_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#each_index" do
     let(:vector) { V[1,2,3,4] }
 

--- a/spec/lib/hamster/vector/each_spec.rb
+++ b/spec/lib/hamster/vector/each_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#each" do
     describe "with no block" do
       let(:vector) { V["A", "B", "C"] }

--- a/spec/lib/hamster/vector/each_spec.rb
+++ b/spec/lib/hamster/vector/each_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/each_with_index_spec.rb
+++ b/spec/lib/hamster/vector/each_with_index_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/each_with_index_spec.rb
+++ b/spec/lib/hamster/vector/each_with_index_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#each_with_index" do
     describe "with no block" do
       let(:vector) { V["A", "B", "C"] }

--- a/spec/lib/hamster/vector/empty_spec.rb
+++ b/spec/lib/hamster/vector/empty_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/empty_spec.rb
+++ b/spec/lib/hamster/vector/empty_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#empty?" do
     [
       [[], true],

--- a/spec/lib/hamster/vector/eql_spec.rb
+++ b/spec/lib/hamster/vector/eql_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/eql_spec.rb
+++ b/spec/lib/hamster/vector/eql_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#eql" do
     let(:vector) { V["A", "B", "C"] }
 

--- a/spec/lib/hamster/vector/fetch_spec.rb
+++ b/spec/lib/hamster/vector/fetch_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/fetch_spec.rb
+++ b/spec/lib/hamster/vector/fetch_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#fetch" do
     let(:vector) { V['a', 'b', 'c'] }
 

--- a/spec/lib/hamster/vector/fill_spec.rb
+++ b/spec/lib/hamster/vector/fill_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/fill_spec.rb
+++ b/spec/lib/hamster/vector/fill_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#fill" do
     let(:vector) { V[1, 2, 3, 4, 5, 6] }
 

--- a/spec/lib/hamster/vector/first_spec.rb
+++ b/spec/lib/hamster/vector/first_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/first_spec.rb
+++ b/spec/lib/hamster/vector/first_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#first" do
     [
       [[], nil],

--- a/spec/lib/hamster/vector/flat_map_spec.rb
+++ b/spec/lib/hamster/vector/flat_map_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   describe "#flat_map" do

--- a/spec/lib/hamster/vector/flat_map_spec.rb
+++ b/spec/lib/hamster/vector/flat_map_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/flatten_spec.rb
+++ b/spec/lib/hamster/vector/flatten_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/flatten_spec.rb
+++ b/spec/lib/hamster/vector/flatten_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#flatten" do
     it "recursively flattens nested vectors into containing vector" do
       expect(V[V[1], V[2]].flatten).to eql(V[1,2])

--- a/spec/lib/hamster/vector/get_spec.rb
+++ b/spec/lib/hamster/vector/get_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/get_spec.rb
+++ b/spec/lib/hamster/vector/get_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   [:get, :at].each do |method|
     describe "##{method}" do
       context "when empty" do

--- a/spec/lib/hamster/vector/group_by_spec.rb
+++ b/spec/lib/hamster/vector/group_by_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/group_by_spec.rb
+++ b/spec/lib/hamster/vector/group_by_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#group_by" do
     context "with a block" do
       [

--- a/spec/lib/hamster/vector/include_spec.rb
+++ b/spec/lib/hamster/vector/include_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/include_spec.rb
+++ b/spec/lib/hamster/vector/include_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   [:include?, :member?].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/vector/insert_spec.rb
+++ b/spec/lib/hamster/vector/insert_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 require 'pry'
 

--- a/spec/lib/hamster/vector/insert_spec.rb
+++ b/spec/lib/hamster/vector/insert_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/vector"
 require 'pry'
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#insert" do
     let(:original) { V[1, 2, 3] }
 

--- a/spec/lib/hamster/vector/inspect_spec.rb
+++ b/spec/lib/hamster/vector/inspect_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/inspect_spec.rb
+++ b/spec/lib/hamster/vector/inspect_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   describe "#inspect" do

--- a/spec/lib/hamster/vector/join_spec.rb
+++ b/spec/lib/hamster/vector/join_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#join" do
     context "with a separator" do
       [

--- a/spec/lib/hamster/vector/join_spec.rb
+++ b/spec/lib/hamster/vector/join_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/last_spec.rb
+++ b/spec/lib/hamster/vector/last_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/last_spec.rb
+++ b/spec/lib/hamster/vector/last_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   describe "#last" do

--- a/spec/lib/hamster/vector/length_spec.rb
+++ b/spec/lib/hamster/vector/length_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/length_spec.rb
+++ b/spec/lib/hamster/vector/length_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   describe "#length" do

--- a/spec/lib/hamster/vector/ltlt_spec.rb
+++ b/spec/lib/hamster/vector/ltlt_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/ltlt_spec.rb
+++ b/spec/lib/hamster/vector/ltlt_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   describe "#<<" do

--- a/spec/lib/hamster/vector/map_spec.rb
+++ b/spec/lib/hamster/vector/map_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/map_spec.rb
+++ b/spec/lib/hamster/vector/map_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   [:map, :collect].each do |method|
     describe "##{method}" do
       context "when empty" do

--- a/spec/lib/hamster/vector/marshal_spec.rb
+++ b/spec/lib/hamster/vector/marshal_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/marshal_spec.rb
+++ b/spec/lib/hamster/vector/marshal_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#marshal_dump/#marshal_load" do
     let(:ruby) do
       File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])

--- a/spec/lib/hamster/vector/maximum_spec.rb
+++ b/spec/lib/hamster/vector/maximum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/maximum_spec.rb
+++ b/spec/lib/hamster/vector/maximum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#max" do
     context "with a block" do
       [

--- a/spec/lib/hamster/vector/minimum_spec.rb
+++ b/spec/lib/hamster/vector/minimum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/minimum_spec.rb
+++ b/spec/lib/hamster/vector/minimum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#min" do
     context "with a block" do
       [

--- a/spec/lib/hamster/vector/multiply_spec.rb
+++ b/spec/lib/hamster/vector/multiply_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/multiply_spec.rb
+++ b/spec/lib/hamster/vector/multiply_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#*" do
     let(:vector) { V[1, 2, 3] }
 

--- a/spec/lib/hamster/vector/new_spec.rb
+++ b/spec/lib/hamster/vector/new_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/new_spec.rb
+++ b/spec/lib/hamster/vector/new_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe ".new" do
     it "accepts a single enumerable argument and creates a new vector" do
       vector = Hamster::Vector.new([1,2,3])

--- a/spec/lib/hamster/vector/partition_spec.rb
+++ b/spec/lib/hamster/vector/partition_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/partition_spec.rb
+++ b/spec/lib/hamster/vector/partition_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#partition" do
     [
       [[], [], []],

--- a/spec/lib/hamster/vector/permutation_spec.rb
+++ b/spec/lib/hamster/vector/permutation_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/permutation_spec.rb
+++ b/spec/lib/hamster/vector/permutation_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#permutation" do
     let(:vector) { V[1,2,3,4] }
 

--- a/spec/lib/hamster/vector/pop_spec.rb
+++ b/spec/lib/hamster/vector/pop_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/pop_spec.rb
+++ b/spec/lib/hamster/vector/pop_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#pop" do
     [
       [[], []],

--- a/spec/lib/hamster/vector/product_spec.rb
+++ b/spec/lib/hamster/vector/product_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/product_spec.rb
+++ b/spec/lib/hamster/vector/product_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#product" do
     context "when passed no arguments" do
       it "multiplies all items in vector" do

--- a/spec/lib/hamster/vector/put_spec.rb
+++ b/spec/lib/hamster/vector/put_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   describe "#put" do

--- a/spec/lib/hamster/vector/put_spec.rb
+++ b/spec/lib/hamster/vector/put_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/reduce_spec.rb
+++ b/spec/lib/hamster/vector/reduce_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/reduce_spec.rb
+++ b/spec/lib/hamster/vector/reduce_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   [:reduce, :inject].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/vector/reject_spec.rb
+++ b/spec/lib/hamster/vector/reject_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   [:reject, :delete_if].each do |method|
     describe "##{method}" do
       [

--- a/spec/lib/hamster/vector/reject_spec.rb
+++ b/spec/lib/hamster/vector/reject_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/repeated_combination_spec.rb
+++ b/spec/lib/hamster/vector/repeated_combination_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/repeated_combination_spec.rb
+++ b/spec/lib/hamster/vector/repeated_combination_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#repeated_combination" do
     let(:vector) { V[1,2,3,4] }
 

--- a/spec/lib/hamster/vector/repeated_permutation_spec.rb
+++ b/spec/lib/hamster/vector/repeated_permutation_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/repeated_permutation_spec.rb
+++ b/spec/lib/hamster/vector/repeated_permutation_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#repeated_permutation" do
     let(:vector) { V[1,2,3,4] }
 

--- a/spec/lib/hamster/vector/reverse_each_spec.rb
+++ b/spec/lib/hamster/vector/reverse_each_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/reverse_each_spec.rb
+++ b/spec/lib/hamster/vector/reverse_each_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#reverse_each" do
     [2, 31, 32, 33, 1000, 1024, 1025, 2000].each do |size|
       context "on a #{size}-item vector" do

--- a/spec/lib/hamster/vector/reverse_spec.rb
+++ b/spec/lib/hamster/vector/reverse_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/reverse_spec.rb
+++ b/spec/lib/hamster/vector/reverse_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#reverse" do
     [
       [[], []],

--- a/spec/lib/hamster/vector/rindex_spec.rb
+++ b/spec/lib/hamster/vector/rindex_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/rindex_spec.rb
+++ b/spec/lib/hamster/vector/rindex_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#rindex" do
     let(:vector) { V[1,2,3,3,2,1] }
 

--- a/spec/lib/hamster/vector/rotate_spec.rb
+++ b/spec/lib/hamster/vector/rotate_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/rotate_spec.rb
+++ b/spec/lib/hamster/vector/rotate_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#rotate" do
     let(:vector) { V[1,2,3,4,5] }
 

--- a/spec/lib/hamster/vector/sample_spec.rb
+++ b/spec/lib/hamster/vector/sample_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/sample_spec.rb
+++ b/spec/lib/hamster/vector/sample_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#sample" do
     let(:vector) { V.new(1..10) }
 

--- a/spec/lib/hamster/vector/select_spec.rb
+++ b/spec/lib/hamster/vector/select_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/select_spec.rb
+++ b/spec/lib/hamster/vector/select_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   [:select, :find_all].each do |method|
     describe "##{method}" do
       let(:vector) { V["A", "B", "C"] }

--- a/spec/lib/hamster/vector/set_spec.rb
+++ b/spec/lib/hamster/vector/set_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/set_spec.rb
+++ b/spec/lib/hamster/vector/set_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
 
   # Note: Vector#set will be deprecated; use Vector#put instead. See
   # `spec/lib/hamster/vector/put_spec.rb` for the full specs of Vector#put.

--- a/spec/lib/hamster/vector/shift_spec.rb
+++ b/spec/lib/hamster/vector/shift_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/shift_spec.rb
+++ b/spec/lib/hamster/vector/shift_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#shift" do
     [
       [[], []],

--- a/spec/lib/hamster/vector/shuffle_spec.rb
+++ b/spec/lib/hamster/vector/shuffle_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#shuffle" do
     let(:vector) { V[1,2,3,4] }
 

--- a/spec/lib/hamster/vector/shuffle_spec.rb
+++ b/spec/lib/hamster/vector/shuffle_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/slice_spec.rb
+++ b/spec/lib/hamster/vector/slice_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/slice_spec.rb
+++ b/spec/lib/hamster/vector/slice_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[1,2,3,4] }
   let(:big) { V.new(1..10000) }
 

--- a/spec/lib/hamster/vector/sorting_spec.rb
+++ b/spec/lib/hamster/vector/sorting_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   [
     [:sort, ->(left, right) { left.length <=> right.length }],
     [:sort_by, ->(item) { item.length }],

--- a/spec/lib/hamster/vector/sorting_spec.rb
+++ b/spec/lib/hamster/vector/sorting_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/sum_spec.rb
+++ b/spec/lib/hamster/vector/sum_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/sum_spec.rb
+++ b/spec/lib/hamster/vector/sum_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#sum" do
     [
       [[], 0],

--- a/spec/lib/hamster/vector/take_spec.rb
+++ b/spec/lib/hamster/vector/take_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/take_spec.rb
+++ b/spec/lib/hamster/vector/take_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#take" do
     [
       [[], 10, []],

--- a/spec/lib/hamster/vector/take_while_spec.rb
+++ b/spec/lib/hamster/vector/take_while_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/take_while_spec.rb
+++ b/spec/lib/hamster/vector/take_while_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#take_while" do
     [
       [[], []],

--- a/spec/lib/hamster/vector/to_a_spec.rb
+++ b/spec/lib/hamster/vector/to_a_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   describe "#to_a" do

--- a/spec/lib/hamster/vector/to_a_spec.rb
+++ b/spec/lib/hamster/vector/to_a_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/to_ary_spec.rb
+++ b/spec/lib/hamster/vector/to_ary_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/to_ary_spec.rb
+++ b/spec/lib/hamster/vector/to_ary_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   let(:vector) { V[*values] }
 
   describe "#to_ary" do

--- a/spec/lib/hamster/vector/to_list_spec.rb
+++ b/spec/lib/hamster/vector/to_list_spec.rb
@@ -2,7 +2,7 @@ require "hamster/vector"
 require "hamster/list"
 require "hamster/core_ext"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#to_list" do
     [
       [],

--- a/spec/lib/hamster/vector/to_list_spec.rb
+++ b/spec/lib/hamster/vector/to_list_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 require "hamster/list"
 require "hamster/core_ext"

--- a/spec/lib/hamster/vector/to_set_spec.rb
+++ b/spec/lib/hamster/vector/to_set_spec.rb
@@ -1,7 +1,7 @@
 require "hamster/vector"
 require "hamster/set"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#to_set" do
     [
       [],

--- a/spec/lib/hamster/vector/to_set_spec.rb
+++ b/spec/lib/hamster/vector/to_set_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 require "hamster/set"
 

--- a/spec/lib/hamster/vector/transpose_spec.rb
+++ b/spec/lib/hamster/vector/transpose_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#transpose" do
     it "takes a vector of vectors and transposes rows and columns" do
       expect(V[V[1, 'a'], V[2, 'b'], V[3, 'c']].transpose).to eql(V[V[1, 2, 3], V["a", "b", "c"]])

--- a/spec/lib/hamster/vector/transpose_spec.rb
+++ b/spec/lib/hamster/vector/transpose_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/uniq_spec.rb
+++ b/spec/lib/hamster/vector/uniq_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#uniq" do
     let(:vector) { V['a', 'b', 'a', 'a', 'c', 'b'] }
 

--- a/spec/lib/hamster/vector/uniq_spec.rb
+++ b/spec/lib/hamster/vector/uniq_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/unshift_spec.rb
+++ b/spec/lib/hamster/vector/unshift_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/unshift_spec.rb
+++ b/spec/lib/hamster/vector/unshift_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#unshift" do
     [
       [[], "A", ["A"]],

--- a/spec/lib/hamster/vector/values_at_spec.rb
+++ b/spec/lib/hamster/vector/values_at_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/values_at_spec.rb
+++ b/spec/lib/hamster/vector/values_at_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#values_at" do
     let(:vector) { V['a', 'b', 'c'] }
 

--- a/spec/lib/hamster/vector/zip_spec.rb
+++ b/spec/lib/hamster/vector/zip_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "hamster/vector"
 
 describe Hamster::Vector do

--- a/spec/lib/hamster/vector/zip_spec.rb
+++ b/spec/lib/hamster/vector/zip_spec.rb
@@ -1,6 +1,6 @@
 require "hamster/vector"
 
-describe Hamster::Vector do
+RSpec.describe Hamster::Vector do
   describe "#zip" do
     let(:vector) { V[1,2,3,4] }
 

--- a/spec/lib/load_spec.rb
+++ b/spec/lib/load_spec.rb
@@ -3,7 +3,7 @@
 
 hamster_lib_dir = File.join(File.dirname(__FILE__), "..", "..", 'lib')
 
-describe :Hamster do
+RSpec.describe :Hamster do
   describe :Hash do
     it "can be loaded separately" do
       expect(system(%{ruby -e "$:.unshift('#{hamster_lib_dir}'); require 'hamster/hash'; Hamster::Hash.new"})).to be(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -135,7 +135,7 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  #config.disable_monkey_patching!
+  config.disable_monkey_patching!
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,3 +83,88 @@ class EqlNotEqual
     true
   end
 end
+
+# The next part of this file was bootstrapped using the `rspec --init` command.
+#
+# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+RSpec.configure do |config|
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #config.disable_monkey_patching!
+
+  # This setting enables warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies.
+  #config.warnings = true
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = "doc"
+  end
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -154,7 +154,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  config.profile_examples = 5
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
Added a modern RSpec configuration to `.rspec` and `spec_helper.rb`, based on the one generated by `rspec --init`.

This includes quite a number of options that for backwards-compatibility reasons are not enabled by default, but that add extra checks and that will be the default on RSpec 4.

See <https://ivoanjo.me/blog/2016/09/25/why-you-should-regenerate-your-spec-helper/> for more notes on this.

May be easier to review commit-by-commit, as the combined diff got a little big due to a1e38ff and 
8a9c41d  .