### PR TITLE
Hash#== peforms numeric conversions, like == on built-in Ruby classes

### DIFF
--- a/lib/hamster/enumerable.rb
+++ b/lib/hamster/enumerable.rb
@@ -106,7 +106,7 @@ module Hamster
     # Return true if `other` contains the same elements, in the same order.
     # @return [Boolean]
     def ==(other)
-      self.eql?(other) || other.respond_to?(:to_ary) && to_ary.eql?(other.to_ary)
+      self.eql?(other) || (other.respond_to?(:to_ary) && to_ary == other.to_ary)
     end
 
     # Convert all the elements into strings and join them together, separated by

--- a/lib/hamster/hash.rb
+++ b/lib/hamster/hash.rb
@@ -743,7 +743,7 @@ module Hamster
     # @param other [Object] The object to compare with
     # @return [Boolean]
     def ==(other)
-      self.eql?(other) || (other.respond_to?(:to_hash) && to_hash.eql?(other.to_hash))
+      self.eql?(other) || (other.respond_to?(:to_hash) && to_hash == other.to_hash)
     end
 
     # Return true if this `Hash` is a proper superset of `other`, which means

--- a/spec/lib/hamster/hash/eql_spec.rb
+++ b/spec/lib/hamster/hash/eql_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "hamster/hash"
+require "bigdecimal"
 
 describe Hamster::Hash do
   let(:hash) { H["A" => "aye", "B" => "bee", "C" => "see"] }
@@ -33,6 +34,11 @@ describe Hamster::Hash do
       subclass = Class.new(Hamster::Hash)
       instance = subclass.new("A" => "aye", "B" => "bee", "C" => "see")
       expect(hash == instance).to eq(true)
+    end
+
+    it "performs numeric conversions between floats and BigDecimals" do
+      expect(H[a: 0.0] == H[a: BigDecimal('0.0')]).to be true
+      expect(H[a: BigDecimal('0.0')] == H[a: 0.0]).to be true
     end
   end
 


### PR DESCRIPTION
Fixes #247.