### PR TITLE
Vector#transpose raises TypeError if item is of wrong type

### DIFF
--- a/lib/hamster/vector.rb
+++ b/lib/hamster/vector.rb
@@ -1100,6 +1100,13 @@ module Hamster
 
       result.map! { |a| self.class.new(a) }
       self.class.new(result)
+    rescue NoMethodError
+      if any? { |x| !x.respond_to?(:size) || !x.respond_to?(:[]) }
+        bad = find { |x| !x.respond_to?(:size) || !x.respond_to?(:[]) }
+        raise TypeError, "'#{bad.inspect}' must respond to #size and #[] to be transposed"
+      else
+        raise
+      end
     end
 
     # Finds a value from this `Vector` which meets the condition defined by the

--- a/spec/lib/hamster/vector/transpose_spec.rb
+++ b/spec/lib/hamster/vector/transpose_spec.rb
@@ -45,5 +45,13 @@ describe Hamster::Vector do
         instance.transpose.each { |v| expect(v.class).to be(subclass) }
       end
     end
+
+    context "if an item does not respond to #size and #[]" do
+      it "raises TypeError" do
+        expect {
+          V[[1, 2], [2, 3], nil].transpose
+        }.to raise_error(TypeError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is to match the behavior of Array#transpose. Thanks to Xavier Shay for
noticing this issue.

Fixes #185.

(Don't know how I forgot to merge this back when it was written, more than 4 years ago!)